### PR TITLE
fix: enforce a single instance so the widget stops duplicating

### DIFF
--- a/src/TaskbarQuota.App/App.xaml.cs
+++ b/src/TaskbarQuota.App/App.xaml.cs
@@ -98,6 +98,29 @@ namespace TaskbarQuota
             }
         }
 
+        /// <summary>Handles an activation that a second process redirected to this instance
+        /// (Start menu, Microsoft Store "Open", another double-click). Surfaces the existing
+        /// window instead of letting a duplicate widget appear.</summary>
+        internal static void HandleRedirectedActivation(string? activationArguments)
+        {
+            if (!ShouldSurfaceWindowOnActivation(activationArguments))
+                return;
+
+            var dispatcher = Dispatcher;
+            if (dispatcher is null)
+            {
+                Log.Warning("Redirected activation arrived before the dispatcher was ready");
+                return;
+            }
+
+            dispatcher.TryEnqueue(() => ((App)Current).ShowMainWindow());
+        }
+
+        /// <summary>A redirected startup-widget launch must stay in the tray, matching the
+        /// behaviour of a cold start with the same argument.</summary>
+        internal static bool ShouldSurfaceWindowOnActivation(string? activationArguments)
+            => !IsWidgetStartup(activationArguments);
+
         private void ScheduleTaskbarInitialization()
         {
             _taskbarInitializationTimer?.Dispose();

--- a/src/TaskbarQuota.App/Program.cs
+++ b/src/TaskbarQuota.App/Program.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Microsoft.UI.Dispatching;
+using Microsoft.Windows.AppLifecycle;
+using TaskbarQuota.Diagnostics;
+
+namespace TaskbarQuota
+{
+    /// <summary>
+    /// Replaces the XAML-generated entry point so the app can enforce a single instance.
+    /// WinUI 3 desktop apps are not single-instance by default: every activation (Start menu,
+    /// Microsoft Store "Open", a second double-click) spawns a new process, and each process
+    /// injects its own taskbar widget and tray icon. The key instance registered here owns the
+    /// widget; later launches redirect their activation to it and exit.
+    /// </summary>
+    public static class Program
+    {
+        /// <summary>Identifies the single instance that owns the taskbar widget. Per-user by design:
+        /// AppInstance keys are scoped to the session, so different users get their own widget.</summary>
+        private const string SingleInstanceKey = "TaskbarQuota.MainInstance";
+
+        [STAThread]
+        private static int Main(string[] args)
+        {
+            WinRT.ComWrappersSupport.InitializeComWrappers();
+
+            if (RedirectToExistingInstance())
+                return 0;
+
+            Microsoft.UI.Xaml.Application.Start(initializationParameters =>
+            {
+                var context = new DispatcherQueueSynchronizationContext(DispatcherQueue.GetForCurrentThread());
+                System.Threading.SynchronizationContext.SetSynchronizationContext(context);
+                _ = new App();
+            });
+
+            return 0;
+        }
+
+        /// <summary>Returns true when this process handed its activation to the already running
+        /// instance and should exit without creating an <see cref="App"/>.</summary>
+        private static bool RedirectToExistingInstance()
+        {
+            try
+            {
+                var activationArguments = AppInstance.GetCurrent().GetActivatedEventArgs();
+                var keyInstance = AppInstance.FindOrRegisterForKey(SingleInstanceKey);
+
+                if (keyInstance.IsCurrent)
+                {
+                    keyInstance.Activated += OnKeyInstanceActivated;
+                    return false;
+                }
+
+                RedirectActivationTo(activationArguments, keyInstance);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                // Never block startup on the single-instance machinery; a duplicate widget is
+                // better than an app that refuses to launch.
+                Log.Warning(ex, "Single-instance registration failed; continuing as a new instance");
+                return false;
+            }
+        }
+
+        private static void OnKeyInstanceActivated(object? sender, AppActivationArguments args)
+        {
+            try
+            {
+                App.HandleRedirectedActivation(GetLaunchArguments(args));
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Failed to handle redirected activation");
+            }
+        }
+
+        internal static string? GetLaunchArguments(AppActivationArguments args)
+            => args.Data is Windows.ApplicationModel.Activation.ILaunchActivatedEventArgs launch
+                ? launch.Arguments
+                : null;
+
+        private static void RedirectActivationTo(AppActivationArguments args, AppInstance keyInstance)
+        {
+            // The redirect must complete while this thread pumps COM messages, otherwise the
+            // cross-process call deadlocks. CoWaitForMultipleObjects keeps the STA pumping.
+            var redirectCompleted = CreateEvent(IntPtr.Zero, true, false, null);
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await keyInstance.RedirectActivationToAsync(args);
+                }
+                finally
+                {
+                    SetEvent(redirectCompleted);
+                }
+            });
+
+            _ = CoWaitForMultipleObjects(CWMO_DEFAULT, INFINITE, 1, [redirectCompleted], out _);
+            CloseHandle(redirectCompleted);
+        }
+
+        private const uint CWMO_DEFAULT = 0;
+        private const uint INFINITE = 0xFFFFFFFF;
+
+        [DllImport("ole32.dll")]
+        private static extern uint CoWaitForMultipleObjects(
+            uint flags, uint timeoutMilliseconds, ulong handleCount, IntPtr[] handles, out uint handleIndex);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr CreateEvent(IntPtr eventAttributes, bool manualReset, bool initialState, string? name);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool SetEvent(IntPtr handle);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool CloseHandle(IntPtr handle);
+    }
+}

--- a/src/TaskbarQuota.App/Program.cs
+++ b/src/TaskbarQuota.App/Program.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.UI.Dispatching;
 using Microsoft.Windows.AppLifecycle;
@@ -95,12 +97,14 @@ namespace TaskbarQuota
                 return false;
             }
 
+            // Read after the wait, which the SetEvent below happens-before. Reading the task's own
+            // state would race: the event is signalled before the task is marked completed. Boxed and
+            // accessed through Volatile so the write is published even without that ordering.
+            var redirectFailure = new StrongBox<Exception?>(null);
+            bool signalled = false;
+
             try
             {
-                // Read after the wait, which the SetEvent below happens-before. Reading the task's
-                // own state would race: the event is signalled before the task is marked completed.
-                Exception? redirectFailure = null;
-
                 _ = Task.Run(async () =>
                 {
                     try
@@ -109,7 +113,7 @@ namespace TaskbarQuota
                     }
                     catch (Exception ex)
                     {
-                        redirectFailure = ex;
+                        Volatile.Write(ref redirectFailure.Value, ex);
                     }
                     finally
                     {
@@ -123,15 +127,16 @@ namespace TaskbarQuota
                 var waitResult = CoWaitForMultipleObjects(
                     CWMO_DEFAULT, RedirectTimeoutMilliseconds, 1, [redirectCompleted], out _);
 
-                if (waitResult != WAIT_OBJECT_0)
+                signalled = waitResult == WAIT_OBJECT_0;
+                if (!signalled)
                 {
                     Log.Warning($"Activation redirect did not complete within {RedirectTimeoutMilliseconds}ms (result 0x{waitResult:X8})");
                     return false;
                 }
 
-                if (redirectFailure is not null)
+                if (Volatile.Read(ref redirectFailure.Value) is { } failure)
                 {
-                    Log.Warning(redirectFailure, "Activation redirect to the running instance failed");
+                    Log.Warning(failure, "Activation redirect to the running instance failed");
                     return false;
                 }
 
@@ -139,7 +144,12 @@ namespace TaskbarQuota
             }
             finally
             {
-                CloseHandle(redirectCompleted);
+                // Only close once the redirect task has signalled. On the timeout path that task is
+                // still running and about to call SetEvent, which would then signal a closed handle —
+                // or, once the value is recycled, an unrelated object. Leaking one event handle in a
+                // process that is seconds from either exiting or starting the app is the cheaper bug.
+                if (signalled)
+                    CloseHandle(redirectCompleted);
             }
         }
 

--- a/src/TaskbarQuota.App/Program.cs
+++ b/src/TaskbarQuota.App/Program.cs
@@ -53,8 +53,9 @@ namespace TaskbarQuota
                     return false;
                 }
 
-                RedirectActivationTo(activationArguments, keyInstance);
-                return true;
+                // A failed redirect means the activation went nowhere. Launching normally costs a
+                // duplicate widget, but exiting here would make the click do nothing at all.
+                return TryRedirectActivationTo(activationArguments, keyInstance);
             }
             catch (Exception ex)
             {
@@ -82,29 +83,69 @@ namespace TaskbarQuota
                 ? launch.Arguments
                 : null;
 
-        private static void RedirectActivationTo(AppActivationArguments args, AppInstance keyInstance)
+        /// <summary>Hands this process's activation to <paramref name="keyInstance"/>.
+        /// Returns false when the activation was not delivered, so the caller can fall back to
+        /// launching normally rather than exiting and losing it.</summary>
+        private static bool TryRedirectActivationTo(AppActivationArguments args, AppInstance keyInstance)
         {
-            // The redirect must complete while this thread pumps COM messages, otherwise the
-            // cross-process call deadlocks. CoWaitForMultipleObjects keeps the STA pumping.
             var redirectCompleted = CreateEvent(IntPtr.Zero, true, false, null);
-            _ = Task.Run(async () =>
+            if (redirectCompleted == IntPtr.Zero)
             {
-                try
-                {
-                    await keyInstance.RedirectActivationToAsync(args);
-                }
-                finally
-                {
-                    SetEvent(redirectCompleted);
-                }
-            });
+                Log.Warning($"CreateEvent failed while redirecting activation (win32 error {Marshal.GetLastWin32Error()})");
+                return false;
+            }
 
-            _ = CoWaitForMultipleObjects(CWMO_DEFAULT, INFINITE, 1, [redirectCompleted], out _);
-            CloseHandle(redirectCompleted);
+            try
+            {
+                // Read after the wait, which the SetEvent below happens-before. Reading the task's
+                // own state would race: the event is signalled before the task is marked completed.
+                Exception? redirectFailure = null;
+
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await keyInstance.RedirectActivationToAsync(args);
+                    }
+                    catch (Exception ex)
+                    {
+                        redirectFailure = ex;
+                    }
+                    finally
+                    {
+                        SetEvent(redirectCompleted);
+                    }
+                });
+
+                // The redirect must complete while this thread pumps COM messages, otherwise the
+                // cross-process call deadlocks. CoWaitForMultipleObjects keeps the STA pumping.
+                // Bounded, so a wedged key instance can't hang this process indefinitely.
+                var waitResult = CoWaitForMultipleObjects(
+                    CWMO_DEFAULT, RedirectTimeoutMilliseconds, 1, [redirectCompleted], out _);
+
+                if (waitResult != WAIT_OBJECT_0)
+                {
+                    Log.Warning($"Activation redirect did not complete within {RedirectTimeoutMilliseconds}ms (result 0x{waitResult:X8})");
+                    return false;
+                }
+
+                if (redirectFailure is not null)
+                {
+                    Log.Warning(redirectFailure, "Activation redirect to the running instance failed");
+                    return false;
+                }
+
+                return true;
+            }
+            finally
+            {
+                CloseHandle(redirectCompleted);
+            }
         }
 
         private const uint CWMO_DEFAULT = 0;
-        private const uint INFINITE = 0xFFFFFFFF;
+        private const uint WAIT_OBJECT_0 = 0;
+        private const uint RedirectTimeoutMilliseconds = 10_000;
 
         [DllImport("ole32.dll")]
         private static extern uint CoWaitForMultipleObjects(

--- a/src/TaskbarQuota.App/TaskbarQuota.App.csproj
+++ b/src/TaskbarQuota.App/TaskbarQuota.App.csproj
@@ -12,6 +12,8 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Custom Program.Main enforces a single instance; see Program.cs -->
+    <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
 
     <!-- Unpackaged, self-contained so it runs without prerequisites and can inject into the taskbar -->
     <WindowsPackageType>None</WindowsPackageType>

--- a/tests/TaskbarQuota.Tests/AppStartupTests.cs
+++ b/tests/TaskbarQuota.Tests/AppStartupTests.cs
@@ -23,6 +23,19 @@ public class AppStartupTests
     }
 
     [Fact]
+    public void ShouldSurfaceWindowOnActivation_ForStoreOpen_ReturnsTrue()
+    {
+        Assert.True(App.ShouldSurfaceWindowOnActivation(null));
+        Assert.True(App.ShouldSurfaceWindowOnActivation(string.Empty));
+    }
+
+    [Fact]
+    public void ShouldSurfaceWindowOnActivation_ForStartupWidgetLaunch_ReturnsFalse()
+    {
+        Assert.False(App.ShouldSurfaceWindowOnActivation("--startup-widget"));
+    }
+
+    [Fact]
     public void ShouldRetryTaskbarInitialization_AllowsStartupWidgetRetries()
     {
         Assert.True(App.ShouldRetryTaskbarInitialization(1));


### PR DESCRIPTION
Fixes #29 — the taskbar widget duplicates when launching the app while it is already running (reported via Microsoft Store "Open").

## Cause

WinUI 3 desktop apps are **not** single-instance by default. There was no mutex or `AppInstance` registration anywhere in the codebase, and no custom `Main` — the app used the XAML-generated entry point, which calls `Application.Start` unconditionally.

So every activation spawned a fresh process. Each process ran `OnLaunched` → `TaskBarManager.Initialize` → `CreateTrayIcon()` + `EnsureWidgets()`, injecting a second widget and tray icon. The `_initialized` guard in `TaskBarManager` is a static, so it only ever protected against duplicates *within* a process. The widget health timer then kept re-asserting both, so the duplicate persisted.

This was especially easy to hit because the app normally sits in the tray with its main window closed, so the shell has no visible top-level window to reactivate.

## Fix

- **`Program.cs`** (new): custom entry point behind `DISABLE_XAML_GENERATED_MAIN`. Registers a key instance with `AppInstance.FindOrRegisterForKey`. A non-key instance calls `RedirectActivationToAsync` and returns before `Application.Start`, so no second `App` — and therefore no second widget or tray icon — is ever created.
  - The redirect waits on `CoWaitForMultipleObjects` rather than a plain blocking wait, so the STA keeps pumping COM messages while the cross-process call completes. A `SemaphoreSlim.Wait()` here can deadlock.
  - Any failure in the registration path is logged and falls through to a normal launch. A duplicate widget is better than an app that refuses to start.
- **`App.HandleRedirectedActivation`**: the running instance surfaces its main window when it receives a redirected activation, so Store "Open" does something visible instead of nothing. `ShouldSurfaceWindowOnActivation` reuses the existing `IsWidgetStartup` check, so a redirected `--startup-widget` launch stays in the tray — same as a cold start with that argument.

Works for both the packaged (Store) and unpackaged builds; `AppInstance` is the same API for both.

## Testing

- Build clean (x64 Debug).
- `AppStartupTests` 7/7 pass, including two new cases covering the activation gate.
- Manual: launched the built exe twice, six seconds apart. One process survived; the log shows a single `TaskbarQuota launching` line and no redirect warnings. Before this change, both processes started and two widgets appeared.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enforced single-instance behavior so launching the app again reuses the existing window.
  * Redirected launches now bring the main window to the foreground when appropriate.
  * Widget startup launches continue without unnecessarily opening the main window.

* **Bug Fixes**
  * Improved activation handling to prevent launch failures and keep the app responsive during redirected launches.

* **Tests**
  * Added coverage for standard, empty, and widget-specific startup arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->