### PR TITLE
Usage native notifications

### DIFF
--- a/src/TaskbarQuota.App/App.xaml.cs
+++ b/src/TaskbarQuota.App/App.xaml.cs
@@ -40,6 +40,7 @@ namespace TaskbarQuota
             Log.Information("TaskbarQuota launching");
 
             UsageCoordinator.Instance.Start();
+            QuotaAlertService.Instance.Start();
 
             ScheduleTaskbarInitialization();
 

--- a/src/TaskbarQuota.App/Services/QuotaAlertService.cs
+++ b/src/TaskbarQuota.App/Services/QuotaAlertService.cs
@@ -68,7 +68,7 @@ public sealed class QuotaAlertService
                 _state,
                 DateTimeOffset.Now).ToList();
 
-            if (notifications.Count > 0)
+            if (_state.HasUnsavedChanges)
                 _state.Save();
         }
 
@@ -181,6 +181,8 @@ internal sealed class QuotaAlertState
         Path.Combine(AppStorage.AppDataDirectory, "quota-alert-state.json");
 
     public Dictionary<string, DateTimeOffset> LastAlertedAt { get; init; } = new();
+    internal bool HasUnsavedChanges { get; private set; }
+    internal void ResetUnsavedChangesForTesting() => HasUnsavedChanges = false;
 
     public static QuotaAlertState Load()
     {
@@ -202,10 +204,16 @@ internal sealed class QuotaAlertState
         || now - previous >= cooldown;
 
     public void MarkAlerted(string key, DateTimeOffset now)
-        => LastAlertedAt[key] = now;
+    {
+        LastAlertedAt[key] = now;
+        HasUnsavedChanges = true;
+    }
 
     public void Clear(string key)
-        => LastAlertedAt.Remove(key);
+    {
+        if (LastAlertedAt.Remove(key))
+            HasUnsavedChanges = true;
+    }
 
     public void Save()
     {
@@ -213,6 +221,7 @@ internal sealed class QuotaAlertState
         {
             Directory.CreateDirectory(Path.GetDirectoryName(StatePath)!);
             File.WriteAllText(StatePath, JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true }));
+            HasUnsavedChanges = false;
         }
         catch (Exception ex)
         {
@@ -248,7 +257,6 @@ internal static class QuotaAlertStateKey
     public static string For(ProviderId provider, string windowId, double threshold, RateWindow window)
     {
         var reset = window.ResetAt?.ToUnixTimeSeconds().ToString(System.Globalization.CultureInfo.InvariantCulture)
-            ?? window.ResetDescription
             ?? "no-reset";
 
         return $"{provider}:{windowId}:{threshold:0}:{reset}";

--- a/src/TaskbarQuota.App/Services/QuotaAlertService.cs
+++ b/src/TaskbarQuota.App/Services/QuotaAlertService.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using Microsoft.Windows.AppNotifications;
+using Microsoft.Windows.AppNotifications.Builder;
+using TaskbarQuota.Diagnostics;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.Services;
+
+public sealed class QuotaAlertService
+{
+    public static QuotaAlertService Instance { get; } = new(new AppNotificationQuotaAlertNotifier());
+
+    private readonly IQuotaAlertNotifier _notifier;
+    private readonly object _lock = new();
+    private QuotaAlertState _state;
+    private bool _started;
+
+    internal QuotaAlertService(IQuotaAlertNotifier notifier)
+    {
+        _notifier = notifier;
+        _state = QuotaAlertState.Load();
+    }
+
+    public void Start()
+    {
+        lock (_lock)
+        {
+            if (_started)
+                return;
+
+            UsageCoordinator.Instance.StateChanged += OnStateChanged;
+            App.Quitting += Stop;
+            _started = true;
+        }
+
+        _notifier.Register();
+    }
+
+    public void Stop()
+    {
+        lock (_lock)
+        {
+            if (!_started)
+                return;
+
+            UsageCoordinator.Instance.StateChanged -= OnStateChanged;
+            App.Quitting -= Stop;
+            _started = false;
+        }
+    }
+
+    private void OnStateChanged(UsageResult result)
+    {
+        if (!QuotaAlertSettingsService.Current.Enabled || !result.Ok || result.Fetch is null)
+            return;
+
+        List<QuotaAlertNotification> notifications;
+        lock (_lock)
+        {
+            notifications = QuotaAlertEvaluator.Evaluate(
+                result,
+                QuotaAlertSettingsService.Current,
+                _state,
+                DateTimeOffset.Now).ToList();
+
+            if (notifications.Count > 0)
+                _state.Save();
+        }
+
+        foreach (var notification in notifications)
+            _notifier.Show(notification);
+    }
+}
+
+internal interface IQuotaAlertNotifier
+{
+    void Register();
+    void Show(QuotaAlertNotification notification);
+}
+
+internal sealed class AppNotificationQuotaAlertNotifier : IQuotaAlertNotifier
+{
+    private int _registered;
+
+    public void Register()
+    {
+        if (Interlocked.Exchange(ref _registered, 1) == 1)
+            return;
+
+        try
+        {
+            AppNotificationManager.Default.Register();
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to register app notifications");
+        }
+    }
+
+    public void Show(QuotaAlertNotification notification)
+    {
+        try
+        {
+            Register();
+            var appNotification = new AppNotificationBuilder()
+                .AddText(notification.Title)
+                .AddText(notification.Body)
+                .BuildNotification();
+
+            AppNotificationManager.Default.Show(appNotification);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to show quota alert notification");
+        }
+    }
+}
+
+internal static class QuotaAlertEvaluator
+{
+    public static IEnumerable<QuotaAlertNotification> Evaluate(
+        UsageResult result,
+        QuotaAlertSettings settings,
+        QuotaAlertState state,
+        DateTimeOffset now)
+    {
+        if (!settings.Enabled || !result.Ok || result.Fetch?.Usage is not { } usage)
+            yield break;
+
+        foreach (var window in EnumerateWindows(usage))
+        {
+            var thresholds = OrderedThresholds(settings).ToArray();
+            foreach (var threshold in thresholds.Where(t => window.Window.UsedPercent < t.Value))
+                state.Clear(QuotaAlertStateKey.For(result.Id, window.Id, threshold.Value, window.Window));
+
+            var crossed = thresholds.FirstOrDefault(t => window.Window.UsedPercent >= t.Value);
+            if (crossed == default)
+                continue;
+
+            var key = QuotaAlertStateKey.For(result.Id, window.Id, crossed.Value, window.Window);
+            if (!state.ShouldAlert(key, now, TimeSpan.FromMinutes(settings.CooldownMinutes)))
+                continue;
+
+            state.MarkAlerted(key, now);
+            yield return QuotaAlertNotification.From(result.DisplayName, window, crossed);
+        }
+    }
+
+    private static IEnumerable<QuotaAlertWindow> EnumerateWindows(UsageSnapshot usage)
+    {
+        yield return new QuotaAlertWindow("primary", "Session", usage.Primary);
+
+        if (usage.Secondary is { } secondary)
+            yield return new QuotaAlertWindow("secondary", "Weekly", secondary);
+
+        if (usage.ModelSpecific is { } model)
+            yield return new QuotaAlertWindow("model", "Model", model);
+
+        if (usage.Monthly is { } monthly)
+            yield return new QuotaAlertWindow("monthly", "Monthly", monthly);
+
+        foreach (var extra in usage.ExtraRateWindows)
+            yield return new QuotaAlertWindow($"extra:{extra.Id}", extra.Title, extra.Window);
+    }
+
+    private static IEnumerable<QuotaAlertThreshold> OrderedThresholds(QuotaAlertSettings settings)
+    {
+        yield return new QuotaAlertThreshold("critical", settings.CriticalThreshold);
+        yield return new QuotaAlertThreshold("warning", settings.WarningThreshold);
+    }
+}
+
+internal sealed class QuotaAlertState
+{
+    private static readonly string StatePath =
+        Path.Combine(AppStorage.AppDataDirectory, "quota-alert-state.json");
+
+    public Dictionary<string, DateTimeOffset> LastAlertedAt { get; init; } = new();
+
+    public static QuotaAlertState Load()
+    {
+        try
+        {
+            if (!File.Exists(StatePath))
+                return new QuotaAlertState();
+
+            return JsonSerializer.Deserialize<QuotaAlertState>(File.ReadAllText(StatePath)) ?? new QuotaAlertState();
+        }
+        catch
+        {
+            return new QuotaAlertState();
+        }
+    }
+
+    public bool ShouldAlert(string key, DateTimeOffset now, TimeSpan cooldown)
+        => !LastAlertedAt.TryGetValue(key, out var previous)
+        || now - previous >= cooldown;
+
+    public void MarkAlerted(string key, DateTimeOffset now)
+        => LastAlertedAt[key] = now;
+
+    public void Clear(string key)
+        => LastAlertedAt.Remove(key);
+
+    public void Save()
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(StatePath)!);
+            File.WriteAllText(StatePath, JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to write quota alert state");
+        }
+    }
+}
+
+internal readonly record struct QuotaAlertWindow(string Id, string Title, RateWindow Window);
+
+internal readonly record struct QuotaAlertThreshold(string Severity, double Value);
+
+internal sealed record QuotaAlertNotification(string Title, string Body)
+{
+    public static QuotaAlertNotification From(
+        string providerName,
+        QuotaAlertWindow window,
+        QuotaAlertThreshold threshold)
+    {
+        var used = window.Window.UsedPercent;
+        var reset = string.IsNullOrWhiteSpace(window.Window.ResetDescription)
+            ? string.Empty
+            : $" Resets in {window.Window.ResetDescription}.";
+
+        return new QuotaAlertNotification(
+            $"{providerName} {window.Title.ToLowerInvariant()} quota is at {used:0}%",
+            $"{threshold.Severity.ToUpperInvariant()} threshold crossed ({threshold.Value:0}%).{reset}");
+    }
+}
+
+internal static class QuotaAlertStateKey
+{
+    public static string For(ProviderId provider, string windowId, double threshold, RateWindow window)
+    {
+        var reset = window.ResetAt?.ToUnixTimeSeconds().ToString(System.Globalization.CultureInfo.InvariantCulture)
+            ?? window.ResetDescription
+            ?? "no-reset";
+
+        return $"{provider}:{windowId}:{threshold:0}:{reset}";
+    }
+}

--- a/src/TaskbarQuota.App/Services/QuotaAlertSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/QuotaAlertSettingsService.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace TaskbarQuota;
+
+public static class QuotaAlertSettingsService
+{
+    private static readonly string SettingsPath =
+        Path.Combine(AppStorage.AppDataDirectory, "quota-alerts.json");
+
+    private static QuotaAlertSettings _current = Load();
+
+    public static event EventHandler? Changed;
+
+    public static QuotaAlertSettings Current => _current;
+
+    public static void Apply(QuotaAlertSettings settings)
+    {
+        var normalized = settings.Normalized();
+        if (_current.Equals(normalized))
+            return;
+
+        _current = normalized;
+        Save();
+        Changed?.Invoke(null, EventArgs.Empty);
+    }
+
+    public static void SetEnabled(bool enabled)
+        => Apply(_current with { Enabled = enabled });
+
+    public static void SetWarningThreshold(double value)
+        => Apply(_current with { WarningThreshold = value });
+
+    public static void SetCriticalThreshold(double value)
+        => Apply(_current with { CriticalThreshold = value });
+
+    public static void SetCooldownMinutes(double value)
+        => Apply(_current with { CooldownMinutes = value });
+
+    private static QuotaAlertSettings Load()
+    {
+        try
+        {
+            if (!File.Exists(SettingsPath))
+                return QuotaAlertSettings.Default;
+
+            var loaded = JsonSerializer.Deserialize<QuotaAlertSettings>(File.ReadAllText(SettingsPath));
+            return (loaded ?? QuotaAlertSettings.Default).Normalized();
+        }
+        catch
+        {
+            return QuotaAlertSettings.Default;
+        }
+    }
+
+    private static void Save()
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(SettingsPath)!);
+            File.WriteAllText(SettingsPath, JsonSerializer.Serialize(_current, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch
+        {
+            // Settings are best-effort; keep the in-memory values for this run.
+        }
+    }
+}
+
+public sealed record QuotaAlertSettings
+{
+    public static QuotaAlertSettings Default { get; } = new()
+    {
+        Enabled = false,
+        WarningThreshold = 75,
+        CriticalThreshold = 90,
+        CooldownMinutes = 30,
+    };
+
+    public bool Enabled { get; init; }
+    public double WarningThreshold { get; init; }
+    public double CriticalThreshold { get; init; }
+    public double CooldownMinutes { get; init; }
+
+    public QuotaAlertSettings Normalized()
+    {
+        var warning = Math.Clamp(WarningThreshold, 1, 99);
+        var critical = Math.Clamp(CriticalThreshold, 1, 100);
+        if (critical <= warning)
+            critical = Math.Min(100, warning + 1);
+
+        return this with
+        {
+            WarningThreshold = Math.Round(warning),
+            CriticalThreshold = Math.Round(critical),
+            CooldownMinutes = Math.Clamp(Math.Round(CooldownMinutes), 1, 1440),
+        };
+    }
+}

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml
@@ -63,6 +63,61 @@
                               Toggled="OnStartupToggled"/>
             </tk:SettingsCard>
 
+            <TextBlock Text="Notifications" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,16,0,2"/>
+            <tk:SettingsCard Header="Quota alerts" Description="Show Windows notifications when usage crosses your configured thresholds.">
+                <tk:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xEA8F;"/>
+                </tk:SettingsCard.HeaderIcon>
+                <ToggleSwitch x:Name="QuotaAlertsToggle"
+                              AutomationProperties.Name="Enable quota alerts"
+                              Toggled="OnQuotaAlertsToggled"/>
+            </tk:SettingsCard>
+
+            <tk:SettingsCard Header="Warning threshold" Description="Notify when a usage window reaches this consumed percentage.">
+                <tk:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE7BA;"/>
+                </tk:SettingsCard.HeaderIcon>
+                <NumberBox x:Name="WarningThresholdBox"
+                           AutomationProperties.Name="Warning threshold"
+                           Minimum="1"
+                           Maximum="99"
+                           SmallChange="1"
+                           LargeChange="5"
+                           SpinButtonPlacementMode="Compact"
+                           ValueChanged="OnWarningThresholdChanged"
+                           Width="120"/>
+            </tk:SettingsCard>
+
+            <tk:SettingsCard Header="Critical threshold" Description="Notify again when a usage window reaches this higher consumed percentage.">
+                <tk:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE814;"/>
+                </tk:SettingsCard.HeaderIcon>
+                <NumberBox x:Name="CriticalThresholdBox"
+                           AutomationProperties.Name="Critical threshold"
+                           Minimum="2"
+                           Maximum="100"
+                           SmallChange="1"
+                           LargeChange="5"
+                           SpinButtonPlacementMode="Compact"
+                           ValueChanged="OnCriticalThresholdChanged"
+                           Width="120"/>
+            </tk:SettingsCard>
+
+            <tk:SettingsCard Header="Notification cooldown" Description="Minimum minutes before TaskbarQuota repeats the same alert.">
+                <tk:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE823;"/>
+                </tk:SettingsCard.HeaderIcon>
+                <NumberBox x:Name="AlertCooldownBox"
+                           AutomationProperties.Name="Notification cooldown"
+                           Minimum="1"
+                           Maximum="1440"
+                           SmallChange="1"
+                           LargeChange="15"
+                           SpinButtonPlacementMode="Compact"
+                           ValueChanged="OnAlertCooldownChanged"
+                           Width="120"/>
+            </tk:SettingsCard>
+
             <TextBlock Text="Credentials" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,16,0,2"/>
             <TextBlock Text="All providers detect credentials automatically. If auto-detection fails for a provider, use the &quot;Fix&quot; button on its dashboard card."
                        Opacity="0.7" Style="{StaticResource CaptionTextBlockStyle}" TextWrapping="Wrap" Margin="0,0,0,4"/>

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
@@ -28,6 +28,7 @@ namespace TaskbarQuota.Views
             };
             PercentageModeCombo.SelectedIndex = WidgetSettingsService.CurrentPercentageMode == PercentageDisplayMode.Remaining ? 1 : 0;
             StartupToggle.IsOn = StartupSettingsService.IsEnabled;
+            ApplyQuotaAlertSettingsToControls();
             VersionLabel.Text = $"Version {AppVersion.GetDisplayLabel()}";
             _isInitializing = false;
         }
@@ -76,6 +77,59 @@ namespace TaskbarQuota.Views
                     ? PercentageDisplayMode.Remaining
                     : PercentageDisplayMode.Consumed;
                 WidgetSettingsService.Apply(mode);
+            }
+        }
+
+        private void OnQuotaAlertsToggled(object sender, RoutedEventArgs e)
+        {
+            if (_isInitializing)
+                return;
+
+            QuotaAlertSettingsService.SetEnabled(QuotaAlertsToggle.IsOn);
+        }
+
+        private void OnWarningThresholdChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+        {
+            if (_isInitializing || double.IsNaN(args.NewValue))
+                return;
+
+            QuotaAlertSettingsService.SetWarningThreshold(args.NewValue);
+            ApplyQuotaAlertSettingsToControls();
+        }
+
+        private void OnCriticalThresholdChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+        {
+            if (_isInitializing || double.IsNaN(args.NewValue))
+                return;
+
+            QuotaAlertSettingsService.SetCriticalThreshold(args.NewValue);
+            ApplyQuotaAlertSettingsToControls();
+        }
+
+        private void OnAlertCooldownChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+        {
+            if (_isInitializing || double.IsNaN(args.NewValue))
+                return;
+
+            QuotaAlertSettingsService.SetCooldownMinutes(args.NewValue);
+            ApplyQuotaAlertSettingsToControls();
+        }
+
+        private void ApplyQuotaAlertSettingsToControls()
+        {
+            var settings = QuotaAlertSettingsService.Current;
+            var wasInitializing = _isInitializing;
+            _isInitializing = true;
+            try
+            {
+                QuotaAlertsToggle.IsOn = settings.Enabled;
+                WarningThresholdBox.Value = settings.WarningThreshold;
+                CriticalThresholdBox.Value = settings.CriticalThreshold;
+                AlertCooldownBox.Value = settings.CooldownMinutes;
+            }
+            finally
+            {
+                _isInitializing = wasInitializing;
             }
         }
     }

--- a/tests/TaskbarQuota.Tests/CodexProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/CodexProviderTests.cs
@@ -45,19 +45,38 @@ public class CodexProviderTests
     [Fact]
     public void WidgetRows_ForCodex_HidesExtraRowsByDefault()
     {
-        var result = UsageResult.Success(ProviderId.Codex, new TestProvider(), new ProviderFetchResult(
-            new UsageSnapshot(new RateWindow(10))
-            {
-                Secondary = new RateWindow(20),
-                LoginMethod = "Pro 20x",
-            },
-            "oauth"));
-        result.Fetch!.Usage.ExtraRateWindows.Add(new NamedRateWindow("Spark-session", "Spark Session", new RateWindow(25)));
-        result.Fetch!.Usage.ExtraRateWindows.Add(new NamedRateWindow("Spark-weekly", "Spark Weekly", new RateWindow(40)));
+        WidgetSettingsService.ResetRowVisibilityForTesting();
+        try
+        {
+            var result = CodexWidgetResultWithExtraRows();
 
-        var labels = WidgetSummary.BuildRowLabelsForTesting(result, result.Fetch.Usage);
+            var labels = WidgetSummary.BuildRowLabelsForTesting(result, result.Fetch!.Usage);
 
-        Assert.Equal(new[] { "Session", "Weekly" }, labels);
+            Assert.Equal(new[] { "Session", "Weekly" }, labels);
+        }
+        finally
+        {
+            WidgetSettingsService.ResetRowVisibilityForTesting();
+        }
+    }
+
+    [Fact]
+    public void WidgetRows_ForCodex_ShowsExtraRowsWhenEnabled()
+    {
+        WidgetSettingsService.ResetRowVisibilityForTesting();
+        try
+        {
+            WidgetSettingsService.SetRowVisibleForTesting(ProviderId.Codex, WidgetSettingsService.RowExtra, true);
+            var result = CodexWidgetResultWithExtraRows();
+
+            var labels = WidgetSummary.BuildRowLabelsForTesting(result, result.Fetch!.Usage);
+
+            Assert.Equal(new[] { "Session", "Weekly", "Spark Session", "Spark Weekly" }, labels);
+        }
+        finally
+        {
+            WidgetSettingsService.ResetRowVisibilityForTesting();
+        }
     }
 
     private static string CodexUsageJson(string planType, bool includeSpark = false)
@@ -103,6 +122,20 @@ public class CodexProviderTests
                  {{additional}}
                }
                """;
+    }
+
+    private static UsageResult CodexWidgetResultWithExtraRows()
+    {
+        var result = UsageResult.Success(ProviderId.Codex, new TestProvider(), new ProviderFetchResult(
+            new UsageSnapshot(new RateWindow(10))
+            {
+                Secondary = new RateWindow(20),
+                LoginMethod = "Pro 20x",
+            },
+            "oauth"));
+        result.Fetch!.Usage.ExtraRateWindows.Add(new NamedRateWindow("Spark-session", "Spark Session", new RateWindow(25)));
+        result.Fetch!.Usage.ExtraRateWindows.Add(new NamedRateWindow("Spark-weekly", "Spark Weekly", new RateWindow(40)));
+        return result;
     }
 
     private sealed class TestProvider : IUsageProvider

--- a/tests/TaskbarQuota.Tests/QuotaAlertEvaluatorTests.cs
+++ b/tests/TaskbarQuota.Tests/QuotaAlertEvaluatorTests.cs
@@ -83,6 +83,35 @@ public class QuotaAlertEvaluatorTests
     }
 
     [Fact]
+    public void Evaluate_DropsBelowThreshold_MarksStateChanged()
+    {
+        var state = new QuotaAlertState();
+        var first = Now();
+
+        _ = QuotaAlertEvaluator.Evaluate(Result(91), Settings(), state, first).ToArray();
+        Assert.True(state.HasUnsavedChanges);
+
+        state.ResetUnsavedChangesForTesting();
+        Assert.False(state.HasUnsavedChanges);
+
+        _ = QuotaAlertEvaluator.Evaluate(Result(10), Settings(), state, first.AddMinutes(1)).ToArray();
+
+        Assert.True(state.HasUnsavedChanges);
+    }
+
+    [Fact]
+    public void StateKey_WithoutResetAt_DoesNotUseChangingResetDescription()
+    {
+        var first = new RateWindow(91, resetDescription: "91/100 USD");
+        var second = new RateWindow(92, resetDescription: "92/100 USD");
+
+        var firstKey = QuotaAlertStateKey.For(ProviderId.Claude, "primary", 90, first);
+        var secondKey = QuotaAlertStateKey.For(ProviderId.Claude, "primary", 90, second);
+
+        Assert.Equal(firstKey, secondKey);
+    }
+
+    [Fact]
     public void Settings_Normalized_KeepsCriticalAboveWarning()
     {
         var settings = new QuotaAlertSettings

--- a/tests/TaskbarQuota.Tests/QuotaAlertEvaluatorTests.cs
+++ b/tests/TaskbarQuota.Tests/QuotaAlertEvaluatorTests.cs
@@ -1,0 +1,130 @@
+using TaskbarQuota.Services;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.Tests;
+
+public class QuotaAlertEvaluatorTests
+{
+    [Fact]
+    public void Evaluate_DisabledSettings_DoesNotAlert()
+    {
+        var state = new QuotaAlertState();
+        var result = Result(91);
+
+        var alerts = QuotaAlertEvaluator.Evaluate(result, Settings(enabled: false), state, Now()).ToArray();
+
+        Assert.Empty(alerts);
+    }
+
+    [Fact]
+    public void Evaluate_AboveCritical_AlertsForCriticalOnly()
+    {
+        var state = new QuotaAlertState();
+        var result = Result(91);
+
+        var alerts = QuotaAlertEvaluator.Evaluate(result, Settings(), state, Now()).ToArray();
+
+        var alert = Assert.Single(alerts);
+        Assert.Contains("CRITICAL", alert.Body);
+    }
+
+    [Fact]
+    public void Evaluate_WarningThenCritical_AlertsAtEachThreshold()
+    {
+        var state = new QuotaAlertState();
+        var first = Now();
+
+        var warning = QuotaAlertEvaluator.Evaluate(Result(80), Settings(), state, first).ToArray();
+        var critical = QuotaAlertEvaluator.Evaluate(Result(91), Settings(), state, first.AddMinutes(1)).ToArray();
+
+        Assert.Single(warning);
+        Assert.Contains("WARNING", warning[0].Body);
+        Assert.Single(critical);
+        Assert.Contains("CRITICAL", critical[0].Body);
+    }
+
+    [Fact]
+    public void Evaluate_RepeatedWithinCooldown_DoesNotAlertAgain()
+    {
+        var state = new QuotaAlertState();
+        var first = Now();
+        var result = Result(91);
+
+        _ = QuotaAlertEvaluator.Evaluate(result, Settings(), state, first).ToArray();
+        var second = QuotaAlertEvaluator.Evaluate(result, Settings(), state, first.AddMinutes(5)).ToArray();
+
+        Assert.Empty(second);
+    }
+
+    [Fact]
+    public void Evaluate_AfterCooldown_AlertsAgain()
+    {
+        var state = new QuotaAlertState();
+        var first = Now();
+        var result = Result(91);
+
+        _ = QuotaAlertEvaluator.Evaluate(result, Settings(), state, first).ToArray();
+        var second = QuotaAlertEvaluator.Evaluate(result, Settings(), state, first.AddMinutes(31)).ToArray();
+
+        Assert.Single(second);
+    }
+
+    [Fact]
+    public void Evaluate_DropsBelowThreshold_AllowsFutureCrossing()
+    {
+        var state = new QuotaAlertState();
+        var first = Now();
+
+        _ = QuotaAlertEvaluator.Evaluate(Result(91), Settings(), state, first).ToArray();
+        _ = QuotaAlertEvaluator.Evaluate(Result(10), Settings(), state, first.AddMinutes(1)).ToArray();
+        var alerts = QuotaAlertEvaluator.Evaluate(Result(91), Settings(), state, first.AddMinutes(2)).ToArray();
+
+        Assert.Single(alerts);
+    }
+
+    [Fact]
+    public void Settings_Normalized_KeepsCriticalAboveWarning()
+    {
+        var settings = new QuotaAlertSettings
+        {
+            Enabled = true,
+            WarningThreshold = 90,
+            CriticalThreshold = 80,
+            CooldownMinutes = 0,
+        }.Normalized();
+
+        Assert.Equal(90, settings.WarningThreshold);
+        Assert.Equal(91, settings.CriticalThreshold);
+        Assert.Equal(1, settings.CooldownMinutes);
+    }
+
+    private static QuotaAlertSettings Settings(bool enabled = true) => new()
+    {
+        Enabled = enabled,
+        WarningThreshold = 75,
+        CriticalThreshold = 90,
+        CooldownMinutes = 30,
+    };
+
+    private static DateTimeOffset Now()
+        => new(2026, 6, 6, 12, 0, 0, TimeSpan.Zero);
+
+    private static UsageResult Result(double primaryPercent)
+    {
+        var provider = new AlertTestProvider();
+        var usage = new UsageSnapshot(new RateWindow(primaryPercent, resetAt: Now().AddHours(1)));
+        return UsageResult.Success(provider.Id, provider, new ProviderFetchResult(usage, "test"));
+    }
+
+    private sealed class AlertTestProvider : IUsageProvider
+    {
+        public ProviderId Id => ProviderId.Claude;
+        public string DisplayName => "Claude";
+        public string SessionLabel => "Session";
+        public string WeeklyLabel => "Weekly";
+        public BillingKind Billing => BillingKind.Subscription;
+
+        public Task<ProviderFetchResult> FetchUsageAsync(CancellationToken ct = default)
+            => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
This pull request introduces a complete quota alert notification system to TaskbarQuota, allowing users to receive Windows notifications when their usage crosses configurable thresholds. It includes a new background service for monitoring usage and sending alerts, persistent state and settings management, and a comprehensive UI for configuring alert preferences. Additionally, it improves test coverage for widget row visibility.

**Quota Alert Notification System**

- Added `QuotaAlertService`, a singleton service that monitors usage and triggers Windows notifications when configured thresholds are crossed. It handles registration, notification delivery, and cooldown logic, and persists alert state to disk. [[1]](diffhunk://#diff-0e61c5600ffdb22054c3b235e3da4501ace4f9dca1a3068e95ffc70aa3885307R1-R256) [[2]](diffhunk://#diff-5e8df926ff6d995cd589b8739010db0180cf1235f99de19ea8285e7258f9c9e2R43)
- Implemented `QuotaAlertSettingsService` for persistent storage and management of alert settings, including enabling/disabling alerts, thresholds, and cooldown periods. Settings are normalized and changes are persisted to disk.

**User Interface Enhancements**

- Added a new "Notifications" section to the settings page, including controls for enabling quota alerts, setting warning/critical thresholds, and configuring cooldown periods.
- Updated the settings page code-behind to synchronize UI controls with settings, handle user changes, and apply settings reactively. [[1]](diffhunk://#diff-e19fdcb06655b8e5fa0c2c71dfd348b91994883aaf34f4adc260870c533861d3R31) [[2]](diffhunk://#diff-e19fdcb06655b8e5fa0c2c71dfd348b91994883aaf34f4adc260870c533861d3R82-R134)

**Testing and Reliability Improvements**

- Improved widget row visibility tests for Codex, adding coverage for extra rows when enabled and refactoring test setup/teardown for reliability. [[1]](diffhunk://#diff-af61dcce8ce3332ef1182e400acdffa22ac475505df0af939c938691daee9a02L48-R80) [[2]](diffhunk://#diff-af61dcce8ce3332ef1182e400acdffa22ac475505df0af939c938691daee9a02R127-R140)