### PR TITLE
[codex] Fix Codex usage windows

### DIFF
--- a/src/TaskbarQuota.App/Usage/Providers/CodexProvider.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CodexProvider.cs
@@ -135,7 +135,7 @@ namespace TaskbarQuota.Usage.Providers
                 string shortName = CodexModelPrefix.Replace(rawName, string.Empty);
                 if (string.IsNullOrWhiteSpace(shortName))
                     shortName = string.IsNullOrWhiteSpace(rawName) ? "Model" : rawName;
-                if (IsSparkLimit(shortName) && !IsProPlan(planType))
+                if (IsSparkLimit(shortName))
                     continue;
 
                 if (rl.TryGetProperty("primary_window", out var primary) && primary.ValueKind == JsonValueKind.Object)
@@ -147,12 +147,6 @@ namespace TaskbarQuota.Usage.Providers
 
         private static bool IsSparkLimit(string shortName)
             => string.Equals(shortName.Trim(), "Spark", StringComparison.OrdinalIgnoreCase);
-
-        private static bool IsProPlan(string? planType)
-        {
-            var normalized = NormalizePlanType(planType);
-            return normalized is "pro" or "prolite" or "pro_lite" or "pro-lite";
-        }
 
         private static RateWindow ParseWindow(JsonElement window)
         {

--- a/tests/TaskbarQuota.Tests/CodexProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/CodexProviderTests.cs
@@ -21,14 +21,17 @@ public class CodexProviderTests
     }
 
     [Fact]
-    public void BuildResult_ProPlan_SurfacesSparkSessionAndWeeklyWindows()
+    public void BuildResult_ProPlan_UsesBaseSessionAndWeeklyInsteadOfSparkWindows()
     {
         using var doc = JsonDocument.Parse(CodexUsageJson("pro", includeSpark: true));
 
         var result = CodexProvider.BuildResult(doc.RootElement);
 
-        Assert.Contains(result.Usage.ExtraRateWindows, w => w.Title == "Spark Session" && w.Window.UsedPercent == 25);
-        Assert.Contains(result.Usage.ExtraRateWindows, w => w.Title == "Spark Weekly" && w.Window.UsedPercent == 40);
+        Assert.Equal(10, result.Usage.Primary.UsedPercent);
+        Assert.Equal(18000 / 60, result.Usage.Primary.WindowMinutes);
+        Assert.Equal(20, result.Usage.Secondary?.UsedPercent);
+        Assert.Equal(604800 / 60, result.Usage.Secondary?.WindowMinutes);
+        Assert.DoesNotContain(result.Usage.ExtraRateWindows, w => w.Title.Contains("Spark"));
     }
 
     [Fact]
@@ -43,21 +46,15 @@ public class CodexProviderTests
     }
 
     [Fact]
-    public void WidgetRows_ForCodex_KeepSessionAndWeeklyBeforeSpark()
+    public void WidgetRows_ForCodex_ShowSessionAndWeeklyWhenSparkLimitExists()
     {
-        var result = UsageResult.Success(ProviderId.Codex, new TestProvider(), new ProviderFetchResult(
-            new UsageSnapshot(new RateWindow(10))
-            {
-                Secondary = new RateWindow(20),
-                LoginMethod = "Pro 20x",
-            },
-            "oauth"));
-        result.Fetch!.Usage.ExtraRateWindows.Add(new NamedRateWindow("Spark-session", "Spark Session", new RateWindow(25)));
-        result.Fetch!.Usage.ExtraRateWindows.Add(new NamedRateWindow("Spark-weekly", "Spark Weekly", new RateWindow(40)));
+        using var doc = JsonDocument.Parse(CodexUsageJson("pro", includeSpark: true));
+        var fetch = CodexProvider.BuildResult(doc.RootElement);
+        var result = UsageResult.Success(ProviderId.Codex, new TestProvider(), fetch);
 
-        var labels = WidgetSummary.BuildRowLabelsForTesting(result, result.Fetch.Usage);
+        var labels = WidgetSummary.BuildRowLabelsForTesting(result, fetch.Usage);
 
-        Assert.Equal(new[] { "Session", "Weekly", "Spark Session", "Spark Weekly" }, labels);
+        Assert.Equal(new[] { "Session", "Weekly" }, labels);
     }
 
     private static string CodexUsageJson(string planType, bool includeSpark = false)

--- a/tests/TaskbarQuota.Tests/FlyoutLayoutTests.cs
+++ b/tests/TaskbarQuota.Tests/FlyoutLayoutTests.cs
@@ -4,5 +4,5 @@ public class FlyoutLayoutTests
 {
     [Fact]
     public void LogicalHeight_IsSizedForTheExpandedFlyout()
-        => Assert.Equal(596, FlyoutLayout.LogicalHeight);
+        => Assert.Equal(556, FlyoutLayout.LogicalHeight);
 }


### PR DESCRIPTION
## What changed

- Ignore Codex `Spark` additional rate limits for all plan types.
- Keep the top-level Codex 5-hour primary window and weekly secondary window as the displayed usage.
- Update Codex widget tests so a Pro response containing Spark still renders only Session and Weekly.
- Align the flyout layout height test with the current computed layout height after the extra Spark rows are no longer shown.

## Root cause

The Codex provider intentionally surfaced `GPT-*-Codex-Spark` from `additional_rate_limits` for Pro plans. On Pro accounts this made Spark appear alongside, or in place of, the normal Codex usage windows in the compact display. The normal 5-hour and weekly quotas already come from the top-level `rate_limit` object, so Spark should not be promoted into the displayed windows.

## Validation

- `dotnet test tests\TaskbarQuota.Tests\TaskbarQuota.Tests.csproj --filter "FullyQualifiedName~CodexProviderTests" --no-restore --verbosity minimal --nologo`
- `dotnet test tests\TaskbarQuota.Tests\TaskbarQuota.Tests.csproj --no-restore --verbosity minimal --nologo`