### PR TITLE
feat(widget): track Fable and credit quota meters

### DIFF
--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -305,6 +305,23 @@ namespace TaskbarQuota.Controls
             if (result.Id == ProviderId.Codex)
             {
                 var rows = BuildBaseRows(result, usage);
+                // Codex credits (raw balance, or used/limit when the API reports a real cap). Lets org/
+                // Business plans surface credits in the widget — the only meter they have. See issue #12.
+                if (usage.Cost is { Label: "Credits" } codexCredits && ShouldShowCodexCredits(usage, codexCredits))
+                {
+                    if (codexCredits.Limit is { } creditLimit && creditLimit > 0)
+                    {
+                        double creditUsed = Math.Max(0, creditLimit - codexCredits.Amount);
+                        rows.Add(new WidgetUsageRow(
+                            "Credits",
+                            WidgetSettingsService.DisplayPercent(Math.Clamp(creditUsed / creditLimit * 100, 0, 100)),
+                            $"{FormatCreditCount(creditUsed)}/{FormatCreditCount(creditLimit)}"));
+                    }
+                    else
+                    {
+                        rows.Add(new WidgetUsageRow("Credits", 0, FormatCreditCount(codexCredits.Amount), HasBar: false));
+                    }
+                }
                 if (usage.ResetCredits is { AvailableCount: > 0 } resetCredits && WidgetSettingsService.IsRowVisible(result.Id, WidgetSettingsService.RowResetCredits))
                 {
                     string? expiresIn = CodexProvider.FormatResetCountdown(resetCredits.EarliestExpiresAt);
@@ -316,6 +333,20 @@ namespace TaskbarQuota.Controls
                         HasBar: false));
                 }
 
+                if (WidgetSettingsService.IsRowVisible(result.Id, WidgetSettingsService.RowExtra))
+                {
+                    rows.AddRange(usage.ExtraRateWindows.Select(w => new WidgetUsageRow(
+                        CompactLabel(w.Title),
+                        WidgetSettingsService.DisplayPercent(w.Window.UsedPercent),
+                        WidgetSettingsService.FormatDisplayPercent(w.Window.UsedPercent),
+                        w.Window.ResetDescription)));
+                }
+                return rows;
+            }
+
+            if (result.Id == ProviderId.Claude)
+            {
+                var rows = BuildBaseRows(result, usage);
                 if (WidgetSettingsService.IsRowVisible(result.Id, WidgetSettingsService.RowExtra))
                 {
                     rows.AddRange(usage.ExtraRateWindows.Select(w => new WidgetUsageRow(
@@ -351,16 +382,39 @@ namespace TaskbarQuota.Controls
         internal static IReadOnlyList<string> BuildRowLabelsForTesting(UsageResult result, UsageSnapshot usage)
             => BuildRows(result, usage).Select(row => row.Label).ToList();
 
+        private static bool ShouldShowCodexCredits(UsageSnapshot usage, CostSnapshot credits)
+        {
+            if (WidgetSettingsService.TryGetRowVisibilityOverride(ProviderId.Codex, WidgetSettingsService.RowCredits, out bool userVisible))
+                return userVisible;
+
+            return credits.Amount > 0 || !IsNormalCodexPlan(usage.LoginMethod);
+        }
+
+        private static bool IsNormalCodexPlan(string? plan)
+        {
+            var normalized = (plan ?? string.Empty).Trim().ToLowerInvariant();
+            return normalized is "free" or "plus"
+                || normalized.StartsWith("pro", StringComparison.Ordinal);
+        }
+
         private static List<WidgetUsageRow> BuildBaseRows(UsageResult result, UsageSnapshot usage)
         {
             var rows = new List<WidgetUsageRow>();
-            if (WidgetSettingsService.IsRowVisible(result.Id, WidgetSettingsService.RowPrimary))
+            // Skip the primary bar when the provider reported no session window (Codex org/Business):
+            // otherwise the widget shows a bogus "Session 0%". Honor the window's Label override so
+            // Claude Enterprise reads "Spend limit" instead of "Session".
+            if (usage.HasPrimaryWindow && WidgetSettingsService.IsRowVisible(result.Id, WidgetSettingsService.RowPrimary))
             {
-                var primaryLabel = result.Provider?.SessionLabel ?? "Usage";
+                var primaryLabel = usage.Primary.Label ?? result.Provider?.SessionLabel ?? "Usage";
+                // Spend-limit meter (Claude Enterprise): show the money value "$9.27/$100.00" instead of a
+                // bare percent so it matches Codex's "used/limit credits". The bar still tracks used %.
+                string primaryValue = usage.Primary.Label != null && usage.Cost is { } spend
+                    ? FormatSpendValue(spend)
+                    : WidgetSettingsService.FormatDisplayPercent(usage.Primary.UsedPercent);
                 rows.Add(new WidgetUsageRow(
                     CompactLabel(primaryLabel),
                     WidgetSettingsService.DisplayPercent(usage.Primary.UsedPercent),
-                    WidgetSettingsService.FormatDisplayPercent(usage.Primary.UsedPercent),
+                    primaryValue,
                     usage.Primary.ResetDescription));
             }
             if (usage.Secondary != null && WidgetSettingsService.IsRowVisible(result.Id, WidgetSettingsService.RowSecondary))
@@ -375,7 +429,7 @@ namespace TaskbarQuota.Controls
             if (usage.ModelSpecific != null && WidgetSettingsService.IsRowVisible(result.Id, WidgetSettingsService.RowModelSpecific))
             {
                 rows.Add(new WidgetUsageRow(
-                    CompactLabel(ModelSpecificLabel(result.Id)),
+                    CompactLabel(usage.ModelSpecific.Label ?? ModelSpecificLabel(result.Id)),
                     WidgetSettingsService.DisplayPercent(usage.ModelSpecific.UsedPercent),
                     WidgetSettingsService.FormatDisplayPercent(usage.ModelSpecific.UsedPercent),
                     usage.ModelSpecific.ResetDescription));
@@ -503,6 +557,18 @@ namespace TaskbarQuota.Controls
 
         private static string FormatCreditCount(double value)
             => value.ToString(value % 1 == 0 ? "N0" : "N1", CultureInfo.InvariantCulture);
+
+        /// <summary>Compact "used / limit" money string for a spend-limit meter, e.g. "$9.27/$100".
+        /// Space-free to fit the widget's narrow value column.</summary>
+        private static string FormatSpendValue(CostSnapshot cost)
+        {
+            string Money(double v)
+            {
+                string n = v.ToString(v % 1 == 0 ? "N0" : "N2", CultureInfo.InvariantCulture);
+                return string.Equals(cost.Currency, "USD", StringComparison.OrdinalIgnoreCase) ? $"${n}" : $"{n} {cost.Currency}";
+            }
+            return cost.Limit is { } limit ? $"{Money(cost.Amount)}/{Money(limit)}" : Money(cost.Amount);
+        }
 
         private static string WidgetCostTooltipLine(ProviderId id, CostSnapshot? cost)
         {

--- a/src/TaskbarQuota.App/Services/QuotaAlertService.cs
+++ b/src/TaskbarQuota.App/Services/QuotaAlertService.cs
@@ -169,7 +169,8 @@ internal static class QuotaAlertEvaluator
 
     private static IEnumerable<QuotaAlertWindow> EnumerateWindows(UsageSnapshot usage)
     {
-        yield return new QuotaAlertWindow("primary", "Session", usage.Primary);
+        if (usage.HasPrimaryWindow)
+            yield return new QuotaAlertWindow("primary", "Session", usage.Primary);
 
         if (usage.Secondary is { } secondary)
             yield return new QuotaAlertWindow("secondary", "Weekly", secondary);

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -103,6 +103,9 @@ public static class WidgetSettingsService
             : DefaultRowVisible(provider, rowId);
     }
 
+    public static bool TryGetRowVisibilityOverride(ProviderId provider, string rowId, out bool visible)
+        => RowVisibility.TryGetValue(RowVisibilityKey(provider, rowId), out visible);
+
     public static bool IsProviderVisible(ProviderId provider)
     {
         var key = provider.ToString();
@@ -278,6 +281,13 @@ public static class WidgetSettingsService
                 new(RowModelSpecific, "Completions"),
                 new(RowExtra, "Extra quota rows"),
             ],
+            ProviderId.Claude =>
+            [
+                new(RowPrimary, "Session"),
+                new(RowSecondary, "Weekly"),
+                new(RowModelSpecific, "Model weekly"),
+                new(RowExtra, "Extra weekly rows"),
+            ],
             ProviderId.Cursor =>
             [
                 new(RowSecondary, "Auto + Composer"),
@@ -290,6 +300,7 @@ public static class WidgetSettingsService
                 new(RowSecondary, "Weekly"),
                 new(RowModelSpecific, "Model"),
                 new(RowMonthly, "Monthly"),
+                new(RowCredits, "Credits"),
                 new(RowResetCredits, "Reset credits"),
                 new(RowExtra, "Extra model rows"),
             ],
@@ -500,7 +511,8 @@ public static class WidgetSettingsService
 
     private static bool DefaultRowVisible(ProviderId provider, string rowId)
         => provider != ProviderId.Codex
-        || rowId == RowPrimary
-        || rowId == RowSecondary
-        || rowId == RowResetCredits;
+              || rowId == RowPrimary
+              || rowId == RowSecondary
+              || rowId == RowCredits
+              || rowId == RowResetCredits;
 }

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -120,7 +120,6 @@ namespace TaskbarQuota.Taskbar
                 widget.Destroying += (_, _) => _widget = null;
                 if (widget.Summary is { } summary)
                     summary.Clicked += () => _dispatcher?.TryEnqueue(ToggleFlyout);
-                widget.Show();
                 _widget = widget;
                 SyncWidgetState();
                 PrewarmFlyout();
@@ -144,20 +143,26 @@ namespace TaskbarQuota.Taskbar
             var coordinator = UsageCoordinator.Instance;
             summary.DispatcherQueue.TryEnqueue(() =>
             {
-                // No enabled+available provider -> hide instead of falling back to a disabled default (#7).
-                if (coordinator.WidgetDisplayProvider is not { } target)
+                var target = coordinator.WidgetDisplayProvider;
+                bool shouldShowWidget = coordinator.IsActiveToolPresent && target is not null;
+                widget.SetVisible(shouldShowWidget);
+
+                // No enabled+available provider -> hide the native host instead of leaving a transparent
+                // taskbar child window over the notification area (#10).
+                if (target is not { } targetProvider)
                 {
                     summary.SetActiveToolVisible(false);
                     return;
                 }
-                UsageResult? toApply = coordinator.LastState is { } last && last.Id == target
+
+                UsageResult? toApply = coordinator.LastState is { } last && last.Id == targetProvider
                     ? last
-                    : coordinator.Service.TryGetCached(target, out var cached)
+                    : coordinator.Service.TryGetCached(targetProvider, out var cached)
                         ? cached
-                        : coordinator.Service.TryGetLastSuccessfulLiveResult(target, out var lastSuccess)
+                        : coordinator.Service.TryGetLastSuccessfulLiveResult(targetProvider, out var lastSuccess)
                             ? lastSuccess
-                            : coordinator.Service.Get(target) is { } provider
-                                ? UsageResult.Pending(target, provider, "Loading...")
+                            : coordinator.Service.Get(targetProvider) is { } usageProvider
+                                ? UsageResult.Pending(targetProvider, usageProvider, "Loading...")
                                 : null;
 
                 if (toApply is { } result)
@@ -166,8 +171,7 @@ namespace TaskbarQuota.Taskbar
                     LogWidgetApply(result.Id, "sync");
                 }
 
-                bool isVisible = coordinator.IsActiveToolPresent;
-                summary.SetActiveToolVisible(isVisible);
+                summary.SetActiveToolVisible(shouldShowWidget);
 
                 if (toApply is null)
                     _ = coordinator.TickAsync(force: true);
@@ -219,7 +223,9 @@ namespace TaskbarQuota.Taskbar
             {
                 widget.Summary.Apply(result);
                 LogWidgetApply(result.Id, "state");
-                bool isVisible = UsageCoordinator.Instance.IsActiveToolPresent;
+                bool isVisible = UsageCoordinator.Instance.IsActiveToolPresent
+                    && UsageCoordinator.Instance.WidgetDisplayProvider is not null;
+                widget.SetVisible(isVisible);
                 widget.Summary.SetActiveToolVisible(isVisible);
             });
         }
@@ -242,7 +248,11 @@ namespace TaskbarQuota.Taskbar
             var widget = _widget;
             if (widget?.Summary is null) return;
             bool isVisible = isPresent && UsageCoordinator.Instance.WidgetDisplayProvider is not null;
-            widget.Summary.DispatcherQueue.TryEnqueue(() => widget.Summary.SetActiveToolVisible(isVisible));
+            widget.Summary.DispatcherQueue.TryEnqueue(() =>
+            {
+                widget.SetVisible(isVisible);
+                widget.Summary.SetActiveToolVisible(isVisible);
+            });
         }
 
         private static void OnWidgetSettingsChanged(object? sender, EventArgs e)

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -28,11 +28,13 @@ namespace TaskbarQuota.Taskbar
         private const string NotificationAreaClassName = "TrayNotifyWnd";
         private const string WidgetsButtonAutomationId = "WidgetsButton";
         private const int DefaultWidgetHostWidth = 172;
+        private const int TrayClearanceLogicalPx = 6;
 
         private static readonly bool IsRtlUI = System.Globalization.CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft;
 
         // Minimum horizontal recompute delta (logical px, DPI-scaled) before the resting widget is moved.
         private int RepositionDeadbandPx => (int)Math.Ceiling(2 * dpiScale);
+        private int TrayClearancePx => (int)Math.Ceiling(TrayClearanceLogicalPx * dpiScale);
 
         private readonly double dpiScale;
         private readonly IntPtr hwndShell;
@@ -60,6 +62,7 @@ namespace TaskbarQuota.Taskbar
         private int pressCursorPositionX;
         private bool initialized;
         private bool destroyed;
+        private bool isVisible;
         private bool disposedValue;
 
         public IntPtr Handle => hwnd != IntPtr.Zero ? hwnd : throw new InvalidOperationException("Widget not initialized.");
@@ -162,7 +165,25 @@ namespace TaskbarQuota.Taskbar
             destroyed = true;
         }
 
-        public void Show() => appWindow?.Show(false);
+        public void SetVisible(bool visible)
+        {
+            if (appWindow is null || isVisible == visible)
+                return;
+
+            isVisible = visible;
+            if (visible)
+            {
+                _ = UpdatePositionImpl(TaskbarChangeReason.None);
+                appWindow.Show(false);
+            }
+            else
+            {
+                if (isDragging)
+                    EndDragging(revert: true);
+                appWindow.Hide();
+            }
+        }
+
         public void Destroy() => appWindow?.Destroy();
 
         public void UpdatePosition(bool resetManualPosition = false)
@@ -205,7 +226,14 @@ namespace TaskbarQuota.Taskbar
         private async Task UpdatePositionImpl(TaskbarChangeReason reason, bool isCentered, bool isWidgetsEnabled)
         {
             if (appWindow is null) return;
-            User32.GetWindowRect(hwndShell, out RECT taskbarRect);
+            User32.GetWindowRect(hwndShell, out RECT taskbarScreenRect);
+            User32.GetWindowRect(hwndTrayNotify, out RECT trayNotifyScreenRect);
+            User32.GetWindowRect(hwndReBar, out RECT barScreenRect);
+            var notificationScreenRect = GetNotificationAreaScreenRect(taskbarScreenRect, trayNotifyScreenRect);
+
+            var taskbarRect = ToTaskbarClientRect(taskbarScreenRect, taskbarScreenRect);
+            var trayNotifyRect = ToTaskbarClientRect(notificationScreenRect, taskbarScreenRect);
+            var barRect = ToTaskbarClientRect(barScreenRect, taskbarScreenRect);
 
             int offsetX = LoadCustomPosition();
             // Taskbar alignment flipped (e.g. centered -> left): the old manual position now sits on the
@@ -216,11 +244,9 @@ namespace TaskbarQuota.Taskbar
                 offsetX = -1;
             }
             bool useDefault = offsetX == -1;
-            User32.GetWindowRect(hwndTrayNotify, out RECT trayNotifyRect);
-            User32.GetWindowRect(hwndReBar, out RECT barRect);
             // Resting position uses the stable lanes (no running-app buttons) so it doesn't jitter as apps
             // open/close; manual drag (MoveWidgetWithCursor) keeps the full band-avoiding lanes.
-            var lanes = GetWidgetLanes(taskbarRect, trayNotifyRect, barRect, stableOnly: true);
+            var lanes = GetWidgetLanes(taskbarRect, trayNotifyRect, barRect, taskbarScreenRect, stableOnly: true);
 
             // The Widgets button is a XAML element the child-window lane scan can't see, so fetch its
             // bounds separately and treat it as an obstacle to clear — for BOTH the default anchor and a
@@ -232,12 +258,12 @@ namespace TaskbarQuota.Taskbar
                 foreach (var wnd in GetOtherInjectedWindows())
                 {
                     User32.GetWindowRect(wnd, out var injectedBounds);
-                    obstacles.Add(injectedBounds);
+                    obstacles.Add(ToTaskbarClientRect(injectedBounds, taskbarScreenRect));
                 }
             }
             catch (Exception ex) { Log.Warning(ex, "overlap scan failed"); }
             if (wbRect is { } wb && wb.right > wb.left)
-                obstacles.Add(wb);
+                obstacles.Add(ToTaskbarClientRect(wb, taskbarScreenRect));
 
             // Centered default anchors far-left and grows rightward, so step off obstacles to the RIGHT;
             // every other case rests toward the tray and steps LEFT. RTL mirrors both.
@@ -247,7 +273,7 @@ namespace TaskbarQuota.Taskbar
             if (useDefault && isCentered)
             {
                 // Centered Win11 taskbar: far-left is empty, anchor just right of the Widgets button.
-                offsetX = ComputeFarLeftAnchor(taskbarRect, trayNotifyRect, wbRect, isCentered);
+                offsetX = ComputeFarLeftAnchor(taskbarRect, trayNotifyRect, wbRect, taskbarScreenRect, isCentered);
             }
             else if (useDefault)
             {
@@ -262,16 +288,17 @@ namespace TaskbarQuota.Taskbar
 
             offsetX = StepClearOfObstacles(offsetX, obstacles, stepLeft);
 
-            // Keep it on the bar, clear of the tray, and (LTR) right of the app cluster so stepping left off
-            // a tray-side Widgets button lands in the free gap rather than on Start/search/apps.
+            // Keep it on the bar and clear of the tray. If the preferred gap between apps and tray is too
+            // small, prioritize tray access over staying right of the app cluster.
+            int traySafeMax = Math.Max(0, trayNotifyRect.left - WidgetHostWidth - TrayClearancePx);
             int minXBound = IsRtlUI
-                ? Math.Max(0, taskbarRect.left)
-                : Math.Max(Math.Max(0, taskbarRect.left), isCentered ? 0 : barRect.right);
-            int maxXBound = Math.Max(minXBound, trayNotifyRect.left - WidgetHostWidth);
+                ? 0
+                : Math.Min(Math.Max(0, isCentered ? 0 : barRect.right), traySafeMax);
+            int maxXBound = Math.Max(minXBound, traySafeMax);
             offsetX = Math.Clamp(offsetX, minXBound, maxXBound);
-            offsetX = ClampToMonitorContainingTray(offsetX, WidgetHostWidth, taskbarRect, trayNotifyRect, barRect);
+            offsetX = ClampToMonitorContainingTray(offsetX, WidgetHostWidth, taskbarScreenRect, notificationScreenRect, barScreenRect);
 
-            int offsetY = barRect.top - taskbarRect.top;
+            int offsetY = barRect.top;
 
             if (currentOffsetY != offsetY)
             {
@@ -290,8 +317,12 @@ namespace TaskbarQuota.Taskbar
         public void StartDragging()
         {
             if (isDragging || appWindow is null || hostContent is null || widgetSummary is null) return;
+            SetVisible(true);
             widgetSummary.IsHitTestVisible = false;
-            User32.SetCursorPos(appWindow.Position.X + appWindow.Size.Width / 2, appWindow.Position.Y + appWindow.Size.Height / 2);
+            User32.GetWindowRect(hwndShell, out var taskbarRect);
+            User32.SetCursorPos(
+                taskbarRect.left + appWindow.Position.X + appWindow.Size.Width / 2,
+                taskbarRect.top + appWindow.Position.Y + appWindow.Size.Height / 2);
             hostContent.KeyUp += Content_KeyUp;
             hostContent.PointerPressed += Content_PointerPressed;
             hostContent.PointerReleased += Content_PointerReleased;
@@ -333,7 +364,8 @@ namespace TaskbarQuota.Taskbar
             hostContent.CapturePointer(e.Pointer);
             User32.GetCursorPos(out var point);
             lastCursorPositionX = point.x;
-            draggingInnerOffsetX = point.x - appWindow.Position.X;
+            User32.GetWindowRect(hwndShell, out var taskbarRect);
+            draggingInnerOffsetX = point.x - taskbarRect.left - appWindow.Position.X;
         }
 
         private void Content_PointerReleased(object sender, PointerRoutedEventArgs e) => EndDragging(false);
@@ -355,7 +387,8 @@ namespace TaskbarQuota.Taskbar
             User32.GetCursorPos(out var point);
             pressCursorPositionX = point.x;
             lastCursorPositionX = point.x;
-            draggingInnerOffsetX = point.x - appWindow.Position.X;
+            User32.GetWindowRect(hwndShell, out var taskbarRect);
+            draggingInnerOffsetX = point.x - taskbarRect.left - appWindow.Position.X;
         }
 
         private void WidgetSummary_PointerMoved(object sender, PointerRoutedEventArgs e)
@@ -404,8 +437,12 @@ namespace TaskbarQuota.Taskbar
             User32.GetWindowRect(hwndShell, out RECT taskbarRect);
             User32.GetWindowRect(hwndTrayNotify, out RECT trayNotifyRect);
             User32.GetWindowRect(hwndReBar, out RECT barRect);
-            var lanes = GetWidgetLanes(taskbarRect, trayNotifyRect, barRect);
-            int targetX = cursorX - draggingInnerOffsetX;
+            var notificationRect = GetNotificationAreaScreenRect(taskbarRect, trayNotifyRect);
+            var taskbarClientRect = ToTaskbarClientRect(taskbarRect, taskbarRect);
+            var trayNotifyClientRect = ToTaskbarClientRect(notificationRect, taskbarRect);
+            var barClientRect = ToTaskbarClientRect(barRect, taskbarRect);
+            var lanes = GetWidgetLanes(taskbarClientRect, trayNotifyClientRect, barClientRect, taskbarRect);
+            int targetX = cursorX - taskbarRect.left - draggingInnerOffsetX;
             int delta = cursorX - lastCursorPositionX;
             targetX = NormalizeDragX(targetX, delta, lanes);
 
@@ -418,19 +455,21 @@ namespace TaskbarQuota.Taskbar
         // computation makes the widget hop around as you switch apps (most visible on a centered Win11
         // taskbar) — issue #7 case 1. Manual dragging still avoids them, so the user can't drop the widget
         // on top of the app buttons.
-        private TaskbarLanes GetWidgetLanes(RECT taskbarRect, RECT trayNotifyRect, RECT barRect, bool stableOnly = false)
+        private TaskbarLanes GetWidgetLanes(RECT taskbarRect, RECT trayNotifyRect, RECT barRect, RECT taskbarScreenRect, bool stableOnly = false)
         {
             int forbiddenLeft = barRect.left;
             int forbiddenRight = barRect.right;
             if (hwndStart != IntPtr.Zero && User32.GetWindowRect(hwndStart, out RECT startRect) && startRect.right > startRect.left)
             {
+                startRect = ToTaskbarClientRect(startRect, taskbarScreenRect);
                 forbiddenLeft = Math.Min(forbiddenLeft, startRect.left);
                 forbiddenRight = Math.Max(forbiddenRight, startRect.right);
             }
             foreach (var bounds in GetTaskbarItemBandWindows(includeAppButtons: !stableOnly))
             {
-                forbiddenLeft = Math.Min(forbiddenLeft, bounds.left);
-                forbiddenRight = Math.Max(forbiddenRight, bounds.right);
+                var localBounds = ToTaskbarClientRect(bounds, taskbarScreenRect);
+                forbiddenLeft = Math.Min(forbiddenLeft, localBounds.left);
+                forbiddenRight = Math.Max(forbiddenRight, localBounds.right);
             }
 
             int leftMin;
@@ -460,21 +499,21 @@ namespace TaskbarQuota.Taskbar
         // The default "far left" X: hugging the left end of the taskbar's item area. On Win11 the Widgets
         // button is pinned far-left, so we sit just right of it; on a left-aligned classic taskbar we sit
         // right of the Start button; otherwise the very left edge. RTL mirrors to the visual start (right).
-        private int ComputeFarLeftAnchor(RECT taskbarRect, RECT trayNotifyRect, RECT? wbRect, bool isCentered)
+        private int ComputeFarLeftAnchor(RECT taskbarRect, RECT trayNotifyRect, RECT? wbRect, RECT taskbarScreenRect, bool isCentered)
         {
             if (IsRtlUI)
             {
                 if (wbRect is { } wb && wb.right > wb.left)
-                    return wb.left - WidgetHostWidth;
+                    return ToTaskbarClientRect(wb, taskbarScreenRect).left - WidgetHostWidth;
                 return taskbarRect.right - WidgetHostWidth;
             }
 
             int anchor = Math.Max(0, taskbarRect.left);
             if (wbRect is { } w && w.right > w.left)
-                anchor = Math.Max(anchor, w.right);
+                anchor = Math.Max(anchor, ToTaskbarClientRect(w, taskbarScreenRect).right);
             else if (!isCentered && hwndStart != IntPtr.Zero
                      && User32.GetWindowRect(hwndStart, out RECT startRect) && startRect.right > startRect.left)
-                anchor = Math.Max(anchor, startRect.right);
+                anchor = Math.Max(anchor, ToTaskbarClientRect(startRect, taskbarScreenRect).right);
             return anchor;
         }
 
@@ -517,6 +556,54 @@ namespace TaskbarQuota.Taskbar
             screenX = Math.Clamp(screenX, m.left, m.right - widgetHostWidth);
             return screenX - taskbarRect.left;
         }
+
+        private static RECT ToTaskbarClientRect(RECT rect, RECT taskbarScreenRect)
+            => new()
+            {
+                left = rect.left - taskbarScreenRect.left,
+                top = rect.top - taskbarScreenRect.top,
+                right = rect.right - taskbarScreenRect.left,
+                bottom = rect.bottom - taskbarScreenRect.top,
+            };
+
+        private RECT GetNotificationAreaScreenRect(RECT taskbarScreenRect, RECT trayNotifyScreenRect)
+        {
+            var result = trayNotifyScreenRect;
+            IncludeTaskbarChildBounds("ClockButton", taskbarScreenRect, ref result);
+            IncludeTaskbarChildBounds("TrayClockWClass", taskbarScreenRect, ref result);
+            IncludeTaskbarChildBounds("TrayShowDesktopButtonWClass", taskbarScreenRect, ref result);
+            return result;
+        }
+
+        private void IncludeTaskbarChildBounds(string className, RECT taskbarScreenRect, ref RECT result)
+        {
+            for (var child = User32.FindWindowEx(hwndShell, IntPtr.Zero, className, null);
+                 child != IntPtr.Zero;
+                 child = User32.FindWindowEx(hwndShell, child, className, null))
+            {
+                if (!User32.GetWindowRect(child, out var bounds)
+                    || bounds.right <= bounds.left
+                    || bounds.bottom <= bounds.top
+                    || !RectsIntersect(bounds, taskbarScreenRect))
+                {
+                    continue;
+                }
+
+                result = Union(result, bounds);
+            }
+        }
+
+        private static bool RectsIntersect(RECT a, RECT b)
+            => a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+
+        private static RECT Union(RECT a, RECT b)
+            => new()
+            {
+                left = Math.Min(a.left, b.left),
+                top = Math.Min(a.top, b.top),
+                right = Math.Max(a.right, b.right),
+                bottom = Math.Max(a.bottom, b.bottom),
+            };
 
         private int NormalizeWidgetX(int x, TaskbarLanes lanes, bool preferRightLane)
         {
@@ -671,6 +758,7 @@ namespace TaskbarQuota.Taskbar
         public void Dispose()
         {
             if (disposedValue) return;
+            isVisible = false;
             if (!destroyed) appWindow?.Destroy();
             if (widgetSummary is not null)
             {

--- a/src/TaskbarQuota.App/Usage/Models.cs
+++ b/src/TaskbarQuota.App/Usage/Models.cs
@@ -23,13 +23,17 @@ namespace TaskbarQuota.Usage
         public int? WindowMinutes { get; init; }
         public DateTimeOffset? ResetAt { get; init; }
         public string? ResetDescription { get; init; }
+        /// <summary>Optional bar label override (e.g. "Spend limit" for Claude Enterprise), when the
+        /// window isn't the provider's default Session/Weekly meter.</summary>
+        public string? Label { get; init; }
 
-        public RateWindow(double usedPercent, int? windowMinutes = null, DateTimeOffset? resetAt = null, string? resetDescription = null)
+        public RateWindow(double usedPercent, int? windowMinutes = null, DateTimeOffset? resetAt = null, string? resetDescription = null, string? label = null)
         {
             UsedPercent = Math.Clamp(usedPercent, 0, 100);
             WindowMinutes = windowMinutes;
             ResetAt = resetAt;
             ResetDescription = resetDescription;
+            Label = label;
         }
 
         public double RemainingPercent => 100 - UsedPercent;
@@ -155,6 +159,9 @@ namespace TaskbarQuota.Usage
     public sealed class UsageSnapshot
     {
         public RateWindow Primary { get; }            // session
+        /// <summary>False when the provider reported no session window at all (e.g. Codex org/Business
+        /// plans that only expose credits): the card skips the primary bar instead of showing "0%".</summary>
+        public bool HasPrimaryWindow { get; set; } = true;
         public RateWindow? Secondary { get; set; }    // weekly
         public RateWindow? ModelSpecific { get; set; }// e.g. Opus / code review
         public RateWindow? Monthly { get; set; }      // monthly window when available

--- a/src/TaskbarQuota.App/Usage/Providers/ClaudeProvider.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/ClaudeProvider.cs
@@ -147,27 +147,79 @@ namespace TaskbarQuota.Usage.Providers
 
         private static ProviderFetchResult BuildResult(JsonElement json, Credentials creds)
         {
-            var primary = ParseWindow(json, 300, "five_hour", "fiveHour") ?? new RateWindow(0);
-            var usage = new UsageSnapshot(primary);
+            var sessionWindow = ParseWindow(json, 300, "five_hour", "fiveHour");
+            var secondary = ParseWindow(json, 10080, "seven_day", "sevenDay");
+            var modelSpecific =
+                ParseWindow(json, 10080, "seven_day_opus", "sevenDayOpus") is { } opus
+                    ? WithLabel(opus, "Opus")
+                    : ParseWindow(json, 10080, "seven_day_sonnet", "sevenDaySonnet") is { } sonnet
+                        ? WithLabel(sonnet, "Sonnet")
+                        : null;
+            var fableWeekly = ParseScopedWeeklyLimit(json, "Fable");
 
-            usage.Secondary = ParseWindow(json, 10080, "seven_day", "sevenDay");
-            usage.ModelSpecific =
-                ParseWindow(json, 10080, "seven_day_opus", "sevenDayOpus")
-                ?? ParseWindow(json, 10080, "seven_day_sonnet", "sevenDaySonnet");
+            bool hasExtra = TryParseExtraUsage(json, out var cost, out var additional);
+            string plan = ResolvePlan(creds.SubscriptionType, creds.RateLimitTier);
 
+            // Claude Enterprise (and other org-billed plans) expose no session/weekly rate windows —
+            // only an `extra_usage` spend cap. Promote that cap to the primary bar so it's a first-class,
+            // widget-toggleable meter ("Spend limit") instead of a plain text line with no add option.
+            // Mirrors CodexBar's `oauthSpendLimitWindow` / `treatAsSpendLimit`. See github issue #12.
+            bool treatAsSpendLimit = sessionWindow == null && secondary == null && hasExtra;
+            bool isSpendLimit = treatAsSpendLimit || string.Equals(plan, "Enterprise", StringComparison.OrdinalIgnoreCase);
+
+            bool hasSpendLimitWindow = treatAsSpendLimit && cost is { Limit: > 0 };
+            RateWindow primary;
+            if (hasSpendLimitWindow && cost is { } spend)
+                primary = BuildSpendLimitWindow(spend);
+            else
+                primary = sessionWindow ?? new RateWindow(0);
+
+            var usage = new UsageSnapshot(primary)
+            {
+                HasPrimaryWindow = sessionWindow != null || hasSpendLimitWindow,
+            };
+            usage.Secondary = secondary;
+            usage.ModelSpecific = modelSpecific;
+
+            if (fableWeekly is { } fable)
+                usage.ExtraRateWindows.Add(new NamedRateWindow("claude-fable", "Fable", fable));
             AddExtraWindow(usage, json, "claude-oauth-apps", "OAuth apps", "seven_day_oauth_apps", "seven_day_claude_oauth_apps", "oauth_apps", "oauth", "sevenDayOauthApps");
             AddExtraWindow(usage, json, "claude-design", "Claude Design", "seven_day_design", "seven_day_claude_design", "claude_design", "design", "seven_day_omelette", "omelette", "sevenDayDesign");
             AddExtraWindow(usage, json, "claude-routines", "Daily Routines", "seven_day_routines", "seven_day_claude_routines", "claude_routines", "routines", "routine", "seven_day_cowork", "cowork", "sevenDayRoutines");
 
-            if (TryParseExtraUsage(json, out var cost, out var additional))
+            if (hasExtra && cost != null)
             {
-                usage.Cost = cost;
+                // CodexBar wording: spend-limit plans read "Spend limit", others "Monthly cap".
+                usage.Cost = RelabelCostPeriod(cost, isSpendLimit ? "Spend limit" : "Monthly cap");
                 usage.AdditionalUsage = additional;
             }
 
-            usage.LoginMethod = ResolvePlan(creds.SubscriptionType, creds.RateLimitTier);
+            usage.LoginMethod = plan;
             return new ProviderFetchResult(usage, "oauth");
         }
+
+        private static CostSnapshot RelabelCostPeriod(CostSnapshot cost, string period)
+        {
+            var relabeled = new CostSnapshot(cost.Amount, cost.Currency, period);
+            if (cost.Limit is { } limit) relabeled.WithLimit(limit);
+            if (cost.ResetsAt is { } resetsAt) relabeled.WithResetsAt(resetsAt);
+            return relabeled;
+        }
+
+        /// <summary>
+        /// Builds the Enterprise "Spend limit" primary bar from the extra-usage cost: percent = used/limit.
+        /// The dollar detail ($9.27 / $100.00) still renders below via <see cref="UsageSnapshot.Cost"/>.
+        /// </summary>
+        private static RateWindow BuildSpendLimitWindow(CostSnapshot spend)
+        {
+            double pct = spend.Limit is { } lim && lim > 0
+                ? Math.Clamp(spend.Amount / lim * 100, 0, 100)
+                : 0;
+            return new RateWindow(pct, label: "Spend limit");
+        }
+
+        private static RateWindow WithLabel(RateWindow window, string label)
+            => new(window.UsedPercent, window.WindowMinutes, window.ResetAt, window.ResetDescription, label);
 
         internal static ProviderFetchResult BuildResultForTesting(JsonElement json, Credentials creds)
             => BuildResult(json, creds);
@@ -230,6 +282,42 @@ namespace TaskbarQuota.Usage.Providers
             }
 
             return new RateWindow(util, windowMinutes, resetAt, resetDesc);
+        }
+
+        /// <summary>
+        /// A model-scoped weekly limit from the <c>limits</c> array — a <c>kind: "weekly_scoped"</c> row
+        /// whose <c>scope.model.display_name</c> names the model (e.g. "Fable"). Anthropic moved the
+        /// per-model weekly windows off the legacy top-level <c>seven_day_&lt;model&gt;</c> keys (which now
+        /// return null) into this array, so the Fable bucket is read by display name. <c>percent</c> is
+        /// 0–100. Ported from openusage ClaudeUsageMapper.appendScopedWeeklyLimit (#814).
+        /// </summary>
+        private static RateWindow? ParseScopedWeeklyLimit(JsonElement root, string modelDisplayName)
+        {
+            if (!TryGetFirstProperty(root, out var limits, "limits") || limits.ValueKind != JsonValueKind.Array)
+                return null;
+
+            foreach (var entry in limits.EnumerateArray())
+            {
+                if (entry.ValueKind != JsonValueKind.Object) continue;
+                if (!string.Equals(Str(entry, "kind"), "weekly_scoped", StringComparison.Ordinal)) continue;
+                if (!entry.TryGetProperty("scope", out var scope) || scope.ValueKind != JsonValueKind.Object) continue;
+                if (!scope.TryGetProperty("model", out var model) || model.ValueKind != JsonValueKind.Object) continue;
+                if (!string.Equals(Str(model, "display_name"), modelDisplayName, StringComparison.OrdinalIgnoreCase)) continue;
+                if (Num(entry, "percent") is not { } percent) continue;
+
+                DateTimeOffset? resetAt = null;
+                string? resetDesc = null;
+                if (entry.TryGetProperty("resets_at", out var ra) && ra.ValueKind == JsonValueKind.String &&
+                    DateTimeOffset.TryParse(ra.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dt))
+                {
+                    resetAt = dt;
+                    resetDesc = CodexProvider.FormatResetCountdown(dt);
+                }
+
+                return new RateWindow(percent, 10080, resetAt, resetDesc);
+            }
+
+            return null;
         }
 
         private static bool TryGetFirstProperty(JsonElement root, out JsonElement value, params string[] names)

--- a/src/TaskbarQuota.App/Usage/Providers/CodexProvider.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CodexProvider.cs
@@ -67,7 +67,12 @@ namespace TaskbarQuota.Usage.Providers
             double? headerCredits = null,
             JsonElement? resetCreditsJson = null)
         {
-            var (primary, secondary, codeReview) = ExtractRateLimits(json);
+            var (primaryOpt, secondary, codeReview) = ExtractRateLimits(json);
+            // Codex org/Business plans expose no rate windows — only credits. Mirror CodexBar's
+            // credits-only snapshot (primary == nil) rather than fabricating a bogus "Session 0%".
+            // A live header percent still counts as a real session signal. See github issue #12.
+            bool hasPrimary = primaryOpt != null || headerPrimary != null;
+            var primary = primaryOpt ?? new RateWindow(0);
             if (headerPrimary is double hp) primary = WithUsedPercent(primary, hp);
             if (headerSecondary is double hs)
             {
@@ -76,7 +81,7 @@ namespace TaskbarQuota.Usage.Providers
                     : WithUsedPercent(secondary, hs);
             }
 
-            var usage = new UsageSnapshot(primary);
+            var usage = new UsageSnapshot(primary) { HasPrimaryWindow = hasPrimary };
             if (secondary != null) usage.Secondary = secondary;
             if (codeReview != null) usage.ModelSpecific = codeReview;
 
@@ -135,7 +140,7 @@ namespace TaskbarQuota.Usage.Providers
             return request;
         }
 
-        private static (RateWindow primary, RateWindow? secondary, RateWindow? codeReview) ExtractRateLimits(JsonElement json)
+        private static (RateWindow? primary, RateWindow? secondary, RateWindow? codeReview) ExtractRateLimits(JsonElement json)
         {
             if (json.TryGetProperty("rate_limit", out var rl) && rl.ValueKind == JsonValueKind.Object)
             {
@@ -153,10 +158,10 @@ namespace TaskbarQuota.Usage.Providers
 
                 // Promote secondary to primary for weekly-only plans
                 if (p == null && s != null) { p = s; s = null; }
-                return (p ?? new RateWindow(0), s, cr);
+                return (p, s, cr);
             }
 
-            return (new RateWindow(0), null, null);
+            return (null, null, null);
         }
 
         private static void AddAdditionalRateLimits(JsonElement json, UsageSnapshot usage, string? planType)
@@ -217,15 +222,35 @@ namespace TaskbarQuota.Usage.Providers
 
         private static CostSnapshot? ExtractCredits(JsonElement json, double? headerCredits)
         {
+            // Codex credits mirror CodexBar's model: the /wham/usage `credits` object carries a raw
+            // `balance` plus `has_credits` / `unlimited` flags, but NO limit. Business/Enterprise plans
+            // report a raw balance with no cap, so we must never fabricate one (the old code slapped
+            // `.WithLimit(1000)` on every balance, which rendered a bogus "1,000 / 1,000"). A limit is
+            // surfaced only when the API actually reports one; otherwise the balance shows on its own.
             double? balance = headerCredits;
-            if (!json.TryGetProperty("credits", out var credits) || credits.ValueKind != JsonValueKind.Object)
-                return balance is null ? null : new CostSnapshot(balance.Value, "credits", "Credits").WithLimit(1000);
+            double? limit = null;
 
-            bool hasCredits = credits.TryGetProperty("has_credits", out var hc) && hc.ValueKind == JsonValueKind.True;
-            if (!hasCredits && balance is null) return null;
-            if (credits.TryGetProperty("unlimited", out var un) && un.ValueKind == JsonValueKind.True) return null;
-            balance ??= TryF64(credits, "balance") ?? (hasCredits ? 0 : null);
-            return balance is null ? null : new CostSnapshot(balance.Value, "credits", "Credits").WithLimit(1000);
+            if (json.TryGetProperty("credits", out var credits) && credits.ValueKind == JsonValueKind.Object)
+            {
+                // Unlimited orgs have no meaningful credit balance to show.
+                if (credits.TryGetProperty("unlimited", out var un) && un.ValueKind == JsonValueKind.True)
+                    return null;
+
+                bool hasCredits = credits.TryGetProperty("has_credits", out var hc) && hc.ValueKind == JsonValueKind.True;
+                balance ??= TryF64(credits, "balance") ?? (hasCredits ? 0 : null);
+                limit = TryF64(credits, "limit") ?? TryF64(credits, "total_granted") ?? TryF64(credits, "granted") ?? TryF64(credits, "monthly_limit");
+
+                if (!hasCredits && balance is null)
+                    return null;
+            }
+
+            if (balance is null)
+                return null;
+
+            var snapshot = new CostSnapshot(balance.Value, "credits", "Credits");
+            if (limit is { } lim && lim > 0)
+                snapshot.WithLimit(lim);
+            return snapshot;
         }
 
         private static ResetCreditsSnapshot? ExtractResetCredits(JsonElement? maybeJson)

--- a/src/TaskbarQuota.App/ViewModels/ProviderCardViewModel.cs
+++ b/src/TaskbarQuota.App/ViewModels/ProviderCardViewModel.cs
@@ -275,26 +275,38 @@ namespace TaskbarQuota.ViewModels
                     bool creditsOnly = r.Id is ProviderId.Copilot or ProviderId.Grok && u.Cost is { Label: "Credits" };
                     if (!creditsOnly)
                     {
-                        var primaryLabel = r.Provider?.SessionLabel ?? "Session";
-                        bars.Add(new BarViewModel(r.Id, WidgetSettingsService.RowPrimary, primaryLabel, u.Primary));
+                        if (u.HasPrimaryWindow)
+                        {
+                            var primaryLabel = u.Primary.Label ?? r.Provider?.SessionLabel ?? "Session";
+                            bars.Add(new BarViewModel(r.Id, WidgetSettingsService.RowPrimary, primaryLabel, u.Primary));
+                        }
                         if (u.Secondary != null)
                         {
                             var secondaryLabel = r.Provider?.WeeklyLabel ?? "Weekly";
                             bars.Add(new BarViewModel(r.Id, WidgetSettingsService.RowSecondary, secondaryLabel, u.Secondary));
                         }
-                        if (u.ModelSpecific != null) bars.Add(new BarViewModel(r.Id, WidgetSettingsService.RowModelSpecific, ModelSpecificLabel(r.Id), u.ModelSpecific));
+                        if (u.ModelSpecific != null) bars.Add(new BarViewModel(r.Id, WidgetSettingsService.RowModelSpecific, u.ModelSpecific.Label ?? ModelSpecificLabel(r.Id), u.ModelSpecific));
                         if (u.Monthly != null) bars.Add(new BarViewModel(r.Id, WidgetSettingsService.RowMonthly, "Monthly", u.Monthly));
                         foreach (var extra in u.ExtraRateWindows) bars.Add(new BarViewModel(r.Id, extra));
                     }
 
                     if (u.Cost is { Label: "Credits" } credits)
                     {
-                        var limit = credits.Limit ?? 0;
                         var remaining = credits.Amount;
-                        var used = System.Math.Max(0, limit - remaining);
-                        CreditPercent = limit <= 0 ? 0 : System.Math.Clamp(used / limit * 100, 0, 100);
+                        if (credits.Limit is { } limit && limit > 0)
+                        {
+                            var used = System.Math.Max(0, limit - remaining);
+                            CreditPercent = System.Math.Clamp(used / limit * 100, 0, 100);
+                            CreditLeftText = $"{FormatCount(used)}/{FormatCount(limit)} Credits";
+                        }
+                        else
+                        {
+                            // No cap reported (e.g. Codex Business/Enterprise): show the raw balance
+                            // on its own instead of a fabricated "N / N" — matches CodexBar.
+                            CreditPercent = 0;
+                            CreditLeftText = $"{FormatCount(remaining)} Credits";
+                        }
                         CreditBrush = Ui.ConsumedUsageBrush(CreditPercent);
-                        CreditLeftText = $"{FormatCount(used)}/{FormatCount(limit)} Credits";
                         CreditLimitText = FormatCreditReset(credits.ResetsAt, u.Primary.ResetDescription);
                         CreditOpacity = r.Id == ProviderId.Codex && remaining <= 0 ? 0.55 : 1.0;
                         CostText = string.Empty;

--- a/tests/TaskbarQuota.Tests/ClaudeProviderCredentialTests.cs
+++ b/tests/TaskbarQuota.Tests/ClaudeProviderCredentialTests.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using TaskbarQuota.Controls;
+using TaskbarQuota.Usage;
 using TaskbarQuota.Usage.Providers;
 
 namespace TaskbarQuota.Tests;
@@ -82,6 +84,87 @@ public class ClaudeProviderCredentialTests
     }
 
     [Fact]
+    public void BuildResult_FableScopedWeeklyLimit_IsSeparateExtraWeeklyRow()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+          "five_hour": { "utilization": 10, "resets_at": "2099-01-01T00:00:00.000Z" },
+          "seven_day": { "utilization": 20, "resets_at": "2099-01-08T00:00:00.000Z" },
+          "seven_day_sonnet": null,
+          "limits": [
+            { "kind": "session", "group": "session", "percent": 10, "resets_at": "2099-01-01T00:00:00.000Z" },
+            { "kind": "weekly_all", "group": "weekly", "percent": 20, "resets_at": "2099-01-08T00:00:00.000Z" },
+            {
+              "kind": "weekly_scoped",
+              "group": "weekly",
+              "percent": 7,
+              "resets_at": "2099-01-08T00:00:00.000Z",
+              "scope": { "model": { "display_name": "Fable", "id": null }, "surface": null }
+            }
+          ]
+        }
+        """);
+
+        var result = ClaudeProvider.BuildResultForTesting(
+            doc.RootElement,
+            new ClaudeProvider.Credentials("token", "max", "default_claude_ai"));
+
+        var fable = Assert.Single(result.Usage.ExtraRateWindows, w => w.Id == "claude-fable");
+        Assert.Equal("Fable", fable.Title);
+        Assert.Equal(7, fable.Window.UsedPercent);
+        Assert.Equal(10080, fable.Window.WindowMinutes);
+        Assert.Null(result.Usage.ModelSpecific);
+    }
+
+    [Fact]
+    public void WidgetRows_ForClaude_FableIsVisibleByDefaultAndDoesNotReplaceCoreRows()
+    {
+        WidgetSettingsService.ResetRowVisibilityForTesting();
+        try
+        {
+            var usage = new UsageSnapshot(new RateWindow(10))
+            {
+                Secondary = new RateWindow(20),
+            };
+            usage.ExtraRateWindows.Add(new NamedRateWindow("claude-fable", "Fable", new RateWindow(7)));
+            var result = UsageResult.Success(ProviderId.Claude, new TestProvider(), new ProviderFetchResult(usage, "oauth"));
+
+            var defaultLabels = WidgetSummary.BuildRowLabelsForTesting(result, usage);
+            WidgetSettingsService.SetRowVisibleForTesting(ProviderId.Claude, WidgetSettingsService.RowExtra, false);
+            var disabledLabels = WidgetSummary.BuildRowLabelsForTesting(result, usage);
+
+            Assert.Equal(new[] { "Session", "Weekly", "Fable" }, defaultLabels);
+            Assert.Equal(new[] { "Session", "Weekly" }, disabledLabels);
+        }
+        finally
+        {
+            WidgetSettingsService.ResetRowVisibilityForTesting();
+        }
+    }
+
+    [Fact]
+    public void BuildResult_UncappedExtraUsage_DoesNotCreateFakePrimaryWindow()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+          "extra_usage": {
+            "is_enabled": true,
+            "used_credits": 927,
+            "currency": "USD"
+          }
+        }
+        """);
+
+        var result = ClaudeProvider.BuildResultForTesting(
+            doc.RootElement,
+            new ClaudeProvider.Credentials("token", "enterprise", "default_claude_ai"));
+
+        Assert.False(result.Usage.HasPrimaryWindow);
+        Assert.Equal("Spend limit", result.Usage.Cost?.Label);
+        Assert.Equal("$9.27", result.Usage.Cost?.Display);
+    }
+
+    [Fact]
     public void ParseRetryAfter_Delta_ReturnsFutureTime()
     {
         using var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
@@ -93,5 +176,16 @@ public class ClaudeProviderCredentialTests
 
         Assert.NotNull(parsed);
         Assert.InRange(parsed.Value, before, after);
+    }
+
+    private sealed class TestProvider : IUsageProvider
+    {
+        public ProviderId Id => ProviderId.Claude;
+        public string DisplayName => "Claude Code";
+        public string SessionLabel => "Session";
+        public string WeeklyLabel => "Weekly";
+        public BillingKind Billing => BillingKind.Subscription;
+        public Task<ProviderFetchResult> FetchUsageAsync(CancellationToken ct = default)
+            => throw new NotImplementedException();
     }
 }

--- a/tests/TaskbarQuota.Tests/CodexProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/CodexProviderTests.cs
@@ -132,6 +132,147 @@ public class CodexProviderTests
         }
     }
 
+    [Theory]
+    [InlineData("Free")]
+    [InlineData("Plus")]
+    [InlineData("Pro 20x")]
+    [InlineData("Pro 5x")]
+    public void WidgetRows_ForCodex_NormalPlansHideZeroCreditsByDefault(string plan)
+    {
+        WidgetSettingsService.ResetRowVisibilityForTesting();
+        try
+        {
+            var result = CodexWidgetResultWithCredits(plan, amount: 0);
+
+            var labels = WidgetSummary.BuildRowLabelsForTesting(result, result.Fetch!.Usage);
+
+            Assert.DoesNotContain("Credits", labels);
+        }
+        finally
+        {
+            WidgetSettingsService.ResetRowVisibilityForTesting();
+        }
+    }
+
+    [Fact]
+    public void WidgetRows_ForCodex_NormalPlanShowsPositiveCreditsByDefault()
+    {
+        WidgetSettingsService.ResetRowVisibilityForTesting();
+        try
+        {
+            var result = CodexWidgetResultWithCredits("Plus", amount: 250);
+
+            var labels = WidgetSummary.BuildRowLabelsForTesting(result, result.Fetch!.Usage);
+
+            Assert.Contains("Credits", labels);
+        }
+        finally
+        {
+            WidgetSettingsService.ResetRowVisibilityForTesting();
+        }
+    }
+
+    [Fact]
+    public void WidgetRows_ForCodex_NormalPlanShowsCreditsWhenEnabled()
+    {
+        WidgetSettingsService.ResetRowVisibilityForTesting();
+        try
+        {
+            WidgetSettingsService.SetRowVisibleForTesting(ProviderId.Codex, WidgetSettingsService.RowCredits, true);
+            var result = CodexWidgetResultWithCredits("Plus", amount: 0);
+
+            var labels = WidgetSummary.BuildRowLabelsForTesting(result, result.Fetch!.Usage);
+
+            Assert.Contains("Credits", labels);
+        }
+        finally
+        {
+            WidgetSettingsService.ResetRowVisibilityForTesting();
+        }
+    }
+
+    [Fact]
+    public void WidgetRows_ForCodex_NormalPlanHidesPositiveCreditsWhenDisabled()
+    {
+        WidgetSettingsService.ResetRowVisibilityForTesting();
+        try
+        {
+            WidgetSettingsService.SetRowVisibleForTesting(ProviderId.Codex, WidgetSettingsService.RowCredits, false);
+            var result = CodexWidgetResultWithCredits("Plus", amount: 250);
+
+            var labels = WidgetSummary.BuildRowLabelsForTesting(result, result.Fetch!.Usage);
+
+            Assert.DoesNotContain("Credits", labels);
+        }
+        finally
+        {
+            WidgetSettingsService.ResetRowVisibilityForTesting();
+        }
+    }
+
+    [Fact]
+    public void WidgetRows_ForCodex_CreditPlansShowCreditsByDefault()
+    {
+        WidgetSettingsService.ResetRowVisibilityForTesting();
+        try
+        {
+            var result = CodexWidgetResultWithCredits("Business", amount: 250);
+
+            var labels = WidgetSummary.BuildRowLabelsForTesting(result, result.Fetch!.Usage);
+
+            Assert.Contains("Credits", labels);
+        }
+        finally
+        {
+            WidgetSettingsService.ResetRowVisibilityForTesting();
+        }
+    }
+
+    [Fact]
+    public void WidgetRows_ForCodex_CreditPlansHideCreditsWhenDisabled()
+    {
+        WidgetSettingsService.ResetRowVisibilityForTesting();
+        try
+        {
+            WidgetSettingsService.SetRowVisibleForTesting(ProviderId.Codex, WidgetSettingsService.RowCredits, false);
+            var result = CodexWidgetResultWithCredits("Business");
+
+            var labels = WidgetSummary.BuildRowLabelsForTesting(result, result.Fetch!.Usage);
+
+            Assert.DoesNotContain("Credits", labels);
+        }
+        finally
+        {
+            WidgetSettingsService.ResetRowVisibilityForTesting();
+        }
+    }
+
+    [Fact]
+    public void WidgetRows_ForClaude_UsesModelSpecificLabelOverride()
+    {
+        WidgetSettingsService.ResetRowVisibilityForTesting();
+        try
+        {
+            var result = UsageResult.Success(ProviderId.Claude, new TestProvider(ProviderId.Claude), new ProviderFetchResult(
+                new UsageSnapshot(new RateWindow(10))
+                {
+                    Secondary = new RateWindow(20),
+                    ModelSpecific = new RateWindow(30, label: "Sonnet"),
+                },
+                "oauth"));
+
+            var labels = WidgetSummary.BuildRowLabelsForTesting(result, result.Fetch!.Usage);
+
+            Assert.Contains("Sonnet", labels);
+            Assert.DoesNotContain("Fable", labels);
+            Assert.DoesNotContain("Model", labels);
+        }
+        finally
+        {
+            WidgetSettingsService.ResetRowVisibilityForTesting();
+        }
+    }
+
     [Fact]
     public void WidgetRows_ForCodex_ShowsExtraRowsWhenEnabled()
     {
@@ -228,10 +369,23 @@ public class CodexProviderTests
             "oauth"));
     }
 
-    private sealed class TestProvider : IUsageProvider
+    private static UsageResult CodexWidgetResultWithCredits(string plan, double amount = 250)
     {
-        public ProviderId Id => ProviderId.Codex;
-        public string DisplayName => "Codex";
+        var cost = new CostSnapshot(amount, "credits", "Credits").WithLimit(1000);
+        return UsageResult.Success(ProviderId.Codex, new TestProvider(), new ProviderFetchResult(
+            new UsageSnapshot(new RateWindow(10))
+            {
+                Secondary = new RateWindow(20),
+                LoginMethod = plan,
+                Cost = cost,
+            },
+            "oauth"));
+    }
+
+    private sealed class TestProvider(ProviderId id = ProviderId.Codex) : IUsageProvider
+    {
+        public ProviderId Id => id;
+        public string DisplayName => id.ToString();
         public string SessionLabel => "Session";
         public string WeeklyLabel => "Weekly";
         public BillingKind Billing => BillingKind.Subscription;


### PR DESCRIPTION
## New Features

- feat(claude): track Fable model-scoped weekly limit from the limits array
- feat(codex): surface raw Codex credit balances in the widget for Business/Enterprise-style plans without fabricating a cap.
- feat(codex): show reset credits and make Codex credit rows configurable in widget settings.
- feat(widget): support spend-limit primary labels so Claude Enterprise can render spend as a first-class meter when capped.

## Bug Fixes

- fix(claude): remove the fake Session 0% bar when Claude only reports uncapped extra usage.
- fix(claude): keep legacy Sonnet/Opus model windows labeled as Sonnet/Opus instead of relabeling them as Fable.
- fix(widget): hide the native taskbar host when no enabled provider is available so it does not leave a transparent taskbar window.
- fix(widget): improve taskbar positioning around tray, widgets button, injected windows, and multi-monitor tray bounds.


