### PR TITLE
feat(tray): add compact quota flyout

### DIFF
--- a/src/TaskbarQuota.App/FlyoutLayout.cs
+++ b/src/TaskbarQuota.App/FlyoutLayout.cs
@@ -8,6 +8,11 @@ namespace TaskbarQuota
     internal static class FlyoutLayout
     {
         public const int IconButtonWidth = 48;
+        public const int CompactLogicalWidth = 420;
+        public const int CompactProviderLogicalHeight = 104;
+        public const int CompactChromeLogicalHeight = 88;
+        public const int CompactMinLogicalHeight = 260;
+        public const int CompactMaxLogicalHeight = 720;
 
         /// <summary>
         /// Fixed default flyout width. The flyout stays exactly this wide no matter how many
@@ -60,6 +65,12 @@ namespace TaskbarQuota
             contentHeight = Math.Clamp(contentHeight, MinLogicalContentHeight, MaxLogicalContentHeight);
             return contentHeight + ChromeLogicalHeight + HeightMeasureBuffer;
         }
+
+        public static int ComputeCompactLogicalHeight(int providerCount)
+            => Math.Clamp(
+                Math.Max(0, providerCount) * CompactProviderLogicalHeight + CompactChromeLogicalHeight,
+                CompactMinLogicalHeight,
+                CompactMaxLogicalHeight);
 
         /// <summary>
         /// Flyout stays at <see cref="BaseLogicalWidth"/> and only grows past it when the provider

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml
@@ -3,12 +3,101 @@
     x:Class="TaskbarQuota.FlyoutWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="using:TaskbarQuota.Controls">
+    xmlns:controls="using:TaskbarQuota.Controls"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:vm="using:TaskbarQuota.ViewModels">
 
     <Grid x:Name="Root" CornerRadius="8">
+        <Grid.Resources>
+        <DataTemplate x:Key="CompactBarTemplate" x:DataType="vm:BarViewModel">
+            <Grid ColumnSpacing="10" RowSpacing="3">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <TextBlock Text="{x:Bind Label}" Style="{StaticResource CaptionTextBlockStyle}"/>
+                <TextBlock Grid.Column="1" Text="{x:Bind PercentText}" Foreground="{x:Bind PercentForeground}" Style="{StaticResource CaptionTextBlockStyle}"/>
+                <ProgressBar Grid.Row="1" Grid.ColumnSpan="2" Height="3" Maximum="100" Value="{x:Bind Percent}" Foreground="{x:Bind BarBrush}"/>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="CompactMetricTemplate" x:DataType="vm:TextMetricViewModel">
+            <Grid ColumnSpacing="10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="{x:Bind Label}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}"/>
+                <TextBlock Grid.Column="1" Text="{x:Bind Value}" Style="{StaticResource CaptionTextBlockStyle}"/>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="CompactProviderTemplate" x:DataType="vm:ProviderCardViewModel">
+            <Border Margin="0,0,0,8"
+                    Padding="12,10"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{x:Bind CardBorderBrush}"
+                    BorderThickness="{x:Bind CardBorderThickness}"
+                    CornerRadius="8">
+                <Grid ColumnSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="32"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <controls:ProviderAvatar Width="28" Height="28"
+                                             ProviderId="{x:Bind ProviderId}"
+                                             Initial="{x:Bind Initial}"
+                                             ForegroundBrush="{x:Bind AvatarForeground}"/>
+                    <StackPanel Grid.Column="1" Spacing="7">
+                        <Grid ColumnSpacing="8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="{x:Bind DisplayName}" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                            <TextBlock Grid.Column="1" Text="{x:Bind Plan}" Visibility="{x:Bind PlanVisibility}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}"/>
+                        </Grid>
+
+                        <muxc:ItemsRepeater ItemsSource="{x:Bind Bars}"
+                                            Visibility="{x:Bind BarsVisibility}"
+                                            ItemTemplate="{StaticResource CompactBarTemplate}">
+                            <muxc:ItemsRepeater.Layout>
+                                <muxc:StackLayout Spacing="6"/>
+                            </muxc:ItemsRepeater.Layout>
+                        </muxc:ItemsRepeater>
+
+                        <Grid Visibility="{x:Bind CreditVisibility}" ColumnSpacing="10">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="Credits" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}"/>
+                            <TextBlock Grid.Column="1" Text="{x:Bind CreditLeftText}" Style="{StaticResource CaptionTextBlockStyle}"/>
+                        </Grid>
+
+                        <muxc:ItemsRepeater ItemsSource="{x:Bind TextMetrics}"
+                                            Visibility="{x:Bind TextMetricsVisibility}"
+                                            ItemTemplate="{StaticResource CompactMetricTemplate}">
+                            <muxc:ItemsRepeater.Layout>
+                                <muxc:StackLayout Spacing="3"/>
+                            </muxc:ItemsRepeater.Layout>
+                        </muxc:ItemsRepeater>
+
+                        <TextBlock Text="{x:Bind CostText}" Visibility="{x:Bind CostVisibility}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}"/>
+                        <TextBlock Text="{x:Bind SetupTitle}" Visibility="{x:Bind SetupRequiredVisibility}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}"/>
+                        <TextBlock Text="{x:Bind Error}" Visibility="{x:Bind ErrorVisibility}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}" TextTrimming="CharacterEllipsis"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </DataTemplate>
+        </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
+            <RowDefinition x:Name="UpdateRow" Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
@@ -19,6 +108,20 @@
                HorizontalContentAlignment="Stretch"
                VerticalAlignment="Stretch"
                VerticalContentAlignment="Stretch"/>
+
+        <ScrollViewer x:Name="CompactScrollViewer"
+                      Grid.Row="0"
+                      Visibility="Collapsed"
+                      Padding="12,12,12,4"
+                      VerticalScrollBarVisibility="Auto"
+                      HorizontalScrollMode="Disabled">
+            <muxc:ItemsRepeater x:Name="CompactProviderList"
+                                ItemTemplate="{StaticResource CompactProviderTemplate}">
+                <muxc:ItemsRepeater.Layout>
+                    <muxc:StackLayout/>
+                </muxc:ItemsRepeater.Layout>
+            </muxc:ItemsRepeater>
+        </ScrollViewer>
 
         <controls:UpdateActionBar x:Name="UpdateBar"
                                   Grid.Row="1"
@@ -31,7 +134,8 @@
                     Orientation="Horizontal"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Bottom">
-            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            <Border x:Name="ProviderStripBorder"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1"
                     CornerRadius="8"
@@ -39,6 +143,29 @@
                 <StackPanel x:Name="ProviderStrip"
                             MinHeight="48"
                             Orientation="Horizontal"/>
+            </Border>
+
+            <Border x:Name="CompactRefreshBorder"
+                    Visibility="Collapsed"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8">
+                <Button Width="48"
+                        Height="48"
+                        MinWidth="0"
+                        MinHeight="0"
+                        Padding="0"
+                        BorderThickness="0"
+                        Background="Transparent"
+                        AutomationProperties.Name="Refresh all providers"
+                        AutomationProperties.AutomationId="CompactRefreshButton"
+                        Click="CompactRefreshButton_Click"
+                        ToolTipService.ToolTip="Refresh all providers">
+                    <FontIcon Glyph="&#xE72C;"
+                              FontSize="16"
+                              Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                </Button>
             </Border>
 
             <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -39,6 +39,8 @@ namespace TaskbarQuota
         private readonly DashboardViewModel _dashboardViewModel;
         private readonly Dictionary<ProviderId, FlyoutProviderStripItem> _providerStripItems = new();
         private int _stripIconCount;
+        private bool _compactMode;
+        private POINT _trayAnchor;
         private static readonly TimeSpan BoundsCoalesceDelay = TimeSpan.FromMilliseconds(80);
 
         public bool IsShown => _shown;
@@ -48,6 +50,7 @@ namespace TaskbarQuota
             InitializeComponent();
             _dashboardViewModel = DashboardPage.SharedViewModel ?? new DashboardViewModel(DispatcherQueue);
             DashboardPage.SharedViewModel = _dashboardViewModel;
+            CompactProviderList.ItemsSource = _dashboardViewModel.Cards;
             _dashboardViewModel.Cards.CollectionChanged += DashboardCards_CollectionChanged;
             _dashboardViewModel.SelectedCardChanged += DashboardSelectedCardChanged;
             _dashboardViewModel.DetailContentWidthChanged += DashboardDetailContentWidthChanged;
@@ -88,6 +91,22 @@ namespace TaskbarQuota
             ShowAbove(widgetHandle);
         }
 
+        public void ToggleAtTrayIcon()
+        {
+            if (_shown) { Hide(); return; }
+            if (!User32.GetCursorPos(out _trayAnchor))
+                return;
+
+            EnsureDashboardLoaded();
+            _compactMode = true;
+            _widgetHandle = IntPtr.Zero;
+            ApplyMode();
+            _shown = true;
+            ApplyFlyoutBounds();
+            GetAppWindow().Show();
+            Activate();
+        }
+
         /// <summary>
         /// Compose the first XAML frame and spin up the acrylic backdrop off-screen once, so the first
         /// real open doesn't flash a black slab while WinUI warms up composition.
@@ -119,8 +138,10 @@ namespace TaskbarQuota
 
         public void ShowAbove(IntPtr widgetHandle)
         {
+            _compactMode = false;
             _widgetHandle = widgetHandle;
             EnsureDashboardLoaded();
+            ApplyMode();
 
             // Sync the strip selection to the provider the taskbar widget is currently showing,
             // so opening the tray highlights/details that provider rather than a stale selection.
@@ -175,7 +196,7 @@ namespace TaskbarQuota
 
         private void ApplyFlyoutBounds()
         {
-            if (!_shown || _widgetHandle == IntPtr.Zero || _applyingBounds)
+            if (!_shown || (!_compactMode && _widgetHandle == IntPtr.Zero) || _applyingBounds)
                 return;
 
             _applyingBounds = true;
@@ -183,11 +204,21 @@ namespace TaskbarQuota
             {
                 var scale = Root.XamlRoot?.RasterizationScale ?? GetWindowScale();
                 int w = WindowDpi.ToPhysical(
-                    FlyoutLayout.ComputeLogicalWidth(_stripIconCount, _dashboardViewModel.DetailContentWidth),
+                    _compactMode
+                        ? FlyoutLayout.CompactLogicalWidth
+                        : FlyoutLayout.ComputeLogicalWidth(_stripIconCount, _dashboardViewModel.DetailContentWidth),
                     scale);
                 int h = WindowDpi.ToPhysical(
-                    FlyoutLayout.ComputeLogicalHeight(_dashboardViewModel.DetailContentHeight),
+                    _compactMode
+                        ? FlyoutLayout.ComputeCompactLogicalHeight(_dashboardViewModel.Cards.Count)
+                        : FlyoutLayout.ComputeLogicalHeight(_dashboardViewModel.DetailContentHeight),
                     scale);
+
+                if (_compactMode)
+                {
+                    ApplyTrayFlyoutBounds(w, h, scale);
+                    return;
+                }
 
                 if (!User32.GetWindowRect(_widgetHandle, out RECT wr))
                     return;
@@ -230,6 +261,33 @@ namespace TaskbarQuota
             {
                 _applyingBounds = false;
             }
+        }
+
+        private void ApplyTrayFlyoutBounds(int width, int height, double scale)
+        {
+            var monitor = User32.MonitorFromPoint(_trayAnchor, MonitorFromFlags.MONITOR_DEFAULTTONEAREST);
+            var info = MONITORINFO.Create();
+            if (monitor == IntPtr.Zero || !User32.GetMonitorInfo(monitor, ref info))
+                return;
+
+            var work = info.rcWork;
+            int gap = WindowDpi.ToPhysical(8, scale);
+            width = Math.Min(width, work.right - work.left);
+            height = Math.Min(height, work.bottom - work.top);
+            int x = Math.Clamp(_trayAnchor.x - width, work.left, work.right - width);
+            int y = Math.Clamp(_trayAnchor.y - height - gap, work.top, work.bottom - height);
+            var bounds = new RectInt32(x, y, width, height);
+            _lastAppliedBounds = bounds;
+            GetAppWindow().MoveAndResize(bounds);
+        }
+
+        private void ApplyMode()
+        {
+            CompactScrollViewer.Visibility = _compactMode ? Visibility.Visible : Visibility.Collapsed;
+            ContentFrame.Visibility = _compactMode ? Visibility.Collapsed : Visibility.Visible;
+            UpdateRow.Height = _compactMode ? new GridLength(0) : GridLength.Auto;
+            ProviderStripBorder.Visibility = _compactMode ? Visibility.Collapsed : Visibility.Visible;
+            CompactRefreshBorder.Visibility = _compactMode ? Visibility.Visible : Visibility.Collapsed;
         }
 
         private double GetWindowScale()
@@ -375,6 +433,9 @@ namespace TaskbarQuota
             if (Application.Current is App app)
                 app.ShowSettings();
         }
+
+        private void CompactRefreshButton_Click(object sender, RoutedEventArgs e)
+            => _dashboardViewModel.RefreshCommand.Execute(null);
 
         private void SyncProviderStripSelection(bool animate = false)
         {

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -47,7 +47,7 @@ namespace TaskbarQuota.Taskbar
 
         private static void CreateTrayIcon()
         {
-            var open = new PopupMenuItem("Open TaskbarQuota", (_, _) => _dispatcher?.TryEnqueue(() => _showMainWindow?.Invoke()));
+            var open = new PopupMenuItem("Open TaskbarQuota dashboard", (_, _) => _dispatcher?.TryEnqueue(() => _showMainWindow?.Invoke()));
             var move = new PopupMenuItem("Move taskbar widget", (_, _) => _dispatcher?.TryEnqueue(() => _widget?.StartDragging()));
             var reset = new PopupMenuItem("Reset widget position", (_, _) => _dispatcher?.TryEnqueue(() => _widget?.UpdatePosition(resetManualPosition: true)));
             var quit = new PopupMenuItem("Quit", (_, _) => _dispatcher?.TryEnqueue(App.Quit));
@@ -76,8 +76,8 @@ namespace TaskbarQuota.Taskbar
             }
             _trayIcon.MessageWindow.MouseEventReceived += (_, e) =>
             {
-                if (e.MouseEvent is MouseEvent.IconLeftMouseUp or MouseEvent.IconLeftDoubleClick)
-                    _dispatcher?.TryEnqueue(() => _showMainWindow?.Invoke());
+                if (e.MouseEvent == MouseEvent.IconLeftMouseUp)
+                    _dispatcher?.TryEnqueue(ToggleTrayFlyout);
             };
         }
 
@@ -189,6 +189,20 @@ namespace TaskbarQuota.Taskbar
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to toggle flyout");
+                _flyout = null;
+            }
+        }
+
+        private static void ToggleTrayFlyout()
+        {
+            try
+            {
+                _flyout ??= new FlyoutWindow();
+                _flyout.ToggleAtTrayIcon();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to toggle tray flyout");
                 _flyout = null;
             }
         }

--- a/src/TaskbarQuota.App/ViewModels/DashboardViewModel.cs
+++ b/src/TaskbarQuota.App/ViewModels/DashboardViewModel.cs
@@ -358,15 +358,18 @@ namespace TaskbarQuota.ViewModels
                 if (merged.ContainsKey(provider.Id))
                     continue;
 
+                if (ProviderDiscoveryService.IsProbed(provider.Id) && service.TryGetCached(provider.Id, out var cached))
+                {
+                    merged[provider.Id] = cached;
+                    continue;
+                }
+
                 if (ProviderDiscoveryService.ShouldFetch(provider.Id, active))
                 {
                     merged[provider.Id] = UsageResult.Pending(provider.Id, provider,
                         active == provider.Id ? "Loading active provider..." : "Loading...");
                     continue;
                 }
-
-                if (ProviderDiscoveryService.IsProbed(provider.Id) && service.TryGetCached(provider.Id, out var cached))
-                    merged[provider.Id] = cached;
             }
 
             return OrderResults(merged.Values.ToArray(), active).ToList();

--- a/tests/TaskbarQuota.Tests/FlyoutLayoutTests.cs
+++ b/tests/TaskbarQuota.Tests/FlyoutLayoutTests.cs
@@ -59,4 +59,11 @@ public class FlyoutLayoutTests
             Environment.SetEnvironmentVariable(FlyoutLayout.ForceMinWidthEnvironmentVariable, previous);
         }
     }
+
+    [Theory]
+    [InlineData(0, FlyoutLayout.CompactMinLogicalHeight)]
+    [InlineData(3, 400)]
+    [InlineData(20, FlyoutLayout.CompactMaxLogicalHeight)]
+    public void ComputeCompactLogicalHeight_ClampsToCompactBounds(int providers, int expected)
+        => Assert.Equal(expected, FlyoutLayout.ComputeCompactLogicalHeight(providers));
 }


### PR DESCRIPTION
## Why

On Windows with a small taskbar and third-party tray tools (e.g. NetworkSpeedMonitor), the injected widget can struggle with placement. This compact tray popup provides a reliable alternative for quickly checking all provider usage.  
  
<img width="803" height="685" alt="KoJSbc" src="https://github.com/user-attachments/assets/0211db1b-5ecb-433f-a51b-580f38388998" />

## Summary

Add a compact all-provider dashboard that opens when left-clicking the system tray icon. Each enabled provider shows its icon, plan, usage bars/percentages, credits, and current state — all visible at once without opening the full window.

## Changes

- **Tray icon** — Left-click now opens a compact popup positioned near the cursor (context menu still opens the full dashboard)
- **Compact mode** — Reuses the existing `FlyoutWindow` with a scrollable `ItemsRepeater` binding to the shared `DashboardViewModel.Cards`. No second window, no duplicate state
- **Provider cards** — Each provider renders as a compact card: avatar, display name, plan, usage bars, credits, text metrics, cost, error/setup state
- **Cached first** — `BuildDashboardResults` prefers cached results over pending-loading placeholders, so providers never flicker away or get stuck on "Loading..."
- **Refresh button** — A compact-only refresh button (besides Settings) reruns the dashboard fetch for all providers
- **Monitor-aware positioning** — The popup opens clamped to the containing monitor's work area, anchored near the cursor
- **6 files changed** — `FlyoutLayout.cs`, `FlyoutWindow.xaml`, `FlyoutWindow.xaml.cs`, `TaskBarManager.cs`, `DashboardViewModel.cs`, `FlyoutLayoutTests.cs`

*<i>This PR was created with assistance from AI models: GPT-5.6 and Deepseek v4 Flash.</i>*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compact flyout accessible from the tray icon, positioned near the cursor.
  * Added compact provider cards showing usage, plans, progress, costs, and status details.
  * Added a “Refresh all providers” action in the compact flyout.
  * Updated tray icon behavior so left-click toggles the compact flyout.
* **Bug Fixes**
  * Cached provider results now appear before loading placeholders when available.
* **Tests**
  * Added coverage for compact flyout height limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->