### PR TITLE
fix: stop the reposition deadband from overflowing before first placement

### DIFF
--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -446,10 +446,8 @@ namespace TaskbarQuota.Taskbar
                     targetAppWindow.MoveAndResize(new RectInt32(offsetX, offsetY, WidgetHostWidth, barRect.bottom - barRect.top));
                     currentOffsetX = offsetX; currentOffsetY = offsetY;
                 }
-                else if (Math.Abs(currentOffsetX - offsetX) >= RepositionDeadbandPx)
+                else if (ShouldReposition(currentOffsetX, offsetX, RepositionDeadbandPx))
                 {
-                    // Deadband: ignore sub-threshold recompute deltas (rounding / transient tray width changes)
-                    // so the widget doesn't visibly twitch on routine taskbar events.
                     targetAppWindow.Move(new PointInt32(offsetX, offsetY));
                     currentOffsetX = offsetX;
                 }
@@ -468,6 +466,16 @@ namespace TaskbarQuota.Taskbar
                     positionUpdateGate.Release();
             }
         }
+
+        /// <summary>Deadband: ignore sub-threshold recompute deltas (rounding / transient tray width
+        /// changes) so the widget doesn't visibly twitch on routine taskbar events.</summary>
+        /// <remarks><paramref name="currentOffsetX"/> is <see cref="int.MinValue"/> until the widget
+        /// has been placed once, which must always reposition. Subtracting from that sentinel
+        /// overflows: when <paramref name="offsetX"/> is 0 the difference is exactly
+        /// <see cref="int.MinValue"/>, and <c>Math.Abs</c> of that throws. Widen to long.</remarks>
+        internal static bool ShouldReposition(int currentOffsetX, int offsetX, int deadbandPx)
+            => currentOffsetX == int.MinValue
+            || Math.Abs((long)currentOffsetX - offsetX) >= deadbandPx;
 
         public void StartDragging()
         {

--- a/tests/TaskbarQuota.Tests/TaskBarWidgetGapTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskBarWidgetGapTests.cs
@@ -9,6 +9,30 @@ public class TaskBarWidgetGapTests
     private static RECT R(int left, int right) => new() { left = left, top = 0, right = right, bottom = 40 };
 
     [Fact]
+    public void ShouldReposition_BeforeFirstPlacement_IsTrueWithoutOverflowing()
+    {
+        // offsetX == 0 used to make `Math.Abs(int.MinValue - 0)` throw OverflowException,
+        // which the caller swallowed and left the widget unplaced forever.
+        Assert.True(TaskBarWidget.ShouldReposition(int.MinValue, 0, 2));
+        Assert.True(TaskBarWidget.ShouldReposition(int.MinValue, 1200, 2));
+        Assert.True(TaskBarWidget.ShouldReposition(int.MinValue, -1200, 2));
+    }
+
+    [Fact]
+    public void ShouldReposition_WithinDeadband_IsFalse()
+    {
+        Assert.False(TaskBarWidget.ShouldReposition(1200, 1200, 2));
+        Assert.False(TaskBarWidget.ShouldReposition(1200, 1201, 2));
+    }
+
+    [Fact]
+    public void ShouldReposition_AtOrBeyondDeadband_IsTrue()
+    {
+        Assert.True(TaskBarWidget.ShouldReposition(1200, 1202, 2));
+        Assert.True(TaskBarWidget.ShouldReposition(1200, 1198, 2));
+    }
+
+    [Fact]
     public void ComputeFreeGaps_NoObstacles_ReturnsWholeSpan()
     {
         var gaps = TaskBarWidget.ComputeFreeGaps(0, 1000, new List<RECT>());


### PR DESCRIPTION
Fixes an `OverflowException` that leaves the taskbar widget stuck at the position its `AppWindow` was created at, never moving to its computed slot. Spotted in the app log while testing something unrelated:

```
[WARN] Taskbar widget position update failed for taskbar=0x1014C :: System.OverflowException: Negating the minimum value of a twos complement number is invalid.
   at TaskbarQuota.Taskbar.TaskBarWidget.UpdatePositionImpl(...) in TaskBarWidget.cs:line 449
```

## Cause

Three things line up in `UpdatePositionImpl`:

1. `currentOffsetX` starts at the sentinel `int.MinValue`; `currentOffsetY` starts at `0`.
2. `offsetY = barRect.top`, and `barRect` is taskbar-**client**-relative (`ToTaskbarClientRect`), so `barRect.top` is normally `0`. The `currentOffsetY != offsetY` branch is therefore false even on the very first update.
3. Control falls into the deadband branch, `Math.Abs(currentOffsetX - offsetX)`, while `currentOffsetX` is still the sentinel.

`int.MinValue - offsetX` in an unchecked context:

- `offsetX > 0` — wraps to a large positive value. A garbage delta, but it clears the deadband and the widget moves, so the bug stays invisible.
- `offsetX == 0` — the difference is exactly `int.MinValue`, and `Math.Abs` of that throws, since no positive `int` can represent it.

`offsetX == 0` means the widget landed at the left edge of the taskbar client area — a fitting gap at 0, or `ClampToTaskbarMonitor` pinning it there.

The exception is caught and logged as a warning, so the move never happens **and** `currentOffsetX` keeps its sentinel. Every subsequent update repeats the throw for as long as `offsetX` computes to 0, so the widget never recovers on its own.

## Fix

Extract the decision into `ShouldReposition(currentOffsetX, offsetX, deadbandPx)`, which:

- tests the sentinel explicitly (`currentOffsetX == int.MinValue`) rather than subtracting from it, so the first placement always repositions instead of relying on wraparound to clear the deadband;
- widens the subtraction to `long`, so no pair of inputs can overflow.

Behaviour for already-placed widgets is unchanged.

## Testing

- Build clean (x64 Debug).
- Three new cases in `TaskBarWidgetGapTests` cover the sentinel (including the `offsetX == 0` case that used to throw), deltas inside the deadband, and deltas at or beyond it. `TaskBarWidgetGapTests` 28/28 pass.
- Note: the full suite has a pre-existing order-dependent flake unrelated to this change — a different provider test fails on each full run on clean `main` (`ZaiProviderTests` and `CodexProviderTests` observed), and both pass in isolation. Looks like shared widget-settings state across parallel tests.