### PR TITLE
fix(widget): hide Z.ai Session subtitle when the 5-hour window hasn't started

### DIFF
--- a/src/TaskbarQuota.App/Usage/Providers/ZaiProvider.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/ZaiProvider.cs
@@ -112,7 +112,7 @@ namespace TaskbarQuota.Usage.Providers
             int? windowMinutes = entry.WindowMinutes;
             string? resetDesc = entry.NextResetTime.HasValue
                 ? CodexProvider.FormatResetCountdown(entry.NextResetTime)
-                : entry.WindowDescription != null ? $"{entry.WindowDescription} window" : null;
+                : null;
             return new RateWindow(percent, windowMinutes: windowMinutes, resetAt: entry.NextResetTime, resetDescription: resetDesc, label: label);
         }
 


### PR DESCRIPTION
## Problem

When the Z.ai 5-hour prompt pool hasn't started yet (no `nextResetTime`),
the widget showed `Session (5hourswindow)` instead of just `Session`.

The reset subtitle was falling back to the window description, which
rendered as an unhelpful `(5 hours window)` placeholder. Every other
provider (e.g. Claude) shows a bare `Session` label in this state.

### Before

<img width="292" height="50" alt="ikJU9tAhIx" src="https://github.com/user-attachments/assets/0e5f5520-6a8b-4857-b24b-dee158d09f5f" />

## Fix

Drop the window-description fallback in `MakeRateWindow` — when there's no
`nextResetTime`, show no subtitle. The row now reads `Session`, matching
Claude and the other providers.