### PR TITLE
Release 1.0.19: multi-taskbar widgets, Z.ai session fixes, drag gap + boot snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ After detection, usage is fetched from **local credentials** or **provider APIs*
 
 ## Features
 
+### What's new in 1.0.19
+
+- **Widgets on every taskbar** — multi-monitor setups get a widget on each taskbar instead of only the primary one, each confined to its own monitor. (#23)
+- **Z.ai Session row fixes** — the Session row is shown again and honors the MCP toggle, and the Session subtitle is hidden while the 5-hour window has not started yet. (#24, #26)
+- **Steadier widget drag** — dragging no longer jumps between lanes mid-drag; the gap the widget was dropped into is tracked so background repositions keep it there. (#27)
+- **Usage restored on boot** — the last usage snapshot is rendered at startup instead of a failure state while the first fetch is still running, with a stale suffix on the tooltips. (#27)
+- **Widget lifetime fixes** — fixed a window-class wedge and a per-widget handle leak when widgets are recreated. (#27)
+
 ### What's new in 1.0.18
 
 - **Z.ai support** — TaskbarQuota now reads the Z.ai Coding Plan quota (5-hour prompt pool as **Session**, 7-day **Weekly**, plus a monthly **MCP** tool-call meter shown by default and hideable per row) from the ZCode config at `%USERPROFILE%\.zcode\v2\config.json`.

--- a/src/TaskbarQuota.App/Package.appxmanifest
+++ b/src/TaskbarQuota.App/Package.appxmanifest
@@ -8,7 +8,7 @@
   <Identity
     Name="ZiedKallel.TaskbarQuota"
     Publisher="CN=C23CD2AD-C8FB-4147-9E06-4C046EC0A3AD"
-    Version="1.0.18.0" />
+    Version="1.0.19.0" />
 
   <Properties>
     <DisplayName>TaskbarQuota</DisplayName>

--- a/src/TaskbarQuota.App/TaskbarQuota.App.csproj
+++ b/src/TaskbarQuota.App/TaskbarQuota.App.csproj
@@ -29,9 +29,9 @@
     <Product>TaskbarQuota</Product>
     <AssemblyName>TaskbarQuota</AssemblyName>
     <ApplicationIcon>Assets\TaskBarQuota.ico</ApplicationIcon>
-    <Version>1.0.18</Version>
-    <AssemblyVersion>1.0.18.0</AssemblyVersion>
-    <FileVersion>1.0.18.0</FileVersion>
+    <Version>1.0.19</Version>
+    <AssemblyVersion>1.0.19.0</AssemblyVersion>
+    <FileVersion>1.0.19.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
@
Version bump only — all the code shipped in this release is already on `main`.

## Included since 1.0.18

- #23 — widgets on every taskbar (multi-monitor)
- #24 — show the Z.ai Session row and honor the MCP toggle
- #26 — hide the Z.ai Session subtitle when the 5-hour window has not started
- #27 — widget drag gap tracking, boot snapshot restore, widget class wedge / handle leak fixes

## Changes here

- `TaskbarQuota.App.csproj` → 1.0.19 / 1.0.19.0
- `Package.appxmanifest` → 1.0.19.0
- README changelog section for 1.0.19
@