### PR TITLE
fix(widget): show Z.ai Session row and honor the MCP toggle

### DIFF
--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -349,7 +349,7 @@ namespace TaskbarQuota.Controls
                 return rows;
             }
 
-            if (result.Id == ProviderId.Claude)
+            if (result.Id is ProviderId.Claude or ProviderId.Zai)
             {
                 var rows = BuildBaseRows(result, usage);
                 if (WidgetSettingsService.IsRowVisible(result.Id, WidgetSettingsService.RowExtra))

--- a/tests/TaskbarQuota.Tests/ZaiProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/ZaiProviderTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Text.Json;
+using TaskbarQuota;
+using TaskbarQuota.Controls;
 using TaskbarQuota.Usage;
 using TaskbarQuota.Usage.Providers;
 
@@ -218,6 +220,32 @@ public class ZaiProviderTests
         var ex = Assert.Throws<ProviderException>(() => ZaiProvider.BuildResult(doc.RootElement));
         Assert.Equal(ProviderErrorKind.Other, ex.Kind);
         Assert.Contains("no active coding plan", ex.Message);
+    }
+
+    [Fact]
+    public void WidgetRows_ForZai_ToggleSessionAndMcpRows()
+    {
+        WidgetSettingsService.ResetRowVisibilityForTesting();
+        try
+        {
+            var usage = new UsageSnapshot(new RateWindow(10));
+            usage.ExtraRateWindows.Add(new NamedRateWindow("zai-mcp", "MCP", new RateWindow(0, label: "MCP")));
+            var result = UsageResult.Success(ProviderId.Zai, new ZaiProvider(), new ProviderFetchResult(usage, "api"));
+
+            var defaultLabels = WidgetSummary.BuildRowLabelsForTesting(result, usage);
+            Assert.Equal(new[] { "Session", "MCP" }, defaultLabels);
+
+            WidgetSettingsService.SetRowVisibleForTesting(ProviderId.Zai, WidgetSettingsService.RowExtra, false);
+            Assert.Equal(new[] { "Session" }, WidgetSummary.BuildRowLabelsForTesting(result, usage));
+
+            WidgetSettingsService.SetRowVisibleForTesting(ProviderId.Zai, WidgetSettingsService.RowExtra, true);
+            WidgetSettingsService.SetRowVisibleForTesting(ProviderId.Zai, WidgetSettingsService.RowPrimary, false);
+            Assert.Equal(new[] { "MCP" }, WidgetSummary.BuildRowLabelsForTesting(result, usage));
+        }
+        finally
+        {
+            WidgetSettingsService.ResetRowVisibilityForTesting();
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

`BuildRows` routed any provider with extra rate windows through a branch that returns **only** the extras and never builds the base rows. Z.ai always emits an MCP extra (the `TIME_LIMIT` pool), so:

- its **Session** row was dropped entirely, and
- the **MCP** row showed regardless of the row-visibility toggles.

## Fix

Route Z.ai through the same base-rows-plus-extras branch as Claude/Codex, so the Session row shows and MCP obeys the `RowExtra` toggle.

## Tests

Adds a widget-row test (`WidgetRows_ForZai_ToggleSessionAndMcpRows`) covering:

- default → `Session, MCP`
- MCP hidden (`RowExtra` off) → `Session` only
- Session hidden (`RowPrimary` off) → `MCP` only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Zai usage widgets now display session and MCP rate windows correctly.
  * MCP and session rows can be shown or hidden through widget settings, matching the expected behavior for Zai usage data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->