### PR TITLE
feat: pin providers to the taskbar widget

### DIFF
--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml
@@ -7,7 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid x:Name="Root" Background="Transparent" Padding="6,3" Opacity="0">
+    <Grid x:Name="Root" Background="Transparent" Padding="4,3" Opacity="0">
         <Grid.RenderTransform>
             <TranslateTransform x:Name="RootTranslate" Y="4"/>
         </Grid.RenderTransform>

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -95,14 +95,13 @@ namespace TaskbarQuota.Controls
             };
 
         /// <summary>
-        /// How much of this tile renders on the taskbar. Pinned tiles that aren't the active tool are
-        /// capped to their leading rows so a row toggle can never grow them enough to evict a neighbour,
-        /// and a tile with nowhere left to shrink falls back to its provider glyph rather than vanishing —
-        /// a pin is a promise that the provider stays on the bar (issue #25). The tooltip always carries
-        /// the full set of rows, whatever is rendered.
+        /// How much of this tile renders on the taskbar. In normal use every pinned provider renders in
+        /// full — the reduced forms exist for callers that need a smaller tile, but the taskbar host does
+        /// not select them: keeping the row inside the bar is the pin budget's job, and trimming a pinned
+        /// provider the user configured is worse than refusing the pin (issue #25).
         /// </summary>
-        /// <param name="level">
-        /// <see cref="LevelGlyph"/> for the bare provider glyph, <see cref="LevelCompact"/> for the glyph
+        /// <param name="form">
+        /// <see cref="SummaryForm.Glyph"/> for the bare provider glyph, <see cref="SummaryForm.Compact"/> for the glyph
         /// plus its headline figure, or a positive row ceiling.
         /// </param>
         public void SetSummaryMode(SummaryForm form)
@@ -136,7 +135,9 @@ namespace TaskbarQuota.Controls
         /// </summary>
         private void SetSummaryTooltip(string text)
         {
-            if (_isIconOnly || _isCompact)
+            if (_isIconOnly)
+                text += "\nIcon only — not enough room on the taskbar.";
+            else if (_isCompact)
                 text += "\nCompact — not enough room on the taskbar.";
             else if (_rows.Count > _maxVisibleRows)
                 text += $"\n+{_rows.Count - _maxVisibleRows} more row(s) — shown when this tool is active.";
@@ -171,6 +172,9 @@ namespace TaskbarQuota.Controls
         private static int IconWidthFor(WidgetDisplayMode mode)
             => mode == WidgetDisplayMode.PercentagesOnly ? IconHostSizePercentagesOnly : IconHostSizeBars;
 
+        /// <summary>Rows this tile currently has to show, before any host-imposed ceiling.</summary>
+        public int RowCount => Math.Max(1, _rows.Count);
+
         /// <summary>
         /// The width this tile WOULD take at a given row ceiling, without rendering it.
         ///
@@ -179,9 +183,6 @@ namespace TaskbarQuota.Controls
         /// refresh animation, and the host re-runs this on every usage publish. The column widths are a
         /// pure function of the rows and the display mode, so they are computed directly instead.
         /// </summary>
-        /// <summary>Rows this tile currently has to show, before any host-imposed ceiling.</summary>
-        public int RowCount => Math.Max(1, _rows.Count);
-
         public int MeasureDesiredWidth(SummaryForm form)
         {
             var mode = _forcePercentagesOnly ? WidgetDisplayMode.PercentagesOnly : WidgetSettingsService.Current;

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -25,7 +25,6 @@ namespace TaskbarQuota.Controls
         private const int MinLabelColumnWidth = 0;
         private const int MinResetColumnWidth = 0;
         private const int ValueColumnWidth = 34;
-        private const string MaxCreditValueSample = "10,000/10,000";
         private const int WidgetFontSize = 11;
         private const int BarHeight = 6;
         private const int SingleRowBarHeight = 8;
@@ -40,6 +39,11 @@ namespace TaskbarQuota.Controls
         private const double GlyphViewportSize = 100;
         private const double NormalizedGlyphExtent = 88;
         private const double StaleOpacity = 0.55;
+        // Root.Padding left+right, plus the 2px slack CalculateDesiredWidth reserves. Must track the
+        // Padding set on Root in the XAML — the width math is analytic, so a mismatch clips a column.
+        private const int RootHorizontalPadding = 10;
+        private const int PanelColumnSpacing = 5;
+        private const int SlideMilliseconds = 300;
 
         public event Action? Clicked;
         public event Action<DisplayMode>? DisplayModeChanged;
@@ -47,9 +51,26 @@ namespace TaskbarQuota.Controls
 
         public bool SuppressNextClick { get; set; }
 
+        /// <summary>
+        /// Skips the cross-fade on the next render. Set when a tile is taking over another provider as part
+        /// of a re-order: the movement is being conveyed by <see cref="AnimateSlide"/>, and fading the
+        /// content at the same time turns a clean shift into a flicker.
+        /// </summary>
+        public bool SuppressNextTransition { get; set; }
+
+        /// <summary>
+        /// The width (logical px) this tile last asked its host for. The taskbar host sums this across the
+        /// tiles it shows to size the multi-provider widget and to decide how many tiles actually fit.
+        /// </summary>
+        public int DesiredLogicalWidth { get; private set; }
+
         private readonly List<RenderedRow> _renderedRows = new();
         private List<WidgetUsageRow> _rows = new();
         private bool _forcePercentagesOnly;
+        private int _maxVisibleRows = int.MaxValue;
+        private bool _isIconOnly;
+        private bool _isCompact;
+        private bool _hideReset;
         private UsageResult? _lastResult;
         private ProviderId? _lastAppliedProvider;
         private string? _lastRenderSignature;
@@ -57,6 +78,7 @@ namespace TaskbarQuota.Controls
         private bool _isActiveToolVisible = true;
         private Storyboard? _visibilityStoryboard;
         private Storyboard? _softRefreshStoryboard;
+        private Storyboard? _slideStoryboard;
 
         /// <summary>
         /// Returns the display name for the constrained taskbar widget.
@@ -71,6 +93,125 @@ namespace TaskbarQuota.Controls
                 "GitHub Copilot" => "Copilot",
                 _ => fullName,
             };
+
+        /// <summary>
+        /// How much of this tile renders on the taskbar. Pinned tiles that aren't the active tool are
+        /// capped to their leading rows so a row toggle can never grow them enough to evict a neighbour,
+        /// and a tile with nowhere left to shrink falls back to its provider glyph rather than vanishing —
+        /// a pin is a promise that the provider stays on the bar (issue #25). The tooltip always carries
+        /// the full set of rows, whatever is rendered.
+        /// </summary>
+        /// <param name="level">
+        /// <see cref="LevelGlyph"/> for the bare provider glyph, <see cref="LevelCompact"/> for the glyph
+        /// plus its headline figure, or a positive row ceiling.
+        /// </param>
+        public void SetSummaryMode(SummaryForm form)
+        {
+            bool iconOnly = form.IsGlyph;
+            bool compact = form.IsCompact;
+            int maxVisibleRows = Math.Max(1, form.Rows);
+            if (_isIconOnly == iconOnly
+                && _isCompact == compact
+                && _maxVisibleRows == maxVisibleRows
+                && _hideReset == form.HideReset)
+            {
+                return;
+            }
+
+            _isIconOnly = iconOnly;
+            _isCompact = compact;
+            _maxVisibleRows = maxVisibleRows;
+            _hideReset = form.HideReset;
+            // Re-run Apply rather than just RenderRows so the tooltip is rebuilt too — in icon-only mode it
+            // is the only place the numbers survive.
+            if (_lastResult is { } result)
+                Apply(result, force: true);
+            else
+                RenderRows();
+        }
+
+        /// <summary>
+        /// Sets the tile's tooltip, noting when the taskbar is showing less than the full picture. A
+        /// degraded tile must say why, or a pinned provider that quietly shrank looks broken.
+        /// </summary>
+        private void SetSummaryTooltip(string text)
+        {
+            if (_isIconOnly || _isCompact)
+                text += "\nCompact — not enough room on the taskbar.";
+            else if (_rows.Count > _maxVisibleRows)
+                text += $"\n+{_rows.Count - _maxVisibleRows} more row(s) — shown when this tool is active.";
+
+            ToolTipService.SetToolTip(this, text);
+        }
+
+        /// <summary>
+        /// How much of a tile renders. The ladder, richest first: every row with its reset countdown, the
+        /// same rows without the countdown, fewer rows, a single meter with no label, then a bare glyph.
+        /// Dropping the countdown is the cheapest useful step — it is a whole column (~44px) and the same
+        /// information is already in the tooltip.
+        /// </summary>
+        public readonly record struct SummaryForm(int Rows, bool HideReset)
+        {
+            /// <summary>Provider glyph only; every figure lives in the tooltip.</summary>
+            public static SummaryForm Glyph => new(-1, false);
+            /// <summary>Glyph plus a single unlabelled meter — bar and value.</summary>
+            public static SummaryForm Compact => new(0, false);
+
+            public bool IsGlyph => Rows < 0;
+            public bool IsCompact => Rows == 0;
+
+            public override string ToString()
+                => IsGlyph ? "glyph" : IsCompact ? "compact" : HideReset ? $"{Rows}r-" : $"{Rows}r";
+        }
+
+        /// <summary>Width (logical px) a tile occupies once collapsed to its glyph.</summary>
+        public static int IconOnlyWidth(WidgetDisplayMode mode)
+            => IconWidthFor(mode) + RootHorizontalPadding;
+
+        private static int IconWidthFor(WidgetDisplayMode mode)
+            => mode == WidgetDisplayMode.PercentagesOnly ? IconHostSizePercentagesOnly : IconHostSizeBars;
+
+        /// <summary>
+        /// The width this tile WOULD take at a given row ceiling, without rendering it.
+        ///
+        /// The host has to compare layouts (all rows vs capped rows) before choosing one, and rendering
+        /// each candidate to read its width made the tile visibly flash: every re-render restarts the
+        /// refresh animation, and the host re-runs this on every usage publish. The column widths are a
+        /// pure function of the rows and the display mode, so they are computed directly instead.
+        /// </summary>
+        /// <summary>Rows this tile currently has to show, before any host-imposed ceiling.</summary>
+        public int RowCount => Math.Max(1, _rows.Count);
+
+        public int MeasureDesiredWidth(SummaryForm form)
+        {
+            var mode = _forcePercentagesOnly ? WidgetDisplayMode.PercentagesOnly : WidgetSettingsService.Current;
+            if (form.IsGlyph)
+                return IconOnlyWidth(mode);
+            if (form.IsCompact)
+                return CompactWidth(mode);
+
+            return CalculateDesiredWidth(RowsFor(form.Rows, form.HideReset), mode);
+        }
+
+        /// <summary>
+        /// The meter a compact tile shows: the tile's first row, which is the provider's headline window
+        /// (session, 5h, or credit balance).
+        /// </summary>
+        private WidgetUsageRow Headline()
+            => _rows.Count > 0 ? _rows[0] : new WidgetUsageRow("Usage", 0, "--", HasBar: false);
+
+        /// <summary>
+        /// Compact form: glyph, bar and value. The bar matters — a naked "0%" or "0/200" beside a logo does
+        /// not say what is being measured or how full it is, whereas a filled bar reads as a meter at a
+        /// glance and the tooltip names the window.
+        /// </summary>
+        private int CompactWidth(WidgetDisplayMode mode)
+        {
+            var row = Headline();
+            double value = Math.Max(ValueColumnWidth, MeasureTextWidth(row.Value, WidgetFontSize + 1) + 4);
+            double bar = row.HasBar ? BarColumnWidthBarsAndPercentages + PanelColumnSpacing : 0;
+            return (int)Math.Ceiling(IconWidthFor(mode) + bar + value + PanelColumnSpacing + RootHorizontalPadding);
+        }
 
         public HorizontalAlignment ElementsAlignment
         {
@@ -165,7 +306,7 @@ namespace TaskbarQuota.Controls
                 };
                 RenderRows();
                 AnimateRender(isFirstReveal, providerSwitch: providerChanged);
-                ToolTipService.SetToolTip(this, $"{widgetName}: {result.Error ?? "Loading..."}");
+                SetSummaryTooltip( $"{widgetName}: {result.Error ?? "Loading..."}");
                 return;
             }
 
@@ -178,7 +319,7 @@ namespace TaskbarQuota.Controls
                     RenderRows();
                     AnimateRender(isFirstReveal, providerSwitch: providerChanged);
                     var loginSourceText = result.Source.IsKnown ? $" {result.Source.ShortViaText}" : "";
-                    ToolTipService.SetToolTip(this, $"{widgetName}{loginSourceText}: Login required — open the app to connect.");
+                    SetSummaryTooltip( $"{widgetName}{loginSourceText}: Login required — open the app to connect.");
                     return;
                 }
 
@@ -190,7 +331,7 @@ namespace TaskbarQuota.Controls
                 RenderRows();
                 AnimateRender(isFirstReveal, providerSwitch: providerChanged);
                 var sourceText = result.Source.IsKnown ? $" {result.Source.ShortViaText}" : "";
-                ToolTipService.SetToolTip(this, $"{widgetName}{sourceText}: {result.Error ?? "Unavailable"}");
+                SetSummaryTooltip( $"{widgetName}{sourceText}: {result.Error ?? "Unavailable"}");
                 return;
             }
 
@@ -231,7 +372,7 @@ namespace TaskbarQuota.Controls
             var costTooltip = WidgetCostTooltipLine(result.Id, usage.Cost);
             var resetCreditsTooltip = WidgetResetCreditsTooltipLine(usage.ResetCredits);
             var staleTooltip = StaleTooltipLine(result);
-            ToolTipService.SetToolTip(this,
+            SetSummaryTooltip(
                 string.IsNullOrEmpty(plan)
                     ? $"{WidgetTooltipTitle(widgetName, result.Source)}\n{string.Join("\n", tooltipLines)}{costTooltip}{resetCreditsTooltip}{staleTooltip}"
                     : $"{WidgetTooltipTitle(widgetName, result.Source)} · {plan}\n{string.Join("\n", tooltipLines)}{costTooltip}{resetCreditsTooltip}{staleTooltip}");
@@ -407,6 +548,49 @@ namespace TaskbarQuota.Controls
         internal static IReadOnlyList<string> BuildRowLabelsForTesting(UsageResult result, UsageSnapshot usage)
             => BuildRows(result, usage).Select(row => row.Label).ToList();
 
+        /// <summary>Rows assumed for a provider whose usage has not been fetched yet.</summary>
+        public const int AssumedRowCount = 2;
+
+        /// <summary>
+        /// How many rows this provider's tile would render. Used to price a provider against the pin
+        /// budget before its tile exists, so the dashboard can tell a "short" provider from a "long" one.
+        ///
+        /// Mirrors the provider dispatch in <see cref="Apply"/> — the specialised displays build their own
+        /// row sets rather than going through <see cref="BuildRows"/>, so both have to be consulted. Keep
+        /// the two in step when a provider grows a new display path.
+        /// </summary>
+        public static int CountRenderedRows(UsageResult result)
+        {
+            if (!result.Ok || result.Fetch is not { } fetch)
+                return AssumedRowCount;
+
+            var usage = fetch.Usage;
+            int count = result.Id switch
+            {
+                ProviderId.OpenCode =>
+                    (WidgetSettingsService.IsRowVisible(result.Id, WidgetSettingsService.RowUsage) ? 1 : 0)
+                    + (WidgetSettingsService.IsRowVisible(result.Id, WidgetSettingsService.RowBalance) ? 1 : 0),
+                ProviderId.Cline => 1,
+                ProviderId.Antigravity => CountAntigravityRows(usage),
+                ProviderId.Copilot or ProviderId.Grok when usage.Cost is { Label: "Credits" } =>
+                    CountCreditRows(result.Id, usage),
+                _ => BuildRows(result, usage).Count,
+            };
+
+            return Math.Max(1, count);
+        }
+
+        private static int CountAntigravityRows(UsageSnapshot usage)
+            => (WidgetSettingsService.IsRowVisible(ProviderId.Antigravity, WidgetSettingsService.RowPrimary) ? 1 : 0)
+            + (usage.ModelSpecific != null && WidgetSettingsService.IsRowVisible(ProviderId.Antigravity, WidgetSettingsService.RowModelSpecific) ? 1 : 0)
+            + (usage.Secondary != null && WidgetSettingsService.IsRowVisible(ProviderId.Antigravity, WidgetSettingsService.RowSecondary) ? 1 : 0)
+            + (usage.Monthly != null && WidgetSettingsService.IsRowVisible(ProviderId.Antigravity, WidgetSettingsService.RowMonthly) ? 1 : 0);
+
+        private static int CountCreditRows(ProviderId id, UsageSnapshot usage)
+            => (WidgetSettingsService.IsRowVisible(id, WidgetSettingsService.RowCredits) ? 1 : 0)
+            + (usage.AdditionalUsage is { Enabled: true }
+                && WidgetSettingsService.IsRowVisible(id, WidgetSettingsService.RowAdditionalUsage) ? 1 : 0);
+
         private static bool ShouldShowCodexCredits(UsageSnapshot usage, CostSnapshot credits)
         {
             if (WidgetSettingsService.TryGetRowVisibilityOverride(ProviderId.Codex, WidgetSettingsService.RowCredits, out bool userVisible))
@@ -521,7 +705,7 @@ namespace TaskbarQuota.Controls
             RenderRows();
             AnimateRender(!_hasRevealed, providerSwitch: providerChanged);
 
-            ToolTipService.SetToolTip(this,
+            SetSummaryTooltip(
                 $"{WidgetTooltipTitle(result.DisplayName, result.Source)} · {usage.LoginMethod}\n" +
                 $"Usage: {usage.Cost?.Display ?? "--"}\n" +
                 $"Balance: {(balanceText != null ? "$" + balanceText.Split(' ')[0] : "--")}" +
@@ -544,7 +728,7 @@ namespace TaskbarQuota.Controls
             RenderRows();
             AnimateRender(!_hasRevealed, providerSwitch: providerChanged);
 
-            ToolTipService.SetToolTip(this,
+            SetSummaryTooltip(
                 $"{WidgetTooltipTitle(result.DisplayName, result.Source)} · {usage.LoginMethod}\n" +
                 $"Credit balance: {usage.Cost?.Display ?? "--"}" +
                 StaleTooltipLine(result));
@@ -601,7 +785,24 @@ namespace TaskbarQuota.Controls
             if (usage.Primary.ResetDescription is { } resetDesc)
                 tooltip += $"\nresets in {resetDesc}";
             tooltip += StaleTooltipLine(result);
-            ToolTipService.SetToolTip(this, tooltip);
+            SetSummaryTooltip( tooltip);
+        }
+
+        /// <summary>
+        /// Width reserve for a "used/limit" credits value, so the column doesn't twitch as the used side
+        /// grows. Sized from the tile's OWN limit — the used side can never be wider than the limit — rather
+        /// than from a fixed worst case: reserving room for "10,000/10,000" on a plan whose limit is 300
+        /// padded the tile by tens of pixels of permanent dead space, which on a crowded taskbar was enough
+        /// to cost the provider its tile entirely.
+        /// </summary>
+        internal static string CreditValueSample(string value)
+        {
+            int slash = value.IndexOf('/');
+            if (slash <= 0 || slash == value.Length - 1)
+                return value;
+
+            var limit = value[(slash + 1)..];
+            return new string('0', limit.Length) + "/" + limit;
         }
 
         private static string FormatCreditCount(double value)
@@ -708,7 +909,7 @@ namespace TaskbarQuota.Controls
                 (usage.Primary.ResetDescription is { } r1 ? $" (resets {r1})" : "") + "\n" +
                 $"Non-Gemini: {WidgetSettingsService.FormatDisplayPercent(usage.Secondary?.UsedPercent ?? 0)}" +
                 (usage.Secondary?.ResetDescription is { } r2 ? $" (resets {r2})" : "");
-            ToolTipService.SetToolTip(this, header + body + StaleTooltipLine(result));
+            SetSummaryTooltip( header + body + StaleTooltipLine(result));
         }
 
         private void OnWidgetSettingsChanged(object? sender, EventArgs e)
@@ -719,9 +920,39 @@ namespace TaskbarQuota.Controls
                 RenderRows();
         }
 
+        /// <summary>
+        /// Slides this tile into its new position from <paramref name="fromOffsetX"/> logical px away.
+        ///
+        /// The tiles occupy fixed slots and providers are re-assigned between them, so a re-order is really
+        /// a content swap. Starting each tile at the offset where its provider used to sit and easing that
+        /// back to zero turns the swap into what the eye expects: the existing tiles travel sideways and
+        /// the newcomer arrives from the edge.
+        /// </summary>
+        public void AnimateSlide(double fromOffsetX)
+        {
+            _slideStoryboard?.Stop();
+
+            // The RESTING value is written before starting, and the animation supplies the offset through
+            // its From. Storyboard.Stop reverts a property to its local value, so a slide interrupted by the
+            // next layout pass — which happens constantly, the layout is recomputed on every usage publish —
+            // lands at zero instead of stranding the tile at the offset it started from.
+            RootTranslate.X = 0;
+
+            _slideStoryboard = new Storyboard();
+            _slideStoryboard.Children.Add(CreateDoubleAnimation(RootTranslate, "X", fromOffsetX, 0, SlideMilliseconds));
+            _slideStoryboard.Begin();
+        }
+
         private void AnimateRender(bool isFirstReveal, bool providerSwitch = false)
         {
             _hasRevealed = true;
+            if (SuppressNextTransition)
+            {
+                SuppressNextTransition = false;
+                Panel.Opacity = RestingPanelOpacity;
+                return;
+            }
+
             if (isFirstReveal)
                 AnimateFirstReveal();
             else if (providerSwitch)
@@ -775,10 +1006,19 @@ namespace TaskbarQuota.Controls
 
         private void AnimateVisibility(double toOpacity, double toOffset, int milliseconds)
         {
+            double fromOpacity = Root.Opacity;
+            double fromOffset = RootTranslate.Y;
+
             _visibilityStoryboard?.Stop();
+            // Same rule as AnimateSlide: park the local values at the destination and let the animation
+            // supply the start through From, so an interrupted transition can never leave a tile stuck
+            // invisible or offset.
+            Root.Opacity = toOpacity;
+            RootTranslate.Y = toOffset;
+
             _visibilityStoryboard = new Storyboard();
-            _visibilityStoryboard.Children.Add(CreateDoubleAnimation(Root, "Opacity", Root.Opacity, toOpacity, milliseconds));
-            _visibilityStoryboard.Children.Add(CreateDoubleAnimation(RootTranslate, "Y", RootTranslate.Y, toOffset, milliseconds));
+            _visibilityStoryboard.Children.Add(CreateDoubleAnimation(Root, "Opacity", fromOpacity, toOpacity, milliseconds));
+            _visibilityStoryboard.Children.Add(CreateDoubleAnimation(RootTranslate, "Y", fromOffset, toOffset, milliseconds));
             _visibilityStoryboard.Begin();
         }
 
@@ -805,10 +1045,22 @@ namespace TaskbarQuota.Controls
         private void RenderRows()
         {
             var mode = _forcePercentagesOnly ? WidgetDisplayMode.PercentagesOnly : WidgetSettingsService.Current;
-            var rows = _rows.Count > 0 ? _rows : new List<WidgetUsageRow> { new("Usage", 0, "--") };
 
             ClearDynamicContent();
             ConfigureStaticColumns(mode);
+
+            if (_isIconOnly || _isCompact)
+            {
+                if (_isCompact)
+                    AddCompactMeter();
+                ApplyTaskbarForeground();
+                SetBars();
+                DesiredLogicalWidth = _isCompact ? CompactWidth(mode) : IconOnlyWidth(mode);
+                DesiredHostWidthChanged?.Invoke(DesiredLogicalWidth);
+                return;
+            }
+
+            var rows = RowsFor(_maxVisibleRows, _hideReset);
 
             bool showBars = mode is WidgetDisplayMode.BarsOnly or WidgetDisplayMode.BarsAndPercentages;
             bool showPercentages = mode is WidgetDisplayMode.PercentagesOnly or WidgetDisplayMode.BarsAndPercentages;
@@ -822,6 +1074,9 @@ namespace TaskbarQuota.Controls
                 int row = i % MaxRowsPerGroup;
                 int groupStart = group * MaxRowsPerGroup;
                 int groupCount = Math.Min(MaxRowsPerGroup, rows.Count - groupStart);
+                // Only a tile that holds ONE row overall gets the full-height treatment (the Grok/Copilot
+                // credits meter). A trailing lone row in a multi-group tile stays on the top line, level
+                // with the first row of the group beside it — centring it there just reads as misaligned.
                 bool isSingleRowGroup = rows.Count == 1 && groupCount == 1;
                 var layout = CalculateLayoutMetrics(rows, mode, group);
                 int firstColumn = EnsureGroupColumns(mode, group, layout);
@@ -830,7 +1085,57 @@ namespace TaskbarQuota.Controls
 
             ApplyTaskbarForeground();
             SetBars();
-            DesiredHostWidthChanged?.Invoke(CalculateDesiredWidth());
+            DesiredLogicalWidth = CalculateDesiredWidth(rows, mode);
+            DesiredHostWidthChanged?.Invoke(DesiredLogicalWidth);
+        }
+
+        /// <summary>
+        /// Compact form: the provider glyph and its headline figure, full height, nothing else. The rung
+        /// between a full tile and a bare glyph — a pinned provider on a crowded bar still reports a live
+        /// number instead of just identifying itself.
+        /// </summary>
+        private void AddCompactMeter()
+        {
+            var row = Headline();
+            int column = 1;
+
+            var track = new Border { CornerRadius = new CornerRadius(2), Opacity = 0.28 };
+            var bar = new Border
+            {
+                Background = (Brush)Application.Current.Resources["AccentFillColorDefaultBrush"],
+                CornerRadius = new CornerRadius(2),
+                HorizontalAlignment = HorizontalAlignment.Left,
+                Width = 0,
+            };
+
+            if (row.HasBar)
+            {
+                Panel.ColumnDefinitions.Add(new ColumnDefinition
+                {
+                    Width = new GridLength(BarColumnWidthBarsAndPercentages),
+                });
+
+                var barHost = new Grid
+                {
+                    Width = BarWidthBarsAndPercentages,
+                    Height = SingleRowBarHeight,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                };
+                barHost.Children.Add(track);
+                barHost.Children.Add(bar);
+                AddToPanel(barHost, 0, column++, MaxRowsPerGroup);
+            }
+
+            Panel.ColumnDefinitions.Add(new ColumnDefinition
+            {
+                Width = new GridLength(Math.Max(ValueColumnWidth, MeasureTextWidth(row.Value, WidgetFontSize + 1) + 4)),
+            });
+
+            var text = CreateText(row.Value, 0.86, TextAlignment.Center, WidgetFontSize + 1);
+            AddToPanel(text, 0, column, MaxRowsPerGroup);
+
+            _renderedRows.Add(new RenderedRow(row, track, bar, BarWidthBarsAndPercentages, null, text));
         }
 
         private void ClearDynamicContent()
@@ -848,7 +1153,7 @@ namespace TaskbarQuota.Controls
 
         private void ConfigureStaticColumns(WidgetDisplayMode mode)
         {
-            Panel.ColumnSpacing = 5;
+            Panel.ColumnSpacing = PanelColumnSpacing;
             int iconSize = mode == WidgetDisplayMode.PercentagesOnly ? IconHostSizePercentagesOnly : IconHostSizeBars;
             IconColumn.Width = new GridLength(iconSize);
             BadgeHost.Width = iconSize;
@@ -891,6 +1196,55 @@ namespace TaskbarQuota.Controls
             return 1 + (group * columnsPerGroup);
         }
 
+        /// <summary>
+        /// The rows this tile draws at a given ceiling. A capped tile stays a fixed width no matter how
+        /// many rows the user enables; the tooltip still lists every row.
+        /// </summary>
+        private List<WidgetUsageRow> RowsFor(int maxVisibleRows, bool hideReset)
+        {
+            var rows = _rows.Count > 0 ? _rows : new List<WidgetUsageRow> { new("Usage", 0, "--") };
+            if (rows.Count > maxVisibleRows)
+                rows = rows.GetRange(0, maxVisibleRows);
+            // Clearing the countdown here rather than at render time means the column measurement collapses
+            // to zero with it, which is the whole point of the step.
+            return hideReset ? rows.ConvertAll(row => row with { ResetDescription = null }) : rows;
+        }
+
+        /// <summary>
+        /// Total width of the tile for a given row set: the icon column, then per two-row group a label,
+        /// reset and bar/value column, plus inter-column spacing and the root padding. Mirrors exactly what
+        /// <see cref="ConfigureStaticColumns"/> and <see cref="EnsureGroupColumns"/> build, so a measured
+        /// candidate and the rendered result can never disagree.
+        /// </summary>
+        private static int CalculateDesiredWidth(IReadOnlyList<WidgetUsageRow> rows, WidgetDisplayMode mode)
+        {
+            int columnsPerGroup = mode switch
+            {
+                WidgetDisplayMode.PercentagesOnly => 3,
+                WidgetDisplayMode.BarsAndPercentages => 4,
+                _ => 3,
+            };
+
+            double total = mode == WidgetDisplayMode.PercentagesOnly ? IconHostSizePercentagesOnly : IconHostSizeBars;
+            int columnCount = 1;
+            int groups = (rows.Count + MaxRowsPerGroup - 1) / MaxRowsPerGroup;
+
+            for (int group = 0; group < groups; group++)
+            {
+                var layout = CalculateLayoutMetrics(rows, mode, group);
+                total += layout.LabelWidth + layout.ResetWidth;
+                total += mode switch
+                {
+                    WidgetDisplayMode.PercentagesOnly => layout.ValueWidth,
+                    WidgetDisplayMode.BarsAndPercentages => BarColumnWidthBarsAndPercentages + layout.ValueWidth,
+                    _ => BarColumnWidthBarsOnly,
+                };
+                columnCount += columnsPerGroup;
+            }
+
+            return (int)Math.Ceiling(total + (Math.Max(0, columnCount - 1) * PanelColumnSpacing) + RootHorizontalPadding);
+        }
+
         private static WidgetLayoutMetrics CalculateLayoutMetrics(
             IReadOnlyList<WidgetUsageRow> rows,
             WidgetDisplayMode mode,
@@ -919,7 +1273,7 @@ namespace TaskbarQuota.Controls
                 var row = rows[start + i];
                 widestValue = Math.Max(widestValue, MeasureTextWidth(row.Value, labelFont));
                 if (row.Label == "Credits")
-                    widestValue = Math.Max(widestValue, MeasureTextWidth(MaxCreditValueSample, labelFont));
+                    widestValue = Math.Max(widestValue, MeasureTextWidth(CreditValueSample(row.Value), labelFont));
                 // Reserve room for a large dollar balance so amounts like "$1,000.00" aren't clipped.
                 if (row.Label == "Balance")
                     widestValue = Math.Max(widestValue, MeasureTextWidth("$1,000.00", labelFont));
@@ -1128,13 +1482,6 @@ namespace TaskbarQuota.Controls
             Panel.Children.Add(element);
         }
 
-        private int CalculateDesiredWidth()
-        {
-            double columns = Panel.ColumnDefinitions.Sum(c => c.Width.Value);
-            double spacing = Math.Max(0, Panel.ColumnDefinitions.Count - 1) * Panel.ColumnSpacing;
-            double padding = Root.Padding.Left + Root.Padding.Right + 2;
-            return (int)Math.Ceiling(columns + spacing + padding);
-        }
 
         private void SetBars()
         {

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -39,11 +39,15 @@ namespace TaskbarQuota.Controls
         private const double GlyphViewportSize = 100;
         private const double NormalizedGlyphExtent = 88;
         private const double StaleOpacity = 0.55;
-        // Root.Padding left+right, plus the 2px slack CalculateDesiredWidth reserves. Must track the
-        // Padding set on Root in the XAML — the width math is analytic, so a mismatch clips a column.
-        private const int RootHorizontalPadding = 10;
         private const int PanelColumnSpacing = 5;
         private const int SlideMilliseconds = 300;
+        // Slack the width math reserves on top of the measured columns, so a rounding difference between
+        // the analytic total and what the Grid actually arranges can never clip the last column.
+        private const int WidthSlack = 2;
+
+        /// <summary>Placeholder shown before any usage has been applied. Shared and never mutated, so a
+        /// tile that renders on every usage publish does not allocate a list per pass.</summary>
+        private static readonly List<WidgetUsageRow> PlaceholderRows = [new("Usage", 0, "--")];
 
         public event Action? Clicked;
         public event Action<DisplayMode>? DisplayModeChanged;
@@ -67,18 +71,20 @@ namespace TaskbarQuota.Controls
         private readonly List<RenderedRow> _renderedRows = new();
         private List<WidgetUsageRow> _rows = new();
         private bool _forcePercentagesOnly;
-        private int _maxVisibleRows = int.MaxValue;
-        private bool _isIconOnly;
-        private bool _isCompact;
-        private bool _hideReset;
         private UsageResult? _lastResult;
         private ProviderId? _lastAppliedProvider;
         private string? _lastRenderSignature;
         private bool _hasRevealed;
         private bool _isActiveToolVisible = true;
+        // Storyboards and their animations are allocated on first use and re-aimed afterwards; all three
+        // run on ordinary usage publishes, so rebuilding them per pass was continuous garbage.
         private Storyboard? _visibilityStoryboard;
+        private DoubleAnimation? _visibilityOpacity;
+        private DoubleAnimation? _visibilityOffset;
         private Storyboard? _softRefreshStoryboard;
+        private DoubleAnimation? _softRefreshAnimation;
         private Storyboard? _slideStoryboard;
+        private DoubleAnimation? _slideAnimation;
 
         /// <summary>
         /// Returns the display name for the constrained taskbar widget.
@@ -94,125 +100,23 @@ namespace TaskbarQuota.Controls
                 _ => fullName,
             };
 
-        /// <summary>
-        /// How much of this tile renders on the taskbar. In normal use every pinned provider renders in
-        /// full — the reduced forms exist for callers that need a smaller tile, but the taskbar host does
-        /// not select them: keeping the row inside the bar is the pin budget's job, and trimming a pinned
-        /// provider the user configured is worse than refusing the pin (issue #25).
-        /// </summary>
-        /// <param name="form">
-        /// <see cref="SummaryForm.Glyph"/> for the bare provider glyph, <see cref="SummaryForm.Compact"/> for the glyph
-        /// plus its headline figure, or a positive row ceiling.
-        /// </param>
-        public void SetSummaryMode(SummaryForm form)
-        {
-            bool iconOnly = form.IsGlyph;
-            bool compact = form.IsCompact;
-            int maxVisibleRows = Math.Max(1, form.Rows);
-            if (_isIconOnly == iconOnly
-                && _isCompact == compact
-                && _maxVisibleRows == maxVisibleRows
-                && _hideReset == form.HideReset)
-            {
-                return;
-            }
-
-            _isIconOnly = iconOnly;
-            _isCompact = compact;
-            _maxVisibleRows = maxVisibleRows;
-            _hideReset = form.HideReset;
-            // Re-run Apply rather than just RenderRows so the tooltip is rebuilt too — in icon-only mode it
-            // is the only place the numbers survive.
-            if (_lastResult is { } result)
-                Apply(result, force: true);
-            else
-                RenderRows();
-        }
-
-        /// <summary>
-        /// Sets the tile's tooltip, noting when the taskbar is showing less than the full picture. A
-        /// degraded tile must say why, or a pinned provider that quietly shrank looks broken.
-        /// </summary>
-        private void SetSummaryTooltip(string text)
-        {
-            if (_isIconOnly)
-                text += "\nIcon only — not enough room on the taskbar.";
-            else if (_isCompact)
-                text += "\nCompact — not enough room on the taskbar.";
-            else if (_rows.Count > _maxVisibleRows)
-                text += $"\n+{_rows.Count - _maxVisibleRows} more row(s) — shown when this tool is active.";
-
-            ToolTipService.SetToolTip(this, text);
-        }
-
-        /// <summary>
-        /// How much of a tile renders. The ladder, richest first: every row with its reset countdown, the
-        /// same rows without the countdown, fewer rows, a single meter with no label, then a bare glyph.
-        /// Dropping the countdown is the cheapest useful step — it is a whole column (~44px) and the same
-        /// information is already in the tooltip.
-        /// </summary>
-        public readonly record struct SummaryForm(int Rows, bool HideReset)
-        {
-            /// <summary>Provider glyph only; every figure lives in the tooltip.</summary>
-            public static SummaryForm Glyph => new(-1, false);
-            /// <summary>Glyph plus a single unlabelled meter — bar and value.</summary>
-            public static SummaryForm Compact => new(0, false);
-
-            public bool IsGlyph => Rows < 0;
-            public bool IsCompact => Rows == 0;
-
-            public override string ToString()
-                => IsGlyph ? "glyph" : IsCompact ? "compact" : HideReset ? $"{Rows}r-" : $"{Rows}r";
-        }
-
-        /// <summary>Width (logical px) a tile occupies once collapsed to its glyph.</summary>
-        public static int IconOnlyWidth(WidgetDisplayMode mode)
-            => IconWidthFor(mode) + RootHorizontalPadding;
-
-        private static int IconWidthFor(WidgetDisplayMode mode)
-            => mode == WidgetDisplayMode.PercentagesOnly ? IconHostSizePercentagesOnly : IconHostSizeBars;
-
-        /// <summary>Rows this tile currently has to show, before any host-imposed ceiling.</summary>
+        /// <summary>Rows this tile shows. A pinned provider always renders exactly what the user configured
+        /// (issue #25); keeping the row inside the bar is <see cref="PinBudgetService"/>'s job, not this
+        /// control's, so there is no reduced form to fall back to.</summary>
         public int RowCount => Math.Max(1, _rows.Count);
 
         /// <summary>
-        /// The width this tile WOULD take at a given row ceiling, without rendering it.
+        /// The width this tile WOULD take, without rendering it.
         ///
-        /// The host has to compare layouts (all rows vs capped rows) before choosing one, and rendering
-        /// each candidate to read its width made the tile visibly flash: every re-render restarts the
-        /// refresh animation, and the host re-runs this on every usage publish. The column widths are a
-        /// pure function of the rows and the display mode, so they are computed directly instead.
+        /// The host sums this across its tiles to size the widget host window. Rendering to read the width
+        /// made the tile visibly flash — every re-render restarts the refresh animation, and the host
+        /// re-runs this on every usage publish — so the column widths, which are a pure function of the
+        /// rows and the display mode, are computed directly instead.
         /// </summary>
-        public int MeasureDesiredWidth(SummaryForm form)
-        {
-            var mode = _forcePercentagesOnly ? WidgetDisplayMode.PercentagesOnly : WidgetSettingsService.Current;
-            if (form.IsGlyph)
-                return IconOnlyWidth(mode);
-            if (form.IsCompact)
-                return CompactWidth(mode);
-
-            return CalculateDesiredWidth(RowsFor(form.Rows, form.HideReset), mode);
-        }
-
-        /// <summary>
-        /// The meter a compact tile shows: the tile's first row, which is the provider's headline window
-        /// (session, 5h, or credit balance).
-        /// </summary>
-        private WidgetUsageRow Headline()
-            => _rows.Count > 0 ? _rows[0] : new WidgetUsageRow("Usage", 0, "--", HasBar: false);
-
-        /// <summary>
-        /// Compact form: glyph, bar and value. The bar matters — a naked "0%" or "0/200" beside a logo does
-        /// not say what is being measured or how full it is, whereas a filled bar reads as a meter at a
-        /// glance and the tooltip names the window.
-        /// </summary>
-        private int CompactWidth(WidgetDisplayMode mode)
-        {
-            var row = Headline();
-            double value = Math.Max(ValueColumnWidth, MeasureTextWidth(row.Value, WidgetFontSize + 1) + 4);
-            double bar = row.HasBar ? BarColumnWidthBarsAndPercentages + PanelColumnSpacing : 0;
-            return (int)Math.Ceiling(IconWidthFor(mode) + bar + value + PanelColumnSpacing + RootHorizontalPadding);
-        }
+        public int MeasureDesiredWidth()
+            => CalculateDesiredWidth(
+                CurrentRows(),
+                _forcePercentagesOnly ? WidgetDisplayMode.PercentagesOnly : WidgetSettingsService.Current);
 
         public HorizontalAlignment ElementsAlignment
         {
@@ -307,7 +211,7 @@ namespace TaskbarQuota.Controls
                 };
                 RenderRows();
                 AnimateRender(isFirstReveal, providerSwitch: providerChanged);
-                SetSummaryTooltip( $"{widgetName}: {result.Error ?? "Loading..."}");
+                ToolTipService.SetToolTip(this, $"{widgetName}: {result.Error ?? "Loading..."}");
                 return;
             }
 
@@ -320,7 +224,7 @@ namespace TaskbarQuota.Controls
                     RenderRows();
                     AnimateRender(isFirstReveal, providerSwitch: providerChanged);
                     var loginSourceText = result.Source.IsKnown ? $" {result.Source.ShortViaText}" : "";
-                    SetSummaryTooltip( $"{widgetName}{loginSourceText}: Login required — open the app to connect.");
+                    ToolTipService.SetToolTip(this, $"{widgetName}{loginSourceText}: Login required — open the app to connect.");
                     return;
                 }
 
@@ -332,7 +236,7 @@ namespace TaskbarQuota.Controls
                 RenderRows();
                 AnimateRender(isFirstReveal, providerSwitch: providerChanged);
                 var sourceText = result.Source.IsKnown ? $" {result.Source.ShortViaText}" : "";
-                SetSummaryTooltip( $"{widgetName}{sourceText}: {result.Error ?? "Unavailable"}");
+                ToolTipService.SetToolTip(this, $"{widgetName}{sourceText}: {result.Error ?? "Unavailable"}");
                 return;
             }
 
@@ -373,7 +277,7 @@ namespace TaskbarQuota.Controls
             var costTooltip = WidgetCostTooltipLine(result.Id, usage.Cost);
             var resetCreditsTooltip = WidgetResetCreditsTooltipLine(usage.ResetCredits);
             var staleTooltip = StaleTooltipLine(result);
-            SetSummaryTooltip(
+            ToolTipService.SetToolTip(this,
                 string.IsNullOrEmpty(plan)
                     ? $"{WidgetTooltipTitle(widgetName, result.Source)}\n{string.Join("\n", tooltipLines)}{costTooltip}{resetCreditsTooltip}{staleTooltip}"
                     : $"{WidgetTooltipTitle(widgetName, result.Source)} · {plan}\n{string.Join("\n", tooltipLines)}{costTooltip}{resetCreditsTooltip}{staleTooltip}");
@@ -706,7 +610,7 @@ namespace TaskbarQuota.Controls
             RenderRows();
             AnimateRender(!_hasRevealed, providerSwitch: providerChanged);
 
-            SetSummaryTooltip(
+            ToolTipService.SetToolTip(this,
                 $"{WidgetTooltipTitle(result.DisplayName, result.Source)} · {usage.LoginMethod}\n" +
                 $"Usage: {usage.Cost?.Display ?? "--"}\n" +
                 $"Balance: {(balanceText != null ? "$" + balanceText.Split(' ')[0] : "--")}" +
@@ -729,7 +633,7 @@ namespace TaskbarQuota.Controls
             RenderRows();
             AnimateRender(!_hasRevealed, providerSwitch: providerChanged);
 
-            SetSummaryTooltip(
+            ToolTipService.SetToolTip(this,
                 $"{WidgetTooltipTitle(result.DisplayName, result.Source)} · {usage.LoginMethod}\n" +
                 $"Credit balance: {usage.Cost?.Display ?? "--"}" +
                 StaleTooltipLine(result));
@@ -786,7 +690,7 @@ namespace TaskbarQuota.Controls
             if (usage.Primary.ResetDescription is { } resetDesc)
                 tooltip += $"\nresets in {resetDesc}";
             tooltip += StaleTooltipLine(result);
-            SetSummaryTooltip( tooltip);
+            ToolTipService.SetToolTip(this, tooltip);
         }
 
         /// <summary>
@@ -910,7 +814,7 @@ namespace TaskbarQuota.Controls
                 (usage.Primary.ResetDescription is { } r1 ? $" (resets {r1})" : "") + "\n" +
                 $"Non-Gemini: {WidgetSettingsService.FormatDisplayPercent(usage.Secondary?.UsedPercent ?? 0)}" +
                 (usage.Secondary?.ResetDescription is { } r2 ? $" (resets {r2})" : "");
-            SetSummaryTooltip( header + body + StaleTooltipLine(result));
+            ToolTipService.SetToolTip(this, header + body + StaleTooltipLine(result));
         }
 
         private void OnWidgetSettingsChanged(object? sender, EventArgs e)
@@ -939,8 +843,17 @@ namespace TaskbarQuota.Controls
             // lands at zero instead of stranding the tile at the offset it started from.
             RootTranslate.X = 0;
 
-            _slideStoryboard = new Storyboard();
-            _slideStoryboard.Children.Add(CreateDoubleAnimation(RootTranslate, "X", fromOffsetX, 0, SlideMilliseconds));
+            // Storyboard and animation are built once and re-aimed, not rebuilt. These run on every layout
+            // pass across every tile, and a fresh Storyboard + DoubleAnimation + CubicEase per pass was
+            // steady garbage for the life of the process.
+            if (_slideStoryboard is null)
+            {
+                _slideAnimation = CreateDoubleAnimation(RootTranslate, "X", fromOffsetX, 0, SlideMilliseconds);
+                _slideStoryboard = new Storyboard();
+                _slideStoryboard.Children.Add(_slideAnimation);
+            }
+
+            _slideAnimation!.From = fromOffsetX;
             _slideStoryboard.Begin();
         }
 
@@ -967,13 +880,8 @@ namespace TaskbarQuota.Controls
         // soft-refresh's partial dim) so the switch feels like a transition rather than a redraw.
         private void AnimateProviderSwitch()
         {
-            double targetOpacity = RestingPanelOpacity;
             Panel.Opacity = 0;
-
-            _softRefreshStoryboard?.Stop();
-            _softRefreshStoryboard = new Storyboard();
-            _softRefreshStoryboard.Children.Add(CreateDoubleAnimation(Panel, "Opacity", 0, targetOpacity, 200));
-            _softRefreshStoryboard.Begin();
+            AnimatePanelOpacity(from: 0, to: RestingPanelOpacity, milliseconds: 200);
         }
 
         private void AnimateFirstReveal()
@@ -992,9 +900,26 @@ namespace TaskbarQuota.Controls
             double startOpacity = Math.Min(0.72, targetOpacity);
             Panel.Opacity = startOpacity;
 
+            AnimatePanelOpacity(startOpacity, targetOpacity, 180);
+        }
+
+        /// <summary>
+        /// Runs the shared Panel.Opacity storyboard. Both callers fire on ordinary usage publishes, so the
+        /// storyboard is built once and re-aimed rather than reallocated per refresh.
+        /// </summary>
+        private void AnimatePanelOpacity(double from, double to, int milliseconds)
+        {
             _softRefreshStoryboard?.Stop();
-            _softRefreshStoryboard = new Storyboard();
-            _softRefreshStoryboard.Children.Add(CreateDoubleAnimation(Panel, "Opacity", startOpacity, targetOpacity, 180));
+            if (_softRefreshStoryboard is null)
+            {
+                _softRefreshAnimation = CreateDoubleAnimation(Panel, "Opacity", from, to, milliseconds);
+                _softRefreshStoryboard = new Storyboard();
+                _softRefreshStoryboard.Children.Add(_softRefreshAnimation);
+            }
+
+            _softRefreshAnimation!.From = from;
+            _softRefreshAnimation.To = to;
+            _softRefreshAnimation.Duration = new Duration(TimeSpan.FromMilliseconds(milliseconds));
             _softRefreshStoryboard.Begin();
         }
 
@@ -1017,9 +942,22 @@ namespace TaskbarQuota.Controls
             Root.Opacity = toOpacity;
             RootTranslate.Y = toOffset;
 
-            _visibilityStoryboard = new Storyboard();
-            _visibilityStoryboard.Children.Add(CreateDoubleAnimation(Root, "Opacity", fromOpacity, toOpacity, milliseconds));
-            _visibilityStoryboard.Children.Add(CreateDoubleAnimation(RootTranslate, "Y", fromOffset, toOffset, milliseconds));
+            if (_visibilityStoryboard is null)
+            {
+                _visibilityOpacity = CreateDoubleAnimation(Root, "Opacity", fromOpacity, toOpacity, milliseconds);
+                _visibilityOffset = CreateDoubleAnimation(RootTranslate, "Y", fromOffset, toOffset, milliseconds);
+                _visibilityStoryboard = new Storyboard();
+                _visibilityStoryboard.Children.Add(_visibilityOpacity);
+                _visibilityStoryboard.Children.Add(_visibilityOffset);
+            }
+
+            var duration = new Duration(TimeSpan.FromMilliseconds(milliseconds));
+            _visibilityOpacity!.From = fromOpacity;
+            _visibilityOpacity.To = toOpacity;
+            _visibilityOpacity.Duration = duration;
+            _visibilityOffset!.From = fromOffset;
+            _visibilityOffset.To = toOffset;
+            _visibilityOffset.Duration = duration;
             _visibilityStoryboard.Begin();
         }
 
@@ -1050,18 +988,7 @@ namespace TaskbarQuota.Controls
             ClearDynamicContent();
             ConfigureStaticColumns(mode);
 
-            if (_isIconOnly || _isCompact)
-            {
-                if (_isCompact)
-                    AddCompactMeter();
-                ApplyTaskbarForeground();
-                SetBars();
-                DesiredLogicalWidth = _isCompact ? CompactWidth(mode) : IconOnlyWidth(mode);
-                DesiredHostWidthChanged?.Invoke(DesiredLogicalWidth);
-                return;
-            }
-
-            var rows = RowsFor(_maxVisibleRows, _hideReset);
+            var rows = CurrentRows();
 
             bool showBars = mode is WidgetDisplayMode.BarsOnly or WidgetDisplayMode.BarsAndPercentages;
             bool showPercentages = mode is WidgetDisplayMode.PercentagesOnly or WidgetDisplayMode.BarsAndPercentages;
@@ -1088,55 +1015,6 @@ namespace TaskbarQuota.Controls
             SetBars();
             DesiredLogicalWidth = CalculateDesiredWidth(rows, mode);
             DesiredHostWidthChanged?.Invoke(DesiredLogicalWidth);
-        }
-
-        /// <summary>
-        /// Compact form: the provider glyph and its headline figure, full height, nothing else. The rung
-        /// between a full tile and a bare glyph — a pinned provider on a crowded bar still reports a live
-        /// number instead of just identifying itself.
-        /// </summary>
-        private void AddCompactMeter()
-        {
-            var row = Headline();
-            int column = 1;
-
-            var track = new Border { CornerRadius = new CornerRadius(2), Opacity = 0.28 };
-            var bar = new Border
-            {
-                Background = (Brush)Application.Current.Resources["AccentFillColorDefaultBrush"],
-                CornerRadius = new CornerRadius(2),
-                HorizontalAlignment = HorizontalAlignment.Left,
-                Width = 0,
-            };
-
-            if (row.HasBar)
-            {
-                Panel.ColumnDefinitions.Add(new ColumnDefinition
-                {
-                    Width = new GridLength(BarColumnWidthBarsAndPercentages),
-                });
-
-                var barHost = new Grid
-                {
-                    Width = BarWidthBarsAndPercentages,
-                    Height = SingleRowBarHeight,
-                    HorizontalAlignment = HorizontalAlignment.Center,
-                    VerticalAlignment = VerticalAlignment.Center,
-                };
-                barHost.Children.Add(track);
-                barHost.Children.Add(bar);
-                AddToPanel(barHost, 0, column++, MaxRowsPerGroup);
-            }
-
-            Panel.ColumnDefinitions.Add(new ColumnDefinition
-            {
-                Width = new GridLength(Math.Max(ValueColumnWidth, MeasureTextWidth(row.Value, WidgetFontSize + 1) + 4)),
-            });
-
-            var text = CreateText(row.Value, 0.86, TextAlignment.Center, WidgetFontSize + 1);
-            AddToPanel(text, 0, column, MaxRowsPerGroup);
-
-            _renderedRows.Add(new RenderedRow(row, track, bar, BarWidthBarsAndPercentages, null, text));
         }
 
         private void ClearDynamicContent()
@@ -1197,27 +1075,22 @@ namespace TaskbarQuota.Controls
             return 1 + (group * columnsPerGroup);
         }
 
-        /// <summary>
-        /// The rows this tile draws at a given ceiling. A capped tile stays a fixed width no matter how
-        /// many rows the user enables; the tooltip still lists every row.
+        /// <summary>The rows this tile draws — everything the user enabled, or the placeholder until the
+        /// first result lands. Never copies: the measure and render paths both run on every usage publish.
         /// </summary>
-        private List<WidgetUsageRow> RowsFor(int maxVisibleRows, bool hideReset)
-        {
-            var rows = _rows.Count > 0 ? _rows : new List<WidgetUsageRow> { new("Usage", 0, "--") };
-            if (rows.Count > maxVisibleRows)
-                rows = rows.GetRange(0, maxVisibleRows);
-            // Clearing the countdown here rather than at render time means the column measurement collapses
-            // to zero with it, which is the whole point of the step.
-            return hideReset ? rows.ConvertAll(row => row with { ResetDescription = null }) : rows;
-        }
+        private List<WidgetUsageRow> CurrentRows() => _rows.Count > 0 ? _rows : PlaceholderRows;
 
         /// <summary>
         /// Total width of the tile for a given row set: the icon column, then per two-row group a label,
         /// reset and bar/value column, plus inter-column spacing and the root padding. Mirrors exactly what
         /// <see cref="ConfigureStaticColumns"/> and <see cref="EnsureGroupColumns"/> build, so a measured
         /// candidate and the rendered result can never disagree.
+        ///
+        /// Root.Padding is read from the live element rather than mirrored as a constant: the analytic
+        /// width and the XAML have to agree exactly or a column is clipped, and a constant only agrees
+        /// until someone edits the XAML.
         /// </summary>
-        private static int CalculateDesiredWidth(IReadOnlyList<WidgetUsageRow> rows, WidgetDisplayMode mode)
+        private int CalculateDesiredWidth(IReadOnlyList<WidgetUsageRow> rows, WidgetDisplayMode mode)
         {
             int columnsPerGroup = mode switch
             {
@@ -1243,7 +1116,8 @@ namespace TaskbarQuota.Controls
                 columnCount += columnsPerGroup;
             }
 
-            return (int)Math.Ceiling(total + (Math.Max(0, columnCount - 1) * PanelColumnSpacing) + RootHorizontalPadding);
+            double padding = Root.Padding.Left + Root.Padding.Right + WidthSlack;
+            return (int)Math.Ceiling(total + (Math.Max(0, columnCount - 1) * PanelColumnSpacing) + padding);
         }
 
         private static WidgetLayoutMetrics CalculateLayoutMetrics(

--- a/src/TaskbarQuota.App/DashboardNavigationBinder.cs
+++ b/src/TaskbarQuota.App/DashboardNavigationBinder.cs
@@ -10,12 +10,13 @@ using TaskbarQuota.ViewModels;
 
 namespace TaskbarQuota
 {
-    internal sealed class DashboardNavigationBinder
+    internal sealed class DashboardNavigationBinder : IDisposable
     {
         private readonly NavigationView _nav;
         private readonly DashboardViewModel _viewModel;
         private readonly DispatcherQueueTimer _rebuildTimer;
         private bool _rebuildPending;
+        private bool _disposed;
 
         public bool IsSyncing { get; private set; }
 
@@ -35,6 +36,27 @@ namespace TaskbarQuota
             _viewModel.SelectedCardChanged += ViewModel_SelectedCardChanged;
             WidgetSettingsService.Changed += OnWidgetSettingsChanged;
             Rebuild();
+        }
+
+        /// <summary>
+        /// Detaches from the view model and from the static settings event.
+        ///
+        /// The window that owns this binder is destroyed and rebuilt every time the user closes and
+        /// reopens it from the tray. <see cref="WidgetSettingsService.Changed"/> is static, so a binder
+        /// that never unsubscribes is rooted for the life of the process — along with its NavigationView
+        /// and everything reachable from it — and each reopen adds another one that then refreshes badges
+        /// on a dead window's dispatcher.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            WidgetSettingsService.Changed -= OnWidgetSettingsChanged;
+            _viewModel.Cards.CollectionChanged -= Cards_CollectionChanged;
+            _viewModel.SelectedCardChanged -= ViewModel_SelectedCardChanged;
+            _rebuildTimer.Stop();
         }
 
         /// <summary>
@@ -63,7 +85,12 @@ namespace TaskbarQuota
 
         // Pins can change from the dashboard card, from Settings, or from the budget auto-unpinning one.
         private void OnWidgetSettingsChanged(object? sender, EventArgs e)
-            => _nav.DispatcherQueue.TryEnqueue(RefreshPinBadges);
+        {
+            if (_disposed)
+                return;
+
+            _nav.DispatcherQueue.TryEnqueue(RefreshPinBadges);
+        }
 
         private void Cards_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {

--- a/src/TaskbarQuota.App/DashboardNavigationBinder.cs
+++ b/src/TaskbarQuota.App/DashboardNavigationBinder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Specialized;
+using System.Linq;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -32,6 +33,7 @@ namespace TaskbarQuota
             };
             _viewModel.Cards.CollectionChanged += Cards_CollectionChanged;
             _viewModel.SelectedCardChanged += ViewModel_SelectedCardChanged;
+            WidgetSettingsService.Changed += OnWidgetSettingsChanged;
             Rebuild();
         }
 
@@ -58,6 +60,10 @@ namespace TaskbarQuota
             _viewModel.SelectProvider(id);
             return true;
         }
+
+        // Pins can change from the dashboard card, from Settings, or from the budget auto-unpinning one.
+        private void OnWidgetSettingsChanged(object? sender, EventArgs e)
+            => _nav.DispatcherQueue.TryEnqueue(RefreshPinBadges);
 
         private void Cards_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
@@ -92,7 +98,7 @@ namespace TaskbarQuota
                     Icon = CreateProviderIcon(card.ProviderId),
                     HorizontalAlignment = iconOnly ? HorizontalAlignment.Center : HorizontalAlignment.Stretch,
                 };
-                ToolTipService.SetToolTip(item, card.DisplayName);
+                ApplyPinBadge(item, card.ProviderId, card.DisplayName);
                 _nav.MenuItems.Add(item);
             }
 
@@ -128,6 +134,44 @@ namespace TaskbarQuota
                 SetActiveVisual(navItem, isSelected);
             }
         }
+
+        /// <summary>
+        /// Marks the providers that are pinned to the taskbar. In icon-only mode the strip is nothing but
+        /// glyphs, so without a marker there is no way to tell which of them are pinned short of opening
+        /// each one.
+        /// </summary>
+        private static void ApplyPinBadge(NavigationViewItem item, ProviderId id, string displayName)
+        {
+            bool pinned = WidgetSettingsService.IsProviderPinned(id);
+            item.InfoBadge = pinned
+                ? new InfoBadge
+                {
+                    IconSource = new FontIconSource { Glyph = PinGlyph, FontSize = 10 },
+                    Style = (Style)Application.Current.Resources["AttentionIconInfoBadgeStyle"],
+                }
+                : null;
+
+            ToolTipService.SetToolTip(item, pinned ? $"{displayName} — pinned to the taskbar" : displayName);
+        }
+
+        /// <summary>
+        /// Refreshes the pin markers in place. A full rebuild would recreate every PathIcon, which is what
+        /// the Replace guard above exists to avoid.
+        /// </summary>
+        private void RefreshPinBadges()
+        {
+            foreach (var menuItem in _nav.MenuItems)
+            {
+                if (menuItem is not NavigationViewItem { Tag: ProviderId id } item)
+                    continue;
+
+                var card = _viewModel.Cards.FirstOrDefault(c => c.ProviderId == id);
+                ApplyPinBadge(item, id, card?.DisplayName ?? id.ToString());
+            }
+        }
+
+        // Segoe Fluent "Pin" glyph.
+        private const string PinGlyph = "";
 
         private static IconElement CreateProviderIcon(ProviderId id)
         {

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Linq;
 using Microsoft.UI;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Windowing;
@@ -53,6 +54,7 @@ namespace TaskbarQuota
             _dashboardViewModel.DetailContentWidthChanged += DashboardDetailContentWidthChanged;
             _dashboardViewModel.DetailContentHeightChanged += DashboardDetailContentHeightChanged;
             ProviderStrip.Loaded += (_, _) => RebuildProviderStrip();
+            WidgetSettingsService.Changed += OnWidgetSettingsChanged;
 
             SystemBackdrop = new DesktopAcrylicBackdrop();
             ThemeService.Register(Root);
@@ -71,6 +73,9 @@ namespace TaskbarQuota
 
             Activated += OnActivated;
         }
+
+        private void OnWidgetSettingsChanged(object? sender, EventArgs e)
+            => DispatcherQueue.TryEnqueue(SyncProviderStripPins);
 
         private void OnActivated(object sender, WindowActivatedEventArgs args)
         {
@@ -334,6 +339,19 @@ namespace TaskbarQuota
                 Opacity = 0,
             };
 
+            // Pin mark, top-right of the glyph. The strip is icons only, so without it there is no way to
+            // tell which providers are pinned to the taskbar without opening each one.
+            var pin = new FontIcon
+            {
+                Glyph = PinGlyph,
+                FontSize = 9,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                VerticalAlignment = VerticalAlignment.Top,
+                Margin = new Thickness(0, 2, 2, 0),
+                Foreground = GetSelectionBrush(isSelected: true),
+                Visibility = Visibility.Collapsed,
+            };
+
             var buttonContent = new Grid
             {
                 Width = FlyoutLayout.IconButtonWidth,
@@ -341,6 +359,7 @@ namespace TaskbarQuota
             };
             buttonContent.Children.Add(icon);
             buttonContent.Children.Add(indicator);
+            buttonContent.Children.Add(pin);
 
             var button = new Button
             {
@@ -355,12 +374,40 @@ namespace TaskbarQuota
                 Content = buttonContent,
             };
             button.Click += ProviderStripButton_Click;
-            ToolTipService.SetToolTip(button, card.DisplayName);
             AutomationProperties.SetName(button, card.DisplayName);
             AutomationProperties.SetAutomationId(button, $"FlyoutProvider{card.ProviderId}Button");
 
-            _providerStripItems[card.ProviderId] = new FlyoutProviderStripItem(icon, indicator);
+            _providerStripItems[card.ProviderId] = new FlyoutProviderStripItem(icon, indicator, pin);
+            ApplyStripPin(card.ProviderId, button, card.DisplayName);
             return button;
+        }
+
+        // Segoe Fluent Icons "Pin".
+        private const string PinGlyph = "";
+
+        private void ApplyStripPin(ProviderId id, Button button, string displayName)
+        {
+            bool pinned = WidgetSettingsService.IsProviderPinned(id);
+            if (_providerStripItems.TryGetValue(id, out var item))
+                item.Pin.Visibility = pinned ? Visibility.Visible : Visibility.Collapsed;
+
+            ToolTipService.SetToolTip(button, pinned ? $"{displayName} — pinned to the taskbar" : displayName);
+        }
+
+        /// <summary>
+        /// Refreshes the pin marks in place. Pins change from the dashboard card, from Settings, and when
+        /// the pin budget auto-unpins one, and the flyout may be open while any of those happen.
+        /// </summary>
+        private void SyncProviderStripPins()
+        {
+            foreach (var child in ProviderStrip.Children)
+            {
+                if (child is not Button { Tag: ProviderId id } button)
+                    continue;
+
+                var card = _dashboardViewModel.Cards.FirstOrDefault(c => c.ProviderId == id);
+                ApplyStripPin(id, button, card?.DisplayName ?? id.ToString());
+            }
         }
 
         private void ProviderStripButton_Click(object sender, RoutedEventArgs e)
@@ -462,14 +509,16 @@ namespace TaskbarQuota
 
         private sealed class FlyoutProviderStripItem
         {
-            public FlyoutProviderStripItem(ProviderAvatar icon, Border indicator)
+            public FlyoutProviderStripItem(ProviderAvatar icon, Border indicator, FontIcon pin)
             {
                 Icon = icon;
                 Indicator = indicator;
+                Pin = pin;
             }
 
             public ProviderAvatar Icon { get; }
             public Border Indicator { get; }
+            public FontIcon Pin { get; }
         }
     }
 }

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -72,6 +72,26 @@ namespace TaskbarQuota
             GetAppWindow().SetPresenter(presenter);
 
             Activated += OnActivated;
+            Closed += OnClosed;
+        }
+
+        /// <summary>
+        /// Drops every subscription the window owns. <see cref="WidgetSettingsService.Changed"/> is static
+        /// and the flyout is discarded and rebuilt (TaskBarManager nulls it on shutdown and on a failed
+        /// show), so without this each rebuilt flyout stays rooted for the life of the process and keeps
+        /// enqueuing strip refreshes onto a closed window's dispatcher.
+        /// </summary>
+        private void OnClosed(object sender, WindowEventArgs args)
+        {
+            Closed -= OnClosed;
+            Activated -= OnActivated;
+            WidgetSettingsService.Changed -= OnWidgetSettingsChanged;
+            _dashboardViewModel.Cards.CollectionChanged -= DashboardCards_CollectionChanged;
+            _dashboardViewModel.SelectedCardChanged -= DashboardSelectedCardChanged;
+            _dashboardViewModel.DetailContentWidthChanged -= DashboardDetailContentWidthChanged;
+            _dashboardViewModel.DetailContentHeightChanged -= DashboardDetailContentHeightChanged;
+            _boundsUpdateTimer.Stop();
+            _providerStripItems.Clear();
         }
 
         private void OnWidgetSettingsChanged(object? sender, EventArgs e)

--- a/src/TaskbarQuota.App/Interop/Native.cs
+++ b/src/TaskbarQuota.App/Interop/Native.cs
@@ -20,6 +20,10 @@ namespace TaskbarQuota.Interop
         [DllImport("user32.dll")]
         public static extern bool IsWindow([In] IntPtr hWnd);
 
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool IsWindowVisible([In] IntPtr hWnd);
+
         [DllImport("user32.dll")]
         public static extern IntPtr DefWindowProc(IntPtr hWnd, uint uMsg, IntPtr wParam, IntPtr lParam);
 

--- a/src/TaskbarQuota.App/MainWindow.xaml.cs
+++ b/src/TaskbarQuota.App/MainWindow.xaml.cs
@@ -33,6 +33,13 @@ namespace TaskbarQuota
             Root.SizeChanged += (_, _) => UpdateResponsiveNavigation();
             Root.Loaded += OnRootLoaded;
             Nav.Loaded += (_, _) => _navigationBinder?.ReapplySelection();
+            // The window is discarded on close and rebuilt on the next tray open, so the binder has to let
+            // go of the static settings event or every reopen leaks one.
+            Closed += (_, _) =>
+            {
+                _navigationBinder?.Dispose();
+                _navigationBinder = null;
+            };
             UpdateResponsiveNavigation();
         }
 

--- a/src/TaskbarQuota.App/Services/PinBudgetService.cs
+++ b/src/TaskbarQuota.App/Services/PinBudgetService.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TaskbarQuota.Controls;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.Services;
+
+/// <summary>
+/// Prices pinned providers against a fixed budget so the taskbar row can never be asked to show more than
+/// it can hold.
+///
+/// A flat "three providers" cap is the wrong unit: a provider showing four rows is twice as wide as one
+/// showing two, because rows pack two to a column group. So providers are weighted instead — a short one
+/// (one or two rows) costs <see cref="ShortSlots"/>, a long one (three or more) costs
+/// <see cref="LongSlots"/> — and the user spends a budget of <see cref="TotalSlots"/> however they like:
+/// three short, two long, or a long plus two short.
+/// </summary>
+public static class PinBudgetService
+{
+    /// <summary>Total weight a user may have pinned at once.</summary>
+    public const int TotalSlots = 5;
+    /// <summary>Cost of a provider rendering one or two rows — a single column group.</summary>
+    public const int ShortSlots = 1;
+    /// <summary>Cost of a provider rendering three or more rows — two column groups.</summary>
+    public const int LongSlots = 2;
+    /// <summary>Rows at which a provider stops being "short".</summary>
+    public const int LongRowThreshold = 3;
+
+    /// <summary>Raised after the budget auto-unpins providers, so the UI can refresh and explain.</summary>
+    public static event Action<IReadOnlyList<ProviderId>>? ProvidersUnpinned;
+
+    // Tile chrome, mirroring TaskBarWidget: 4px of margin per tile and a 7px divider between neighbours.
+    private const int TileMarginLogicalPx = 4;
+    private const int TileSeparatorLogicalPx = 7;
+    // A tile is an icon plus one column group per two rows. Calibrated from measured tiles: a one-group
+    // tile lands around 225px and a two-group tile around 405px.
+    private const int TileBaseLogicalPx = 45;
+    private const int TileGroupLogicalPx = 180;
+    private const int RowsPerGroup = 2;
+    // Small slack so a tile is never admitted flush against a shell element. Modest because the widths are
+    // the widget's own measurements, not a model — an estimate is only used for a provider that has never
+    // been rendered.
+    private const int FitSafetyMarginLogicalPx = 6;
+
+    /// <summary>What one provider costs, from the number of rows its tile would render.</summary>
+    public static int SlotCost(ProviderId provider)
+        => RowCount(provider) >= LongRowThreshold ? LongSlots : ShortSlots;
+
+    /// <summary>Width a provider's tile takes, from the column groups its rows occupy.</summary>
+    internal static int EstimateTileWidth(int rows)
+        => TileBaseLogicalPx + (((Math.Max(1, rows) + RowsPerGroup - 1) / RowsPerGroup) * TileGroupLogicalPx);
+
+    /// <summary>Width a whole row of tiles takes, including margins and dividers.</summary>
+    internal static int RowWidth(IReadOnlyList<int> tileWidths)
+    {
+        int total = 0;
+        for (int i = 0; i < tileWidths.Count; i++)
+            total += tileWidths[i] + TileMarginLogicalPx + (i > 0 ? TileSeparatorLogicalPx : 0);
+        return total;
+    }
+
+    /// <summary>Width a whole row takes, given each tile's row count. Modelled, for tests and estimates.</summary>
+    internal static int EstimateRowWidth(IReadOnlyList<int> rowCounts)
+        => RowWidth(rowCounts.Select(EstimateTileWidth).ToList());
+
+    /// <summary>
+    /// A provider's tile width: what the widget actually measured for it, or the model when it has never
+    /// been rendered.
+    /// </summary>
+    private static int TileWidth(ProviderId provider)
+        => Taskbar.TaskbarSpace.TryGetTileWidth(provider, out int measured)
+            ? measured
+            : EstimateTileWidth(RowCount(provider));
+
+    /// <summary>
+    /// Whether a set of providers fits the taskbar space actually measured. Returns true when nothing has
+    /// been measured yet, so a cold start falls back to the weight budget rather than refusing every pin.
+    /// </summary>
+    /// <remarks>
+    /// Only the PINNED set is judged. Reserving extra room for the active tool's tile on top looks prudent
+    /// but is wrong: when the provider being pinned is the one in use there is no extra tile at all, and
+    /// the reserve then refuses pins that fit perfectly well. The case it was guarding — a third, unpinned
+    /// tool in the foreground — is handled where it can be measured exactly, by the widget dropping that
+    /// courtesy tile rather than overflowing.
+    /// </remarks>
+    internal static bool FitsTaskbar(IReadOnlyList<int> rowCounts, int availableWidth)
+        => FitsWidth(rowCounts.Select(EstimateTileWidth).ToList(), availableWidth);
+
+    private static bool FitsWidth(IReadOnlyList<int> tileWidths, int availableWidth)
+        => availableWidth <= Taskbar.TaskbarSpace.UnknownWidth
+        || RowWidth(tileWidths) + FitSafetyMarginLogicalPx <= availableWidth;
+
+    /// <summary>Whether these providers' tiles fit, using each one's measured width where known.</summary>
+    private static bool FitsTaskbar(IReadOnlyList<ProviderId> providers, int availableWidth)
+        => FitsWidth(providers.Select(TileWidth).ToList(), availableWidth);
+
+    public static bool IsLong(ProviderId provider) => SlotCost(provider) == LongSlots;
+
+    /// <summary>Budget currently spent, optionally ignoring one provider.</summary>
+    public static int UsedSlots(ProviderId? excluding = null)
+        => PinnedProviders()
+            .Where(p => excluding is not { } skip || p != skip)
+            .Sum(SlotCost);
+
+    /// <summary>Budget left over, treating <paramref name="excluding"/> as not pinned.</summary>
+    public static int RemainingSlots(ProviderId? excluding = null) => TotalSlots - UsedSlots(excluding);
+
+    /// <summary>
+    /// Whether <paramref name="provider"/> can be pinned right now. Fails when the tile cap is reached or
+    /// the provider's weight does not fit the remaining budget; <paramref name="reason"/> explains which,
+    /// for the pin button's tooltip.
+    /// </summary>
+    public static bool CanPin(ProviderId provider, out string reason)
+    {
+        if (WidgetSettingsService.IsProviderPinned(provider))
+        {
+            reason = string.Empty;
+            return true;
+        }
+
+        var pinned = PinnedProviders();
+        string name = ProviderName(provider);
+
+        if (pinned.Count >= UsageCoordinator.MaxWidgetTiles)
+        {
+            reason = $"The taskbar shows at most {UsageCoordinator.MaxWidgetTiles} pinned providers, and you already "
+                + $"have {string.Join(", ", pinned.Select(ProviderName))} pinned. Unpin one of those to make room for {name}.";
+            return false;
+        }
+
+        int cost = SlotCost(provider);
+        int remaining = RemainingSlots();
+        if (cost > remaining)
+        {
+            reason = $"{name} shows {Describe(provider)}, which costs {cost} of the {TotalSlots} pin slots, "
+                + $"and only {remaining} {(remaining == 1 ? "is" : "are")} free. "
+                + $"Turn off a row or two for {name} to make it a short provider, or unpin one of "
+                + $"{string.Join(", ", pinned.Select(ProviderName))}.";
+            return false;
+        }
+
+        // The weight budget is a coarse rule; this is the real one — a tile is never trimmed or reduced, so
+        // a pin that would not fit the measured free span has to be refused rather than rendered badly.
+        var candidate = pinned.Append(provider).ToList();
+        if (!FitsTaskbar(candidate, Taskbar.TaskbarSpace.AvailableLogicalWidth))
+        {
+            reason = $"There isn't room on the taskbar for {name} ({Describe(provider)}) next to "
+                + $"{string.Join(" and ", pinned.Select(p => $"{ProviderName(p)} ({Describe(p)})"))}. "
+                + $"Turn off some rows for {name} or for a pinned provider, unpin one, or set the Windows "
+                + "taskbar to left alignment — that frees up a lot more room.";
+            return false;
+        }
+
+        reason = string.Empty;
+        return true;
+    }
+
+    private static string Describe(ProviderId provider)
+    {
+        int rows = RowCount(provider);
+        return rows == 1 ? "1 row" : $"{rows} rows";
+    }
+
+    /// <summary>
+    /// Brings the pinned set back inside the budget by unpinning the least recently used providers, and
+    /// reports which went. Called after anything that can change a provider's weight — enabling a row on a
+    /// pinned provider promotes it from short to long, and a display setting must never be refused because
+    /// of an unrelated pin.
+    /// </summary>
+    public static IReadOnlyList<ProviderId> EnforceBudget()
+    {
+        var pinned = PinnedProviders();
+        if (pinned.Count == 0)
+            return Array.Empty<ProviderId>();
+
+        // Least recently active first: whatever the user has touched most recently is what they want kept.
+        var recent = UsageCoordinator.Instance.RecentProviders;
+        var recency = new Dictionary<ProviderId, int>();
+        for (int i = 0; i < recent.Count; i++)
+            recency.TryAdd(recent[i], i);
+
+        var order = pinned
+            .OrderByDescending(p => recency.TryGetValue(p, out int index) ? index : int.MaxValue)
+            .ToList();
+
+        var dropped = SelectDrops(
+                order.Select(p => (p, SlotCost(p))).ToList(),
+                TotalSlots,
+                UsageCoordinator.MaxWidgetTiles)
+            .ToList();
+
+        // Weight alone can pass while the row still overflows the bar — a provider that grew a third row
+        // both costs more slots AND takes another column group. Keep dropping until it genuinely fits,
+        // because there is no trimming or glyph left to absorb the overflow.
+        var keeping = order.Where(p => !dropped.Contains(p)).ToList();
+        foreach (var provider in order)
+        {
+            if (FitsTaskbar(keeping, Taskbar.TaskbarSpace.AvailableLogicalWidth))
+                break;
+
+            if (!keeping.Remove(provider))
+                continue;
+
+            dropped.Add(provider);
+        }
+
+        foreach (var provider in dropped)
+            WidgetSettingsService.SetProviderPinnedSilent(provider, false);
+
+        if (dropped.Count > 0)
+        {
+            WidgetSettingsService.SaveProviderPinsAndNotify();
+            ProvidersUnpinned?.Invoke(dropped);
+        }
+
+        return dropped;
+    }
+
+    /// <summary>Weight of a provider showing <paramref name="rows"/> rows.</summary>
+    internal static int SlotCostForRows(int rows) => rows >= LongRowThreshold ? LongSlots : ShortSlots;
+
+    /// <summary>
+    /// Which pinned providers to drop so the set fits both the weight budget and the tile cap. Pure so the
+    /// arithmetic can be tested without a taskbar or cached usage.
+    /// </summary>
+    /// <param name="pinned">Pinned providers with their weights, least worth keeping FIRST.</param>
+    internal static IReadOnlyList<ProviderId> SelectDrops(
+        IReadOnlyList<(ProviderId Provider, int Cost)> pinned,
+        int budget,
+        int maxCount)
+    {
+        int used = pinned.Sum(p => p.Cost);
+        int count = pinned.Count;
+        var dropped = new List<ProviderId>();
+
+        foreach (var (provider, cost) in pinned)
+        {
+            if (used <= budget && count <= maxCount)
+                break;
+
+            used -= cost;
+            count--;
+            dropped.Add(provider);
+        }
+
+        return dropped;
+    }
+
+    private static List<ProviderId> PinnedProviders()
+        => Enum.GetValues<ProviderId>().Where(WidgetSettingsService.IsProviderPinned).ToList();
+
+    /// <summary>
+    /// Rows a provider's tile would render. Uses its cached usage when there is any, because the enabled
+    /// row settings alone overstate it badly — most providers have several rows switched on that their
+    /// plan never reports.
+    /// </summary>
+    private static int RowCount(ProviderId provider)
+    {
+        var service = UsageCoordinator.Instance.Service;
+        if (service.TryGetCached(provider, out var cached))
+            return WidgetSummary.CountRenderedRows(cached);
+        if (service.TryGetLastSuccessfulLiveResult(provider, out var lastSuccess))
+            return WidgetSummary.CountRenderedRows(lastSuccess);
+        return WidgetSummary.AssumedRowCount;
+    }
+
+    private static string ProviderName(ProviderId provider)
+        => UsageCoordinator.Instance.Service.Get(provider)?.DisplayName ?? provider.ToString();
+}

--- a/src/TaskbarQuota.App/Services/PinBudgetService.cs
+++ b/src/TaskbarQuota.App/Services/PinBudgetService.cs
@@ -147,8 +147,21 @@ public static class PinBudgetService
     /// pinned provider can add a whole column group, and a display setting must never be refused because
     /// of an unrelated pin.
     /// </summary>
-    public static IReadOnlyList<ProviderId> EnforceBudget()
+    /// <param name="notify">
+    /// False when the caller raises <see cref="WidgetSettingsService.Changed"/> itself straight after, so
+    /// one user action does not rebuild the nav badges, the flyout strip and every widget tile twice.
+    /// </param>
+    public static IReadOnlyList<ProviderId> EnforceBudget(bool notify = true)
     {
+        // The 5s widget health tick calls this forever. Nothing can need unpinning unless the pinned set,
+        // one of its tile widths, or the free span has moved since the last run, and all three are already
+        // ints — so the common case costs a hash instead of a sort and three list allocations.
+        int key = BudgetKey();
+        if (key == _lastBudgetKey)
+            return Array.Empty<ProviderId>();
+
+        _lastBudgetKey = key;
+
         var pinned = PinnedProviders();
         if (pinned.Count == 0)
             return Array.Empty<ProviderId>();
@@ -182,11 +195,36 @@ public static class PinBudgetService
 
         if (dropped.Count > 0)
         {
-            WidgetSettingsService.SaveProviderPinsAndNotify();
+            // The set just changed, so the key computed above is stale. Recompute rather than clear, or the
+            // next tick redoes the whole sort to reach the same answer.
+            _lastBudgetKey = BudgetKey();
+            if (notify)
+                WidgetSettingsService.SaveProviderPinsAndNotify();
+            else
+                WidgetSettingsService.SaveProviderPins();
             ProvidersUnpinned?.Invoke(dropped);
         }
 
         return dropped;
+    }
+
+    // Guards the early-out above. Covers everything the decision reads: the free span, which providers are
+    // pinned, and each one's measured tile width (which changes when the user toggles a row).
+    private static int _lastBudgetKey = -1;
+
+    private static int BudgetKey()
+    {
+        var hash = new HashCode();
+        hash.Add(Taskbar.TaskbarSpace.AvailableLogicalWidth);
+        foreach (var provider in AllProviders)
+        {
+            if (!WidgetSettingsService.IsProviderPinned(provider))
+                continue;
+
+            hash.Add(provider);
+            hash.Add(Taskbar.TaskbarSpace.TryGetTileWidth(provider, out int width) ? width : 0);
+        }
+        return hash.ToHashCode();
     }
 
     /// <summary>
@@ -217,8 +255,19 @@ public static class PinBudgetService
         return dropped;
     }
 
+    // Enum.GetValues allocates a fresh array on every call, and this type is on the 5s tick path.
+    private static readonly ProviderId[] AllProviders = Enum.GetValues<ProviderId>();
+
     private static List<ProviderId> PinnedProviders()
-        => Enum.GetValues<ProviderId>().Where(WidgetSettingsService.IsProviderPinned).ToList();
+    {
+        var pinned = new List<ProviderId>();
+        foreach (var provider in AllProviders)
+        {
+            if (WidgetSettingsService.IsProviderPinned(provider))
+                pinned.Add(provider);
+        }
+        return pinned;
+    }
 
     /// <summary>
     /// Rows a provider's tile would render. Uses its cached usage when there is any, because the enabled

--- a/src/TaskbarQuota.App/Services/PinBudgetService.cs
+++ b/src/TaskbarQuota.App/Services/PinBudgetService.cs
@@ -38,10 +38,12 @@ public static class PinBudgetService
     private const int TileBaseLogicalPx = 45;
     private const int TileGroupLogicalPx = 180;
     private const int RowsPerGroup = 2;
-    // Small slack so a tile is never admitted flush against a shell element. Modest because the widths are
-    // the widget's own measurements, not a model — an estimate is only used for a provider that has never
-    // been rendered.
-    private const int FitSafetyMarginLogicalPx = 6;
+    // Slack for a set containing a provider that has never been rendered, whose width can only be modelled.
+    private const int EstimatedFitMarginLogicalPx = 12;
+    // No slack once every width is the widget's own measurement. A margin here refuses layouts that
+    // provably fit — the widget was rendering three tiles at 702px of a 706px span while the pin for the
+    // third was being rejected at 702 + 6 > 706. There is no model error left to absorb.
+    private const int MeasuredFitMarginLogicalPx = 0;
 
     /// <summary>What one provider costs, from the number of rows its tile would render.</summary>
     public static int SlotCost(ProviderId provider)
@@ -85,15 +87,21 @@ public static class PinBudgetService
     /// courtesy tile rather than overflowing.
     /// </remarks>
     internal static bool FitsTaskbar(IReadOnlyList<int> rowCounts, int availableWidth)
-        => FitsWidth(rowCounts.Select(EstimateTileWidth).ToList(), availableWidth);
+        => FitsWidth(rowCounts.Select(EstimateTileWidth).ToList(), availableWidth, EstimatedFitMarginLogicalPx);
 
-    private static bool FitsWidth(IReadOnlyList<int> tileWidths, int availableWidth)
+    private static bool FitsWidth(IReadOnlyList<int> tileWidths, int availableWidth, int margin)
         => availableWidth <= Taskbar.TaskbarSpace.UnknownWidth
-        || RowWidth(tileWidths) + FitSafetyMarginLogicalPx <= availableWidth;
+        || RowWidth(tileWidths) + margin <= availableWidth;
 
     /// <summary>Whether these providers' tiles fit, using each one's measured width where known.</summary>
     private static bool FitsTaskbar(IReadOnlyList<ProviderId> providers, int availableWidth)
-        => FitsWidth(providers.Select(TileWidth).ToList(), availableWidth);
+    {
+        bool allMeasured = providers.All(p => Taskbar.TaskbarSpace.TryGetTileWidth(p, out _));
+        return FitsWidth(
+            providers.Select(TileWidth).ToList(),
+            availableWidth,
+            allMeasured ? MeasuredFitMarginLogicalPx : EstimatedFitMarginLogicalPx);
+    }
 
     public static bool IsLong(ProviderId provider) => SlotCost(provider) == LongSlots;
 
@@ -122,9 +130,9 @@ public static class PinBudgetService
         var pinned = PinnedProviders();
         string name = ProviderName(provider);
 
-        if (pinned.Count >= UsageCoordinator.MaxWidgetTiles)
+if (pinned.Count >= UsageCoordinator.MaxWidgetTiles)
         {
-            reason = $"The taskbar shows at most {UsageCoordinator.MaxWidgetTiles} pinned providers, and you already "
+            reason = $"The taskbar can show at most {UsageCoordinator.MaxWidgetTiles} providers at once, and you already "
                 + $"have {string.Join(", ", pinned.Select(ProviderName))} pinned. Unpin one of those to make room for {name}.";
             return false;
         }
@@ -145,6 +153,13 @@ public static class PinBudgetService
         var candidate = pinned.Append(provider).ToList();
         if (!FitsTaskbar(candidate, Taskbar.TaskbarSpace.AvailableLogicalWidth))
         {
+            // A refusal the user did not expect is impossible to diagnose from the message alone, since it
+            // turns on measurements they cannot see. Record what the decision was actually made from.
+            Diagnostics.Log.Debug(
+                $"[pin] refused {provider}: tiles=[{string.Join(", ", candidate.Select(p => $"{p}:{TileWidth(p)}{(Taskbar.TaskbarSpace.TryGetTileWidth(p, out _) ? "" : "~")}"))}] "
+                + $"row={RowWidth(candidate.Select(TileWidth).ToList())} "
+                + $"available={Taskbar.TaskbarSpace.AvailableLogicalWidth}");
+
             reason = $"There isn't room on the taskbar for {name} ({Describe(provider)}) next to "
                 + $"{string.Join(" and ", pinned.Select(p => $"{ProviderName(p)} ({Describe(p)})"))}. "
                 + $"Turn off some rows for {name} or for a pinned provider, unpin one, or set the Windows "

--- a/src/TaskbarQuota.App/Services/PinBudgetService.cs
+++ b/src/TaskbarQuota.App/Services/PinBudgetService.cs
@@ -7,26 +7,18 @@ using TaskbarQuota.Usage;
 namespace TaskbarQuota.Services;
 
 /// <summary>
-/// Prices pinned providers against a fixed budget so the taskbar row can never be asked to show more than
-/// it can hold.
+/// Decides whether a provider can be pinned, by the only measure that matters: whether its tile fits the
+/// free space the taskbar actually has.
 ///
-/// A flat "three providers" cap is the wrong unit: a provider showing four rows is twice as wide as one
-/// showing two, because rows pack two to a column group. So providers are weighted instead — a short one
-/// (one or two rows) costs <see cref="ShortSlots"/>, a long one (three or more) costs
-/// <see cref="LongSlots"/> — and the user spends a budget of <see cref="TotalSlots"/> however they like:
-/// three short, two long, or a long plus two short.
+/// A pinned tile is never trimmed or reduced — it renders exactly the rows the user configured — so a set
+/// that does not fit has to be refused up front rather than rendered badly. There is deliberately no
+/// second, abstract allowance on top of this. An earlier weight budget (a provider costing one or two
+/// "slots" out of five) both duplicated this check and contradicted it: three three-row providers come to
+/// 1241px, which fits a left-aligned taskbar comfortably, yet cost six slots and were refused. Measured
+/// space is the rule; anything else is a guess that eventually says no to something that plainly works.
 /// </summary>
 public static class PinBudgetService
 {
-    /// <summary>Total weight a user may have pinned at once.</summary>
-    public const int TotalSlots = 5;
-    /// <summary>Cost of a provider rendering one or two rows — a single column group.</summary>
-    public const int ShortSlots = 1;
-    /// <summary>Cost of a provider rendering three or more rows — two column groups.</summary>
-    public const int LongSlots = 2;
-    /// <summary>Rows at which a provider stops being "short".</summary>
-    public const int LongRowThreshold = 3;
-
     /// <summary>Raised after the budget auto-unpins providers, so the UI can refresh and explain.</summary>
     public static event Action<IReadOnlyList<ProviderId>>? ProvidersUnpinned;
 
@@ -44,10 +36,6 @@ public static class PinBudgetService
     // provably fit — the widget was rendering three tiles at 702px of a 706px span while the pin for the
     // third was being rejected at 702 + 6 > 706. There is no model error left to absorb.
     private const int MeasuredFitMarginLogicalPx = 0;
-
-    /// <summary>What one provider costs, from the number of rows its tile would render.</summary>
-    public static int SlotCost(ProviderId provider)
-        => RowCount(provider) >= LongRowThreshold ? LongSlots : ShortSlots;
 
     /// <summary>Width a provider's tile takes, from the column groups its rows occupy.</summary>
     internal static int EstimateTileWidth(int rows)
@@ -76,15 +64,16 @@ public static class PinBudgetService
             : EstimateTileWidth(RowCount(provider));
 
     /// <summary>
-    /// Whether a set of providers fits the taskbar space actually measured. Returns true when nothing has
-    /// been measured yet, so a cold start falls back to the weight budget rather than refusing every pin.
+    /// Whether tiles of these row counts fit. Returns true when nothing has been measured yet — for the
+    /// second or two before a widget reports a span, the tile cap is the only bound, and refusing every
+    /// pin in that window would look broken.
     /// </summary>
     /// <remarks>
     /// Only the PINNED set is judged. Reserving extra room for the active tool's tile on top looks prudent
     /// but is wrong: when the provider being pinned is the one in use there is no extra tile at all, and
     /// the reserve then refuses pins that fit perfectly well. The case it was guarding — a third, unpinned
-    /// tool in the foreground — is handled where it can be measured exactly, by the widget dropping that
-    /// courtesy tile rather than overflowing.
+    /// tool in the foreground — is handled where it can be measured exactly, by the widget holding that
+    /// tile back rather than overflowing.
     /// </remarks>
     internal static bool FitsTaskbar(IReadOnlyList<int> rowCounts, int availableWidth)
         => FitsWidth(rowCounts.Select(EstimateTileWidth).ToList(), availableWidth, EstimatedFitMarginLogicalPx);
@@ -103,21 +92,9 @@ public static class PinBudgetService
             allMeasured ? MeasuredFitMarginLogicalPx : EstimatedFitMarginLogicalPx);
     }
 
-    public static bool IsLong(ProviderId provider) => SlotCost(provider) == LongSlots;
-
-    /// <summary>Budget currently spent, optionally ignoring one provider.</summary>
-    public static int UsedSlots(ProviderId? excluding = null)
-        => PinnedProviders()
-            .Where(p => excluding is not { } skip || p != skip)
-            .Sum(SlotCost);
-
-    /// <summary>Budget left over, treating <paramref name="excluding"/> as not pinned.</summary>
-    public static int RemainingSlots(ProviderId? excluding = null) => TotalSlots - UsedSlots(excluding);
-
     /// <summary>
-    /// Whether <paramref name="provider"/> can be pinned right now. Fails when the tile cap is reached or
-    /// the provider's weight does not fit the remaining budget; <paramref name="reason"/> explains which,
-    /// for the pin button's tooltip.
+    /// Whether <paramref name="provider"/> can be pinned right now: only the tile cap and the measured
+    /// taskbar space can refuse it. <paramref name="reason"/> says which, and what to change.
     /// </summary>
     public static bool CanPin(ProviderId provider, out string reason)
     {
@@ -130,26 +107,13 @@ public static class PinBudgetService
         var pinned = PinnedProviders();
         string name = ProviderName(provider);
 
-if (pinned.Count >= UsageCoordinator.MaxWidgetTiles)
+        if (pinned.Count >= UsageCoordinator.MaxWidgetTiles)
         {
             reason = $"The taskbar can show at most {UsageCoordinator.MaxWidgetTiles} providers at once, and you already "
                 + $"have {string.Join(", ", pinned.Select(ProviderName))} pinned. Unpin one of those to make room for {name}.";
             return false;
         }
 
-        int cost = SlotCost(provider);
-        int remaining = RemainingSlots();
-        if (cost > remaining)
-        {
-            reason = $"{name} shows {Describe(provider)}, which costs {cost} of the {TotalSlots} pin slots, "
-                + $"and only {remaining} {(remaining == 1 ? "is" : "are")} free. "
-                + $"Turn off a row or two for {name} to make it a short provider, or unpin one of "
-                + $"{string.Join(", ", pinned.Select(ProviderName))}.";
-            return false;
-        }
-
-        // The weight budget is a coarse rule; this is the real one — a tile is never trimmed or reduced, so
-        // a pin that would not fit the measured free span has to be refused rather than rendered badly.
         var candidate = pinned.Append(provider).ToList();
         if (!FitsTaskbar(candidate, Taskbar.TaskbarSpace.AvailableLogicalWidth))
         {
@@ -178,9 +142,9 @@ if (pinned.Count >= UsageCoordinator.MaxWidgetTiles)
     }
 
     /// <summary>
-    /// Brings the pinned set back inside the budget by unpinning the least recently used providers, and
-    /// reports which went. Called after anything that can change a provider's weight — enabling a row on a
-    /// pinned provider promotes it from short to long, and a display setting must never be refused because
+    /// Brings the pinned set back inside the taskbar by unpinning the least recently used providers, and
+    /// reports which went. Called after anything that can change a tile's width — enabling a row on a
+    /// pinned provider can add a whole column group, and a display setting must never be refused because
     /// of an unrelated pin.
     /// </summary>
     public static IReadOnlyList<ProviderId> EnforceBudget()
@@ -199,24 +163,17 @@ if (pinned.Count >= UsageCoordinator.MaxWidgetTiles)
             .OrderByDescending(p => recency.TryGetValue(p, out int index) ? index : int.MaxValue)
             .ToList();
 
-        var dropped = SelectDrops(
-                order.Select(p => (p, SlotCost(p))).ToList(),
-                TotalSlots,
-                UsageCoordinator.MaxWidgetTiles)
-            .ToList();
-
-        // Weight alone can pass while the row still overflows the bar — a provider that grew a third row
-        // both costs more slots AND takes another column group. Keep dropping until it genuinely fits,
-        // because there is no trimming or glyph left to absorb the overflow.
-        var keeping = order.Where(p => !dropped.Contains(p)).ToList();
+        var keeping = new List<ProviderId>(order);
+        var dropped = new List<ProviderId>();
         foreach (var provider in order)
         {
-            if (FitsTaskbar(keeping, Taskbar.TaskbarSpace.AvailableLogicalWidth))
+            if (keeping.Count <= UsageCoordinator.MaxWidgetTiles
+                && FitsTaskbar(keeping, Taskbar.TaskbarSpace.AvailableLogicalWidth))
+            {
                 break;
+            }
 
-            if (!keeping.Remove(provider))
-                continue;
-
+            keeping.Remove(provider);
             dropped.Add(provider);
         }
 
@@ -232,31 +189,29 @@ if (pinned.Count >= UsageCoordinator.MaxWidgetTiles)
         return dropped;
     }
 
-    /// <summary>Weight of a provider showing <paramref name="rows"/> rows.</summary>
-    internal static int SlotCostForRows(int rows) => rows >= LongRowThreshold ? LongSlots : ShortSlots;
-
     /// <summary>
-    /// Which pinned providers to drop so the set fits both the weight budget and the tile cap. Pure so the
-    /// arithmetic can be tested without a taskbar or cached usage.
+    /// Which pinned providers to drop so the rest fit <paramref name="availableWidth"/> and the tile cap.
+    /// Pure so the ordering can be tested without a taskbar or cached usage.
     /// </summary>
-    /// <param name="pinned">Pinned providers with their weights, least worth keeping FIRST.</param>
+    /// <param name="pinned">Pinned providers with their tile widths, least worth keeping FIRST.</param>
     internal static IReadOnlyList<ProviderId> SelectDrops(
-        IReadOnlyList<(ProviderId Provider, int Cost)> pinned,
-        int budget,
+        IReadOnlyList<(ProviderId Provider, int Width)> pinned,
+        int availableWidth,
         int maxCount)
     {
-        int used = pinned.Sum(p => p.Cost);
-        int count = pinned.Count;
+        var keeping = pinned.ToList();
         var dropped = new List<ProviderId>();
 
-        foreach (var (provider, cost) in pinned)
+        foreach (var entry in pinned)
         {
-            if (used <= budget && count <= maxCount)
+            if (keeping.Count <= maxCount
+                && RowWidth(keeping.Select(k => k.Width).ToList()) <= availableWidth)
+            {
                 break;
+            }
 
-            used -= cost;
-            count--;
-            dropped.Add(provider);
+            keeping.Remove(entry);
+            dropped.Add(entry.Provider);
         }
 
         return dropped;

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -238,7 +238,11 @@ public static class WidgetSettingsService
         // Enabling a row can promote a pinned provider from short to long and push the pinned set over
         // budget. The row toggle always wins — it is this provider's own display setting — so the budget
         // is rebalanced by dropping the least recently used pin instead of refusing the change.
-        Services.PinBudgetService.EnforceBudget();
+        //
+        // Silent, because the single Changed below already covers both edits. Letting the rebalance raise
+        // its own notification meant one row toggle rebuilt the nav badges, the flyout strip and every
+        // widget tile twice.
+        Services.PinBudgetService.EnforceBudget(notify: false);
         Changed?.Invoke(null, EventArgs.Empty);
     }
 
@@ -541,7 +545,7 @@ public static class WidgetSettingsService
         }
     }
 
-    private static void SaveProviderPins()
+    internal static void SaveProviderPins()
     {
         try
         {

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -48,6 +48,9 @@ public static class WidgetSettingsService
     private static readonly string WidgetProvidersPath =
         Path.Combine(AppStorage.AppDataDirectory, "widget-providers.json");
 
+    private static readonly string WidgetPinsPath =
+        Path.Combine(AppStorage.AppDataDirectory, "widget-pins.json");
+
     private static readonly string DashboardProvidersPath =
         Path.Combine(AppStorage.AppDataDirectory, "dashboard-providers.json");
 
@@ -57,6 +60,7 @@ public static class WidgetSettingsService
     private static readonly Dictionary<string, bool> RowVisibility = LoadRowVisibility();
     private static readonly Dictionary<string, bool> ProviderVisibility = LoadProviderVisibility();
     private static readonly Dictionary<string, bool> DashboardProviderVisibility = LoadDashboardProviderVisibility();
+    private static readonly Dictionary<string, bool> ProviderPins = LoadProviderPins();
 
     public static WidgetDisplayMode Current { get; private set; } = LoadWidgetDisplayMode();
     public static PercentageDisplayMode CurrentPercentageMode { get; private set; } = LoadPercentageDisplayMode();
@@ -120,11 +124,49 @@ public static class WidgetSettingsService
 
     public static void SetProviderVisible(ProviderId provider, bool visible)
     {
-        if (!SetProviderVisibleSilent(provider, visible))
+        bool visibilityChanged = SetProviderVisibleSilent(provider, visible);
+        // Hiding a provider from the widget drops its pin too: a pin that can never render is a state the
+        // user can't see, and it would silently resurrect the tile when they re-enable the provider.
+        bool pinChanged = !visible && SetProviderPinnedSilent(provider, false);
+        if (!visibilityChanged && !pinChanged)
             return;
 
-        SaveProviderVisibility();
+        if (visibilityChanged)
+            SaveProviderVisibility();
+        if (pinChanged)
+            SaveProviderPins();
         Changed?.Invoke(null, EventArgs.Empty);
+    }
+
+    public static bool IsProviderPinned(ProviderId provider)
+        => ProviderPins.TryGetValue(provider.ToString(), out bool pinned) && pinned;
+
+    /// <summary>
+    /// Pins a provider so the taskbar widget keeps a tile for it regardless of which tool is active.
+    /// Pinning implies widget-visible — a provider hidden from the widget can't hold a permanent tile —
+    /// so turning a pin on also turns the provider's widget visibility on. Unpinning leaves it alone.
+    /// </summary>
+    public static void SetProviderPinned(ProviderId provider, bool pinned)
+    {
+        bool pinChanged = SetProviderPinnedSilent(provider, pinned);
+        bool visibilityChanged = pinned && SetProviderVisibleSilent(provider, true);
+        if (!pinChanged && !visibilityChanged)
+            return;
+
+        if (pinChanged)
+            SaveProviderPins();
+        if (visibilityChanged)
+            SaveProviderVisibility();
+        Changed?.Invoke(null, EventArgs.Empty);
+    }
+
+    internal static bool SetProviderPinnedSilent(ProviderId provider, bool pinned)
+    {
+        if (IsProviderPinned(provider) == pinned)
+            return false;
+
+        ProviderPins[provider.ToString()] = pinned;
+        return true;
     }
 
     public static void SetProviderDashboardVisible(ProviderId provider, bool visible)
@@ -153,6 +195,12 @@ public static class WidgetSettingsService
 
         DashboardProviderVisibility[provider.ToString()] = visible;
         return true;
+    }
+
+    internal static void SaveProviderPinsAndNotify()
+    {
+        SaveProviderPins();
+        Changed?.Invoke(null, EventArgs.Empty);
     }
 
     internal static void SaveProviderVisibilityAndNotify()
@@ -187,6 +235,10 @@ public static class WidgetSettingsService
 
         RowVisibility[key] = visible;
         SaveRowVisibility();
+        // Enabling a row can promote a pinned provider from short to long and push the pinned set over
+        // budget. The row toggle always wins — it is this provider's own display setting — so the budget
+        // is rebalanced by dropping the least recently used pin instead of refusing the change.
+        Services.PinBudgetService.EnforceBudget();
         Changed?.Invoke(null, EventArgs.Empty);
     }
 
@@ -235,7 +287,7 @@ public static class WidgetSettingsService
         var parts = Enum.GetValues<ProviderId>()
             .OrderBy(provider => provider.ToString())
             .Select(provider =>
-                $"{provider}:{(IsProviderVisible(provider) ? 1 : 0)}:{(IsProviderDashboardVisible(provider) ? 1 : 0)}");
+                $"{provider}:{(IsProviderVisible(provider) ? 1 : 0)}:{(IsProviderDashboardVisible(provider) ? 1 : 0)}:{(IsProviderPinned(provider) ? 1 : 0)}");
         return string.Join(",", parts);
     }
 
@@ -256,6 +308,12 @@ public static class WidgetSettingsService
 
     internal static void ResetDashboardProviderVisibilityForTesting()
         => DashboardProviderVisibility.Clear();
+
+    internal static void SetProviderPinnedForTesting(ProviderId provider, bool pinned)
+        => ProviderPins[provider.ToString()] = pinned;
+
+    internal static void ResetProviderPinsForTesting()
+        => ProviderPins.Clear();
 
     public static IReadOnlyList<WidgetRowOption> RowOptions(ProviderId provider)
         => provider switch
@@ -460,6 +518,35 @@ public static class WidgetSettingsService
         {
             Directory.CreateDirectory(Path.GetDirectoryName(WidgetProvidersPath)!);
             File.WriteAllText(WidgetProvidersPath, JsonSerializer.Serialize(ProviderVisibility, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch
+        {
+            // Best effort. The widget can still use the in-memory value for this run.
+        }
+    }
+
+    private static Dictionary<string, bool> LoadProviderPins()
+    {
+        try
+        {
+            if (!File.Exists(WidgetPinsPath))
+                return new Dictionary<string, bool>();
+
+            var loaded = JsonSerializer.Deserialize<Dictionary<string, bool>>(File.ReadAllText(WidgetPinsPath));
+            return loaded ?? new Dictionary<string, bool>();
+        }
+        catch
+        {
+            return new Dictionary<string, bool>();
+        }
+    }
+
+    private static void SaveProviderPins()
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(WidgetPinsPath)!);
+            File.WriteAllText(WidgetPinsPath, JsonSerializer.Serialize(ProviderPins, new JsonSerializerOptions { WriteIndented = true }));
         }
         catch
         {

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -17,6 +17,9 @@ namespace TaskbarQuota.Taskbar
         private static TrayIconWithContextMenu? _trayIcon;
         private static System.Drawing.Icon? _trayIconSource;
         private static readonly Dictionary<IntPtr, TaskBarWidget> Widgets = new();
+        // Reused snapshot of Widgets.Values, so iterating it while a callback may mutate the dictionary
+        // doesn't allocate. Only valid until the next SnapshotWidgets call, and only used on the UI thread.
+        private static readonly List<TaskBarWidget> _widgetBuffer = new();
         private static FlyoutWindow? _flyout;
         private static DispatcherQueue? _dispatcher;
         private static Action? _showMainWindow;
@@ -101,10 +104,15 @@ namespace TaskbarQuota.Taskbar
                 RefreshPinnedTiles();
                 // The free span is only known once a widget has measured it, so a set pinned before that
                 // (or pinned when the bar was emptier) is reconciled here rather than rendering badly.
+                // EnforceBudget early-outs when neither the span nor the pinned set has moved, which is
+                // every tick but the few that follow a real change.
                 Services.PinBudgetService.EnforceBudget();
                 // Re-run the tile-fit math against the gap the last position pass measured, so tiles that
                 // were trimmed off a crowded taskbar come back once there is room for them again.
-                foreach (var widget in Widgets.Values.ToArray())
+                // Iterated over the reused buffer rather than Widgets.Values.ToArray(), which allocated an
+                // array every five seconds for the life of the process.
+                SnapshotWidgets();
+                foreach (var widget in _widgetBuffer)
                 {
                     if (widget.IsAlive)
                         widget.RefreshLayout();
@@ -309,7 +317,9 @@ namespace TaskbarQuota.Taskbar
             var providers = coordinator.WidgetDisplayProviders;
             bool isDisplayed = providers.Contains(result.Id);
 
-            foreach (var widget in Widgets.Values.ToArray())
+            // Reused buffer: this runs on every usage publish, so a fresh array per publish was pure waste.
+            SnapshotWidgets();
+            foreach (var widget in _widgetBuffer)
             {
                 if (!widget.IsAlive)
                     continue;
@@ -324,6 +334,19 @@ namespace TaskbarQuota.Taskbar
                 widget.ApplyResult(result);
                 LogWidgetApply(result.Id, "state");
             }
+        }
+
+        /// <summary>
+        /// Refills <see cref="_widgetBuffer"/> from the live dictionary. Callers iterate the buffer rather
+        /// than the dictionary because a widget callback can remove an entry mid-loop; the buffer replaces
+        /// the defensive copy that the hot paths used to allocate per pass. UI thread only, and the buffer
+        /// stays valid only until the next call.
+        /// </summary>
+        private static void SnapshotWidgets()
+        {
+            _widgetBuffer.Clear();
+            foreach (var widget in Widgets.Values)
+                _widgetBuffer.Add(widget);
         }
 
         private static void LogWidgetApply(ProviderId provider, string source)

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -95,7 +95,21 @@ namespace TaskbarQuota.Taskbar
                 return;
 
             _widgetHealthTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
-            _widgetHealthTimer.Tick += (_, _) => EnsureWidgets();
+            _widgetHealthTimer.Tick += (_, _) =>
+            {
+                EnsureWidgets();
+                RefreshPinnedTiles();
+                // The free span is only known once a widget has measured it, so a set pinned before that
+                // (or pinned when the bar was emptier) is reconciled here rather than rendering badly.
+                Services.PinBudgetService.EnforceBudget();
+                // Re-run the tile-fit math against the gap the last position pass measured, so tiles that
+                // were trimmed off a crowded taskbar come back once there is room for them again.
+                foreach (var widget in Widgets.Values.ToArray())
+                {
+                    if (widget.IsAlive)
+                        widget.RefreshLayout();
+                }
+            };
             _widgetHealthTimer.Start();
         }
 
@@ -154,8 +168,8 @@ namespace TaskbarQuota.Taskbar
                     if (sender is TaskBarWidget destroyedWidget)
                         _dispatcher?.TryEnqueue(DispatcherQueuePriority.High, () => OnWidgetDestroying(destroyedWidget));
                 };
-                if (widget.Summary is { } summary)
-                    summary.Clicked += () => _dispatcher?.TryEnqueue(() => ToggleFlyout(widget));
+                widget.HydrateProvider = provider => HydrateResult(UsageCoordinator.Instance, provider);
+                widget.Clicked += () => _dispatcher?.TryEnqueue(() => ToggleFlyout(widget));
                 Widgets[target.Handle] = widget;
                 SyncWidgetState(widget);
                 PrewarmFlyout();
@@ -189,44 +203,69 @@ namespace TaskbarQuota.Taskbar
 
         private static void SyncWidgetState(TaskBarWidget widget)
         {
-            if (!widget.IsAlive || widget.Summary is not { } summary)
+            if (!widget.IsAlive)
                 return;
 
             var coordinator = UsageCoordinator.Instance;
-            var target = coordinator.WidgetDisplayProvider;
-            bool shouldShowWidget = coordinator.IsActiveToolPresent && target is not null;
-            widget.SetVisible(shouldShowWidget);
+            var providers = coordinator.WidgetDisplayProviders;
 
-            // No enabled+available provider -> hide the native host instead of leaving a transparent
-            // taskbar child window over the notification area (#10).
-            if (target is not { } targetProvider)
-            {
-                summary.SetActiveToolVisible(false);
+            // No provider to show -> hide the native host instead of leaving a transparent taskbar child
+            // window over the notification area (#10).
+            widget.SetVisible(providers.Count > 0);
+            widget.SetDisplayProviders(providers, coordinator.ActiveProvider);
+            if (providers.Count == 0)
                 return;
-            }
 
-            UsageResult? toApply = coordinator.LastState is { } last && last.Id == targetProvider
-                ? last
-                : coordinator.Service.TryGetCached(targetProvider, out var cached)
-                    ? cached
-                    : coordinator.Service.TryGetLastSuccessfulLiveResult(targetProvider, out var lastSuccess)
-                        ? lastSuccess
-                        : coordinator.Service.Get(targetProvider) is { } usageProvider
-                            ? UsageResult.Pending(targetProvider, usageProvider, "Loading...")
-                            : null;
-
-            if (toApply is { } result)
+            bool needsFetch = false;
+            foreach (var provider in providers)
             {
-                summary.Apply(result, force: true);
-                LogWidgetApply(result.Id, "sync");
+                var toApply = HydrateResult(coordinator, provider);
+                if (toApply is { } result)
+                {
+                    widget.ApplyResult(result, force: true);
+                    LogWidgetApply(result.Id, "sync");
+                }
+
+                // Hydrating from a placeholder/failed snapshot leaves the tile showing a non-value while
+                // the flyout fetches its own data. Kick a fetch so the widget resolves on its own (#21).
+                if (toApply is null or { Ok: false })
+                    needsFetch = true;
             }
 
-            summary.SetActiveToolVisible(shouldShowWidget);
-
-            // Hydrating from a placeholder/failed snapshot leaves the widget showing a non-value while
-            // the flyout fetches its own data. Kick a fetch so the widget resolves on its own (#21).
-            if (toApply is null or { Ok: false })
+            if (needsFetch)
                 _ = coordinator.TickAsync(force: true);
+        }
+
+        /// <summary>
+        /// Best snapshot available to seed a tile: the last active publish, then either cache tier, then a
+        /// Pending placeholder. Null only when the provider is unknown to the usage service.
+        /// </summary>
+        private static UsageResult? HydrateResult(UsageCoordinator coordinator, ProviderId provider)
+        {
+            if (coordinator.LastState is { } last && last.Id == provider)
+                return last;
+            if (coordinator.Service.TryGetCached(provider, out var cached))
+                return cached;
+            if (coordinator.Service.TryGetLastSuccessfulLiveResult(provider, out var lastSuccess))
+                return lastSuccess;
+            if (coordinator.Service.Get(provider) is { } usageProvider)
+                return UsageResult.Pending(provider, usageProvider, "Loading...");
+            return null;
+        }
+
+        /// <summary>
+        /// Keeps pinned (non-active) tiles fresh. The coordinator's tick only fetches the active provider,
+        /// so a pinned tile would otherwise freeze on its boot snapshot. The fetch is cache-TTL gated, so
+        /// on most ticks this is a cache hit.
+        /// </summary>
+        private static void RefreshPinnedTiles()
+        {
+            var coordinator = UsageCoordinator.Instance;
+            foreach (var provider in coordinator.WidgetDisplayProviders)
+            {
+                if (provider != coordinator.ActiveProvider)
+                    _ = coordinator.RefreshWidgetProviderAsync(provider);
+            }
         }
 
         private static void ToggleFlyout(TaskBarWidget widget)
@@ -266,21 +305,24 @@ namespace TaskbarQuota.Taskbar
 
         private static void ApplyStateChanged(UsageResult result)
         {
-            var active = UsageCoordinator.Instance.WidgetDisplayProvider;
-            if (active is null || result.Id != active)
-                return;
+            var coordinator = UsageCoordinator.Instance;
+            var providers = coordinator.WidgetDisplayProviders;
+            bool isDisplayed = providers.Contains(result.Id);
 
             foreach (var widget in Widgets.Values.ToArray())
             {
-                if (!widget.IsAlive || widget.Summary is not { } summary)
+                if (!widget.IsAlive)
                     continue;
 
-                summary.Apply(result);
+                // Reconcile the tile set first, so a provider that just became active already owns a slot
+                // before its result is routed. SetDisplayProviders is a cheap no-op when nothing changed.
+                widget.SetVisible(providers.Count > 0);
+                widget.SetDisplayProviders(providers, coordinator.ActiveProvider);
+                if (!isDisplayed)
+                    continue;
+
+                widget.ApplyResult(result);
                 LogWidgetApply(result.Id, "state");
-                bool isVisible = UsageCoordinator.Instance.IsActiveToolPresent
-                    && UsageCoordinator.Instance.WidgetDisplayProvider is not null;
-                widget.SetVisible(isVisible);
-                summary.SetActiveToolVisible(isVisible);
             }
         }
 
@@ -302,14 +344,12 @@ namespace TaskbarQuota.Taskbar
 
         private static void ApplyActiveToolPresenceChanged(bool isPresent)
         {
-            bool isVisible = isPresent && UsageCoordinator.Instance.WidgetDisplayProvider is not null;
+            // Pinned tiles stay on the taskbar even when no AI tool is in the foreground; only the active
+            // tile follows presence. SyncWidgetState recomputes the whole set and hydrates it.
             foreach (var widget in Widgets.Values.ToArray())
             {
-                if (!widget.IsAlive || widget.Summary is not { } summary)
-                    continue;
-
-                widget.SetVisible(isVisible);
-                summary.SetActiveToolVisible(isVisible);
+                if (widget.IsAlive)
+                    SyncWidgetState(widget);
             }
         }
 

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -44,22 +44,11 @@ namespace TaskbarQuota.Taskbar
         // Space assumed available before the first position pass has measured the real taskbar gap. Wide
         // enough for three tiles; the first pass corrects it either way.
         private const int DefaultAvailableLogicalWidth = 640;
-        // Rows a pinned tile shows while it is NOT the active tool. Two is one full column group, so such a
-        // tile has a fixed width whatever the user enables, and enabling a row can never evict a neighbour.
-        private const int PinnedTileMaxRows = 2;
-        // Floor for the active tool's tile. It may give up a third row to keep another provider on the bar,
-        // but never drops to a single line — that reads as a glitch rather than as a space saving.
-        private const int MinActiveRows = 2;
         // A tile only animates when it genuinely moved; below this a value simply changed width.
         private const int TileMoveThresholdLogicalPx = 8;
         // How far a newly shown tile eases in from. Short enough to stay inside the host window, so it
         // reads as arriving rather than being clipped off the taskbar edge.
         private const int TileEntryOffsetLogicalPx = 28;
-        // Worth of a reset countdown, by whose tile it is on. Both stay below a row (4 points) so a row is
-        // never traded for a countdown, but the active tool keeps its countdowns until every pinned tile
-        // has given theirs up.
-        private const int ActiveResetWeight = 3;
-        private const int PinnedResetWeight = 1;
         private static readonly TimeSpan PositionDisposeWait = TimeSpan.FromSeconds(3);
         private const int ERROR_CLASS_ALREADY_EXISTS = 1410;
         // Approx width of the Win11 far-left Widgets/weather pill; used to reserve clearance when its exact
@@ -105,19 +94,25 @@ namespace TaskbarQuota.Taskbar
         // Slot has a provider AND fits inside the measured taskbar gap. Trimming only ever drops from the
         // right, so the leading (active) tile is the last one to go.
         private readonly bool[] tileFits = new bool[UsageCoordinator.MaxWidgetTiles];
-        // Collapsed to the provider glyph because the row didn't fit at full width.
-        private readonly bool[] tileIconOnly = new bool[UsageCoordinator.MaxWidgetTiles];
         // Has a provider, but is being held back this pass because the row would otherwise overflow. Only
         // ever the active tool's tile when that provider is not pinned.
         private readonly bool[] tileSuppressed = new bool[UsageCoordinator.MaxWidgetTiles];
+        // Scratch buffers for one layout pass, held as fields because that pass runs on every usage publish
+        // and on the 5s health tick. layoutSlots[0..count) are the occupied slot indices in render order.
+        private readonly int[] layoutSlots = new int[UsageCoordinator.MaxWidgetTiles];
+        private readonly int[] layoutWidths = new int[UsageCoordinator.MaxWidgetTiles];
         private ProviderId? activeTileProvider;
         // Where each shown provider sat in the last layout, so the next one can animate the difference.
+        // Double-buffered and swapped each pass so a layout allocates no dictionary.
         private Dictionary<ProviderId, int> lastTilePositions = new();
+        private Dictionary<ProviderId, int> tilePositions = new();
+        private Microsoft.UI.Xaml.Media.Brush? separatorBrush;
+        private bool? separatorBrushIsLight;
         private Microsoft.UI.Xaml.Controls.StackPanel? summaryPanel;
         private int availableLogicalWidth = DefaultAvailableLogicalWidth;
         private bool isRecomputingLayout;
         private bool layoutRepositionPending;
-        private string? lastLayoutSignature;
+        private int lastLayoutHash;
         private DesktopWindowXamlSource? host;
         private Microsoft.UI.Xaml.FrameworkElement? hostContent;
         private int WidgetHostWidth;
@@ -424,25 +419,18 @@ namespace TaskbarQuota.Taskbar
         public void RefreshLayout() => RecomputeLayout();
 
         /// <summary>
-        /// Fits the tiles into the free taskbar space and resizes the host to the result, degrading only as
-        /// far as it has to:
+        /// Lays the tiles out and resizes the host to the result.
         ///
-        /// 1. every tile shows every row the user enabled — the normal case, and what runs whenever there
-        ///    is room, so a pinned tile is never trimmed just for being pinned;
-        /// 2. tiles other than the active tool's drop to <see cref="PinnedTileMaxRows"/> rows, becoming
-        ///    fixed-width summaries;
-        /// 3. tiles collapse to their provider glyph, from the right, so the active tile keeps its detail
-        ///    longest.
+        /// Every tile renders exactly what the user configured — all of its rows, with their reset
+        /// countdowns. There is deliberately no reduced form: trimming a pinned provider is worse than
+        /// refusing the pin (issue #25), so keeping the row inside the bar is
+        /// <see cref="Services.PinBudgetService"/>'s job. The only concession made here is holding back the
+        /// least recently used non-active tile when the row still overflows the measured gap, which covers
+        /// the transient case of an unpinned active tool arriving beside a full pinned set.
         ///
-        /// A pinned tile is never dropped — pinning is a promise that the provider stays on the bar, and
-        /// even a collapsed tile keeps its numbers in its tooltip.
-        ///
-        /// Every tile is measured fresh in both variants on each pass rather than measured once and cached.
-        /// Caching was wrong twice over: the cache was keyed by slot, but a provider switch re-orders which
-        /// provider a slot holds, and a collapsed tile renders as a glyph so it cannot restate its own
-        /// expanded width — together that left a tile stuck collapsed on a width belonging to a different
-        /// provider. Measuring is cheap (RenderRows only walks columns) and the tree is not painted until
-        /// the pass returns, so the intermediate states are never visible.
+        /// Widths are measured, never rendered: <see cref="WidgetSummary.MeasureDesiredWidth"/> is a pure
+        /// calculation over the columns, whereas rendering to read a width restarted the tile's refresh
+        /// animation on every usage publish and read as a tile flashing once a second.
         /// </summary>
         private void RecomputeLayout(bool forceReposition = false)
         {
@@ -462,52 +450,38 @@ namespace TaskbarQuota.Taskbar
             try
             {
                 Array.Clear(tileSuppressed);
-                var slots = new List<int>(tiles.Length);
+
+                // Slot and width buffers are fields, not locals: at most three tiles, and this pass runs on
+                // every usage publish and every 5s health tick across every taskbar.
+                int count = 0;
                 for (int i = 0; i < tiles.Length; i++)
                 {
                     if (tileProviders[i] is not null)
-                        slots.Add(i);
+                        layoutSlots[count++] = i;
                 }
 
-                HoldBackTilesThatDoNotFit(slots);
+                count = HoldBackTilesThatDoNotFit(layoutSlots, count);
 
-                // Candidate layouts are measured, never rendered — MeasureDesiredWidth is a pure
-                // calculation. Rendering to measure made the tile restart its refresh animation on every
-                // usage publish, which read as a tile flashing about once a second.
-                var rowCounts = new List<int>(slots.Count);
-                int activeIndex = -1;
-                for (int n = 0; n < slots.Count; n++)
-                {
-                    rowCounts.Add(tiles[slots[n]].RowCount);
-                    if (IsActiveTile(slots[n]))
-                        activeIndex = n;
-                }
-
-                var forms = SolveTileLayout(
-                    rowCounts,
-                    activeIndex,
-                    (position, form) => tiles[slots[position]].MeasureDesiredWidth(form),
-                    availableLogicalWidth);
-
-                var widths = new List<int>(slots.Count);
+                // Widths are measured, never rendered — MeasureDesiredWidth is a pure calculation.
+                // Rendering to measure made the tile restart its refresh animation on every usage publish,
+                // which read as a tile flashing about once a second.
+                var brush = TaskbarForegroundBrush();
                 int total = 0;
-                for (int n = 0; n < slots.Count; n++)
+                for (int n = 0; n < count; n++)
                 {
-                    int i = slots[n];
-                    tileIconOnly[i] = forms[n].IsGlyph;
-                    int width = tiles[i].MeasureDesiredWidth(forms[n]);
-                    widths.Add(width);
+                    int i = layoutSlots[n];
+                    int width = tiles[i].MeasureDesiredWidth();
+                    layoutWidths[n] = width;
                     if (tileProviders[i] is { } measuredProvider)
                         TaskbarSpace.RecordTileWidth(measuredProvider, width);
                     total += width + TileHorizontalMarginLogicalPx + (n > 0 ? TileSeparatorLogicalPx : 0);
-                    tiles[i].SetSummaryMode(forms[n]);
                 }
 
                 for (int i = 0; i < tiles.Length; i++)
                 {
                     // A suppressed slot still HAS a provider — it is the courtesy tile that had to give way
                     // — so visibility has to consult the suppression too, or this loop hands it straight
-                    // back with no form or width assigned, which is what left a stray divider on the bar.
+                    // back with no width assigned, which is what left a stray divider on the bar.
                     bool shown = tileProviders[i] is not null && !tileSuppressed[i];
                     tileFits[i] = shown;
                     tiles[i].Visibility = shown ? Microsoft.UI.Xaml.Visibility.Visible : Microsoft.UI.Xaml.Visibility.Collapsed;
@@ -519,21 +493,21 @@ namespace TaskbarQuota.Taskbar
                     separators[i].Visibility = tileFits[i] && tileFits[i + 1]
                         ? Microsoft.UI.Xaml.Visibility.Visible
                         : Microsoft.UI.Xaml.Visibility.Collapsed;
-                    separators[i].Foreground = TaskbarForegroundBrush();
+                    separators[i].Foreground = brush;
                 }
 
-                AnimateTileMovement(slots, widths);
+                AnimateTileMovement(layoutSlots, count, layoutWidths);
 
-                // The layout is recomputed on every usage publish, so only report an actual change.
-                var signature = $"budget={availableLogicalWidth} rows=[{string.Join(",", rowCounts)}] "
-                    + $"forms=[{string.Join(",", forms)}] widths=[{string.Join(",", widths)}] total={total}";
-                if (signature != lastLayoutSignature)
+                // The layout is recomputed on every usage publish, so only report an actual change — and
+                // decide that from a hash, so the unchanged case (nearly all of them) formats no string.
+                int hash = LayoutHash(count, total);
+                if (hash != lastLayoutHash)
                 {
-                    lastLayoutSignature = signature;
-                    Log.Debug($"[widget] layout {signature}");
+                    lastLayoutHash = hash;
+                    Log.Debug($"[widget] layout {DescribeLayout(count, total)}");
                 }
 
-                bool resized = ResizeWidgetHost(slots.Count == 0 ? DefaultWidgetHostWidth : total);
+                bool resized = ResizeWidgetHost(count == 0 ? DefaultWidgetHostWidth : total);
                 if (resized || forceReposition)
                     UpdatePosition();
             }
@@ -552,6 +526,31 @@ namespace TaskbarQuota.Taskbar
         private bool IsActiveTile(int slot)
             => tileProviders[slot] is { } provider && activeTileProvider == provider;
 
+        private int LayoutHash(int count, int total)
+        {
+            var hash = new HashCode();
+            hash.Add(availableLogicalWidth);
+            hash.Add(total);
+            for (int n = 0; n < count; n++)
+            {
+                hash.Add(tileProviders[layoutSlots[n]]);
+                hash.Add(layoutWidths[n]);
+            }
+            return hash.ToHashCode();
+        }
+
+        private string DescribeLayout(int count, int total)
+        {
+            var text = new StringBuilder(128);
+            text.Append("budget=").Append(availableLogicalWidth).Append(" tiles=[");
+            for (int n = 0; n < count; n++)
+            {
+                if (n > 0) text.Append(',');
+                text.Append(tileProviders[layoutSlots[n]]).Append(':').Append(layoutWidths[n]);
+            }
+            return text.Append("] total=").Append(total).ToString();
+        }
+
         /// <summary>
         /// Holds tiles back until the row fits the free taskbar span, so the widget never grows over the
         /// shell's own buttons.
@@ -561,41 +560,68 @@ namespace TaskbarQuota.Taskbar
         /// the cheaper thing to lose for a moment. Pinned tiles yield least-recently-used first and come
         /// straight back when you switch away, so a pin still guarantees presence the rest of the time.
         /// </summary>
-        private void HoldBackTilesThatDoNotFit(List<int> slots)
+        /// <param name="slots">Occupied slot indices; compacted in place. Returns how many survive.</param>
+        private int HoldBackTilesThatDoNotFit(int[] slots, int count)
         {
-            if (slots.Count <= 1)
-                return;
+            if (count <= 1)
+                return count;
 
-            // Least recently used first, and never the active tile.
             var recent = UsageCoordinator.Instance.RecentProviders;
-            var recency = new Dictionary<ProviderId, int>();
-            for (int i = 0; i < recent.Count; i++)
-                recency.TryAdd(recent[i], i);
 
-            var dropOrder = slots
-                .Where(slot => !IsActiveTile(slot))
-                .OrderByDescending(slot => tileProviders[slot] is { } p && recency.TryGetValue(p, out int index)
-                    ? index
-                    : int.MaxValue)
-                .ToList();
-
-            foreach (int slot in dropOrder)
+            // Drop the least recently used non-active tile, one at a time, until the row fits. Selection is
+            // a linear scan rather than an ordered projection: at most three tiles, and this runs on every
+            // usage publish, so the LINQ pipeline it replaces was allocating a dictionary, a lambda closure
+            // and two lists per pass to sort three items.
+            while (count > 1 && MeasureRow(slots, count) > availableLogicalWidth)
             {
-                if (MeasureRow(slots) <= availableLogicalWidth)
-                    return;
+                int worstAt = -1;
+                int worstRecency = int.MinValue;
+                for (int n = 0; n < count; n++)
+                {
+                    if (IsActiveTile(slots[n]))
+                        continue;
 
-                slots.Remove(slot);
-                tileSuppressed[slot] = true;
+                    int recency = RecencyOf(tileProviders[slots[n]], recent);
+                    if (recency > worstRecency)
+                    {
+                        worstRecency = recency;
+                        worstAt = n;
+                    }
+                }
+
+                if (worstAt < 0)
+                    break;
+
+                tileSuppressed[slots[worstAt]] = true;
+                Array.Copy(slots, worstAt + 1, slots, worstAt, count - worstAt - 1);
+                count--;
             }
+
+            return count;
         }
 
-        private int MeasureRow(List<int> slots)
+        /// <summary>Position in the recently-active list; <see cref="int.MaxValue"/> when never active, so
+        /// "never used" sorts as least recent.</summary>
+        internal static int RecencyOf(ProviderId? provider, IReadOnlyList<ProviderId> recent)
+        {
+            if (provider is not { } id)
+                return int.MaxValue;
+
+            for (int i = 0; i < recent.Count; i++)
+            {
+                if (recent[i] == id)
+                    return i;
+            }
+
+            return int.MaxValue;
+        }
+
+        private int MeasureRow(int[] slots, int count)
         {
             int total = 0;
-            for (int n = 0; n < slots.Count; n++)
+            for (int n = 0; n < count; n++)
             {
-                total += tiles[slots[n]].MeasureDesiredWidth(
-                        new WidgetSummary.SummaryForm(Math.Max(1, tiles[slots[n]].RowCount), HideReset: false))
+                total += tiles[slots[n]].MeasureDesiredWidth()
                     + TileHorizontalMarginLogicalPx
                     + (n > 0 ? TileSeparatorLogicalPx : 0);
             }
@@ -612,11 +638,16 @@ namespace TaskbarQuota.Taskbar
         /// slots are a fixed pool and providers move between them, so slot identity says nothing about what
         /// the user saw move.
         /// </summary>
-        private void AnimateTileMovement(List<int> slots, List<int> widths)
+        private void AnimateTileMovement(int[] slots, int count, int[] widths)
         {
-            var positions = new Dictionary<ProviderId, int>(slots.Count);
+            // Scratch dictionary owned by this widget and cleared per pass, then swapped with the previous
+            // one below — the layout runs on every usage publish, so a fresh dictionary each time was the
+            // single largest per-pass allocation here.
+            var positions = tilePositions;
+            positions.Clear();
+
             int x = TileHorizontalMarginLogicalPx / 2;
-            for (int n = 0; n < slots.Count; n++)
+            for (int n = 0; n < count; n++)
             {
                 if (tileProviders[slots[n]] is { } provider)
                     positions[provider] = x;
@@ -625,7 +656,7 @@ namespace TaskbarQuota.Taskbar
 
             // First layout of the session: the tiles have their own reveal animation, nothing to move from.
             bool hadPositions = lastTilePositions.Count > 0;
-            for (int n = 0; n < slots.Count; n++)
+            for (int n = 0; n < count; n++)
             {
                 if (tileProviders[slots[n]] is not { } provider)
                     continue;
@@ -643,196 +674,26 @@ namespace TaskbarQuota.Taskbar
                 }
             }
 
-            lastTilePositions = positions;
+            // Swap rather than reassign: the outgoing dictionary becomes next pass's scratch buffer.
+            (lastTilePositions, tilePositions) = (positions, lastTilePositions);
         }
 
         /// <summary>
-        /// Total logical width of the tile row when the trailing <paramref name="collapsed"/> tiles render
-        /// as glyphs only. Works off cached widths, so a layout that isn't on screen yet can be measured —
-        /// which is what lets the collapse count be solved outright instead of by trial and error.
+        /// Separator colour for the current system theme. Cached: the layout pass runs on every usage
+        /// publish and on the 5s health tick, and a fresh SolidColorBrush per separator per pass was steady
+        /// garbage for a value that only changes when the user switches theme.
         /// </summary>
-        internal static int MeasureRowWidth(IReadOnlyList<int> fullWidths, int collapsed, int iconWidth)
-        {
-            var icons = new bool[fullWidths.Count];
-            for (int i = fullWidths.Count - collapsed; i < fullWidths.Count; i++)
-                icons[i] = true;
-            return MeasureRowWidth(fullWidths, icons, iconWidth);
-        }
-
-        /// <summary>Row width with an explicit set of collapsed tiles, which need not be contiguous.</summary>
-        internal static int MeasureRowWidth(IReadOnlyList<int> fullWidths, IReadOnlyList<bool> icons, int iconWidth)
-        {
-            int total = 0;
-            for (int i = 0; i < fullWidths.Count; i++)
-            {
-                total += (icons[i] ? iconWidth : fullWidths[i])
-                    + TileHorizontalMarginLogicalPx
-                    + (i > 0 ? TileSeparatorLogicalPx : 0);
-            }
-
-            return total;
-        }
-
-        /// <summary>
-        /// Picks the least-degraded layout that fits <paramref name="budget"/>.
-        ///
-        /// Every tile renders in full — all of its rows, with their reset countdowns. When the row does not
-        /// fit, tiles fall back to a bare glyph rather than being trimmed, and the search picks which ones:
-        /// giving up a NARROW tile can be the better trade when it lets a wide neighbour render, which a
-        /// positional rule cannot see. At most three tiles is a search space of eight, evaluated with pure
-        /// arithmetic.
-        ///
-        /// The active tool's tile is never the one given up unless nothing fits at all.
-        /// </summary>
-        /// <param name="rowCounts">Rows each tile wants to show, left to right.</param>
-        /// <param name="activeIndex">Position of the active tool's tile, or -1 when none is active.</param>
-        /// <param name="measure">
-        /// (position, form) => rendered width for that tile in the given form.
-        /// </param>
-        /// <returns>The chosen detail level per tile.</returns>
-        internal static WidgetSummary.SummaryForm[] SolveTileLayout(
-            IReadOnlyList<int> rowCounts,
-            int activeIndex,
-            Func<int, WidgetSummary.SummaryForm, int> measure,
-            int budget)
-        {
-            int count = rowCounts.Count;
-            if (count == 0)
-                return Array.Empty<WidgetSummary.SummaryForm>();
-
-            // A pinned provider shows everything the user asked it to show, countdowns included — that is
-            // the whole point of pinning it (issue #25). There is no fallback form: a tile is never trimmed
-            // and never reduced to a bare glyph, because a logo with no figures is worse than no pin at all.
-            //
-            // Keeping the row inside the taskbar is therefore the PIN BUDGET's job, not this method's —
-            // PinBudgetService refuses a pin that would not fit, so by the time a provider gets here it is
-            // known to have room.
-            var ladders = new List<WidgetSummary.SummaryForm>[count];
-            for (int i = 0; i < count; i++)
-                ladders[i] = [new WidgetSummary.SummaryForm(Math.Max(1, rowCounts[i]), HideReset: false)];
-
-            // Pass 1 keeps the active tile above the floor; pass 2 drops that guard so a bar with no room
-            // at all still renders something rather than nothing.
-            for (int pass = 0; pass < 2; pass++)
-            {
-                var best = SearchLevels(ladders, rowCounts, activeIndex, measure, budget, guardActive: pass == 0);
-                if (best is not null)
-                    return best;
-            }
-
-            // The row overflows the free span. Render it in full regardless: there is deliberately no
-            // reduced form to fall back to, and the pin budget should have refused the pin that caused
-            // this. Overflowing visibly is the honest outcome — and the signal that the budget is wrong.
-            var full = new WidgetSummary.SummaryForm[count];
-            for (int i = 0; i < count; i++)
-                full[i] = ladders[i][0];
-            return full;
-        }
-
-        private static WidgetSummary.SummaryForm[]? SearchLevels(
-            IReadOnlyList<List<WidgetSummary.SummaryForm>> ladders,
-            IReadOnlyList<int> rowCounts,
-            int activeIndex,
-            Func<int, WidgetSummary.SummaryForm, int> measure,
-            int budget,
-            bool guardActive)
-        {
-            int count = ladders.Count;
-            int combinations = 1;
-            for (int i = 0; i < count; i++)
-                combinations *= ladders[i].Count;
-
-            WidgetSummary.SummaryForm[]? bestForms = null;
-            (int Detail, int Shown, int Rightness) bestScore = (-1, -1, -1);
-
-            for (int combo = 0; combo < combinations; combo++)
-            {
-                var forms = new WidgetSummary.SummaryForm[count];
-                int rest = combo;
-                for (int i = 0; i < count; i++)
-                {
-                    forms[i] = ladders[i][rest % ladders[i].Count];
-                    rest /= ladders[i].Count;
-                }
-
-                if (guardActive && activeIndex >= 0
-                    && forms[activeIndex].Rows < Math.Min(MinActiveRows, Math.Max(1, rowCounts[activeIndex])))
-                {
-                    continue;
-                }
-
-                int total = 0;
-                for (int i = 0; i < count; i++)
-                {
-                    total += measure(i, forms[i])
-                        + TileHorizontalMarginLogicalPx
-                        + (i > 0 ? TileSeparatorLogicalPx : 0);
-                }
-
-                if (total > budget)
-                    continue;
-
-                // Rank by how much is actually readable. A row is worth four points, so a row always beats a
-                // countdown and dropping the countdown is the cheapest step down. A countdown on the ACTIVE
-                // tile is worth more than one on a pinned tile: when you are working in a tool, when its
-                // window resets is the number you care about, whereas a pinned provider you are only
-                // monitoring can lose its countdown to the tooltip. Without that weighting every countdown
-                // scored the same, ties fell to enumeration order, and the active tile — evaluated first —
-                // was always the one stripped.
-                int detail = 0, shown = 0, rightness = 0;
-                for (int i = 0; i < count; i++)
-                {
-                    if (forms[i].Rows >= 1)
-                    {
-                        detail += forms[i].Rows * 4;
-                        if (forms[i].HideReset)
-                            rightness += i;
-                        else
-                            detail += i == activeIndex ? ActiveResetWeight : PinnedResetWeight;
-                        shown++;
-                    }
-                    else if (forms[i].IsCompact)
-                    {
-                        detail += 1;
-                        shown++;
-                        rightness += i;
-                    }
-                    else
-                    {
-                        rightness += i;
-                    }
-                }
-
-                var score = (detail, shown, rightness);
-                if (score.CompareTo(bestScore) <= 0)
-                    continue;
-
-                bestScore = score;
-                bestForms = forms;
-            }
-
-            return bestForms;
-        }
-
-        /// <summary>
-        /// How many trailing tiles must collapse to their glyph for the row to fit <paramref name="budget"/>.
-        /// Collapsing from the right means the active tile (slot 0) keeps its detail longest. Can return the
-        /// full count when even a row of glyphs overflows — that's the floor, and a clipped row of glyphs
-        /// still beats a pinned provider disappearing.
-        /// </summary>
-        internal static int SolveCollapseCount(IReadOnlyList<int> fullWidths, int iconWidth, int budget)
-        {
-            int collapsed = 0;
-            while (collapsed < fullWidths.Count && MeasureRowWidth(fullWidths, collapsed, iconWidth) > budget)
-                collapsed++;
-            return collapsed;
-        }
-
-        private static Microsoft.UI.Xaml.Media.Brush TaskbarForegroundBrush()
+        private Microsoft.UI.Xaml.Media.Brush TaskbarForegroundBrush()
         {
             bool light = SystemInfos.IsSystemLightThemeUsed() == true;
-            return new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                light ? Windows.UI.Color.FromArgb(255, 28, 28, 28) : Colors.White);
+            if (separatorBrush is null || separatorBrushIsLight != light)
+            {
+                separatorBrushIsLight = light;
+                separatorBrush = new Microsoft.UI.Xaml.Media.SolidColorBrush(
+                    light ? Windows.UI.Color.FromArgb(255, 28, 28, 28) : Colors.White);
+            }
+
+            return separatorBrush;
         }
 
         // Records the widest free gap (logical px) as the budget for how many tiles may render. Called from
@@ -2022,9 +1883,11 @@ namespace TaskbarQuota.Taskbar
             Array.Clear(separators);
             Array.Clear(tileProviders);
             Array.Clear(tileFits);
-            Array.Clear(tileIconOnly);
             Array.Clear(tileSuppressed);
-            lastTilePositions = new Dictionary<ProviderId, int>();
+            lastTilePositions.Clear();
+            tilePositions.Clear();
+            separatorBrush = null;
+            separatorBrushIsLight = null;
         }
     }
 }

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -461,8 +461,6 @@ namespace TaskbarQuota.Taskbar
             isRecomputingLayout = true;
             try
             {
-                int iconWidth = WidgetSummary.IconOnlyWidth(WidgetSettingsService.Current);
-
                 Array.Clear(tileSuppressed);
                 var slots = new List<int>(tiles.Length);
                 for (int i = 0; i < tiles.Length; i++)
@@ -689,8 +687,7 @@ namespace TaskbarQuota.Taskbar
         /// <param name="rowCounts">Rows each tile wants to show, left to right.</param>
         /// <param name="activeIndex">Position of the active tool's tile, or -1 when none is active.</param>
         /// <param name="measure">
-        /// (position, level) =&gt; rendered width, where level is a positive row count,
-        /// <see cref="WidgetSummary.LevelCompact"/>, or <see cref="WidgetSummary.LevelGlyph"/>.
+        /// (position, form) => rendered width for that tile in the given form.
         /// </param>
         /// <returns>The chosen detail level per tile.</returns>
         internal static WidgetSummary.SummaryForm[] SolveTileLayout(

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
+using System.Linq;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -16,6 +17,7 @@ using Windows.System;
 using TaskbarQuota.Controls;
 using TaskbarQuota.Diagnostics;
 using TaskbarQuota.Interop;
+using TaskbarQuota.Usage;
 
 namespace TaskbarQuota.Taskbar
 {
@@ -31,6 +33,33 @@ namespace TaskbarQuota.Taskbar
         private const string WidgetsButtonAutomationId = "WidgetsButton";
         private const int DefaultWidgetHostWidth = 172;
         private const int TrayClearanceLogicalPx = 6;
+        // Each tile carries a 2px left + 2px right margin that its own desired width excludes, so the host
+        // width has to add this back per visible tile or a multi-tile layout clips its last column.
+        // Kept tight deliberately: with three tiles, margins and dividers were costing 42px of a ~730px
+        // taskbar span, which is the difference between a third provider fitting and being refused.
+        private const int TileHorizontalMarginLogicalPx = 4;
+        // Fixed width of the "|" divider drawn between adjacent tiles. Fixed rather than measured so the
+        // fit math stays exact and doesn't depend on a layout pass having run.
+        private const int TileSeparatorLogicalPx = 7;
+        // Space assumed available before the first position pass has measured the real taskbar gap. Wide
+        // enough for three tiles; the first pass corrects it either way.
+        private const int DefaultAvailableLogicalWidth = 640;
+        // Rows a pinned tile shows while it is NOT the active tool. Two is one full column group, so such a
+        // tile has a fixed width whatever the user enables, and enabling a row can never evict a neighbour.
+        private const int PinnedTileMaxRows = 2;
+        // Floor for the active tool's tile. It may give up a third row to keep another provider on the bar,
+        // but never drops to a single line — that reads as a glitch rather than as a space saving.
+        private const int MinActiveRows = 2;
+        // A tile only animates when it genuinely moved; below this a value simply changed width.
+        private const int TileMoveThresholdLogicalPx = 8;
+        // How far a newly shown tile eases in from. Short enough to stay inside the host window, so it
+        // reads as arriving rather than being clipped off the taskbar edge.
+        private const int TileEntryOffsetLogicalPx = 28;
+        // Worth of a reset countdown, by whose tile it is on. Both stay below a row (4 points) so a row is
+        // never traded for a countdown, but the active tool keeps its countdowns until every pinned tile
+        // has given theirs up.
+        private const int ActiveResetWeight = 3;
+        private const int PinnedResetWeight = 1;
         private static readonly TimeSpan PositionDisposeWait = TimeSpan.FromSeconds(3);
         private const int ERROR_CLASS_ALREADY_EXISTS = 1410;
         // Approx width of the Win11 far-left Widgets/weather pill; used to reserve clearance when its exact
@@ -64,7 +93,31 @@ namespace TaskbarQuota.Taskbar
 
         private IntPtr hwnd;
         private AppWindow? appWindow;
-        private WidgetSummary? widgetSummary;
+        // Fixed pool of tile slots, created once and reused. Slot i renders tileProviders[i]; reassigning a
+        // slot to another provider re-renders it through WidgetSummary's normal provider-switch path. A
+        // fixed pool means the panel's children never change, so no tile is ever unloaded and re-loaded
+        // (which would drop its WidgetSettingsService subscription) when the display order shifts.
+        private readonly WidgetSummary[] tiles = new WidgetSummary[UsageCoordinator.MaxWidgetTiles];
+        // separators[i] is the "|" divider between slot i and slot i+1.
+        private readonly Microsoft.UI.Xaml.Controls.TextBlock[] separators =
+            new Microsoft.UI.Xaml.Controls.TextBlock[UsageCoordinator.MaxWidgetTiles - 1];
+        private readonly ProviderId?[] tileProviders = new ProviderId?[UsageCoordinator.MaxWidgetTiles];
+        // Slot has a provider AND fits inside the measured taskbar gap. Trimming only ever drops from the
+        // right, so the leading (active) tile is the last one to go.
+        private readonly bool[] tileFits = new bool[UsageCoordinator.MaxWidgetTiles];
+        // Collapsed to the provider glyph because the row didn't fit at full width.
+        private readonly bool[] tileIconOnly = new bool[UsageCoordinator.MaxWidgetTiles];
+        // Has a provider, but is being held back this pass because the row would otherwise overflow. Only
+        // ever the active tool's tile when that provider is not pinned.
+        private readonly bool[] tileSuppressed = new bool[UsageCoordinator.MaxWidgetTiles];
+        private ProviderId? activeTileProvider;
+        // Where each shown provider sat in the last layout, so the next one can animate the difference.
+        private Dictionary<ProviderId, int> lastTilePositions = new();
+        private Microsoft.UI.Xaml.Controls.StackPanel? summaryPanel;
+        private int availableLogicalWidth = DefaultAvailableLogicalWidth;
+        private bool isRecomputingLayout;
+        private bool layoutRepositionPending;
+        private string? lastLayoutSignature;
         private DesktopWindowXamlSource? host;
         private Microsoft.UI.Xaml.FrameworkElement? hostContent;
         private int WidgetHostWidth;
@@ -119,7 +172,14 @@ namespace TaskbarQuota.Taskbar
         }
         public IntPtr TaskbarHandle => hwndShell;
         public bool IsPrimaryTaskbar => isPrimaryTaskbar;
-        public WidgetSummary? Summary => widgetSummary;
+        /// <summary>
+        /// Supplies the best available snapshot for a provider when a slot is (re)assigned to it, so a
+        /// re-ordered tile paints its new provider immediately instead of holding the previous one's rows
+        /// until the next fetch lands. Set by <see cref="TaskBarManager"/>.
+        /// </summary>
+        public Func<ProviderId, UsageResult?>? HydrateProvider { get; set; }
+        /// <summary>Raised when any tile is clicked; provider-agnostic, it just opens the flyout.</summary>
+        public event Action? Clicked;
         public event EventHandler? Destroying;
 
         public TaskBarWidget(TaskbarWindowTarget target)
@@ -171,20 +231,10 @@ namespace TaskbarQuota.Taskbar
 
             host.Initialize(id);
             host.SiteBridge.ResizePolicy = Microsoft.UI.Content.ContentSizePolicy.ResizeContentToParentWindow;
-            widgetSummary = new WidgetSummary
-            {
-                Margin = new Microsoft.UI.Xaml.Thickness(4, 0, 4, 0),
-                HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
-                VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Stretch,
-            };
-            widgetSummary.DesiredHostWidthChanged += WidgetSummary_DesiredHostWidthChanged;
-            widgetSummary.PointerPressed += WidgetSummary_PointerPressed;
-            widgetSummary.PointerMoved += WidgetSummary_PointerMoved;
-            widgetSummary.PointerReleased += WidgetSummary_PointerReleased;
-            widgetSummary.PointerCanceled += WidgetSummary_PointerCanceled;
+            summaryPanel = BuildSummaryPanel();
             hostContent = new Microsoft.UI.Xaml.Controls.Grid
             {
-                Children = { widgetSummary },
+                Children = { summaryPanel },
                 Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Colors.Transparent)
             };
             host.Content = hostContent;
@@ -257,10 +307,551 @@ namespace TaskbarQuota.Taskbar
             QueuePositionUpdate(TaskbarChangeReason.None);
         }
 
-        private void WidgetSummary_DesiredHostWidthChanged(int logicalWidth)
+        private Microsoft.UI.Xaml.Controls.StackPanel BuildSummaryPanel()
         {
-            if (ResizeWidgetHost(logicalWidth))
-                UpdatePosition();
+            var panel = new Microsoft.UI.Xaml.Controls.StackPanel
+            {
+                // The inter-tile gap comes from each tile's own 4px L/R margin plus the divider, so no
+                // StackPanel.Spacing — that keeps the width math to content + margins + separators.
+                Orientation = Microsoft.UI.Xaml.Controls.Orientation.Horizontal,
+                HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
+                VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Stretch,
+            };
+
+            for (int i = 0; i < tiles.Length; i++)
+            {
+                if (i > 0)
+                {
+                    separators[i - 1] = CreateSeparator();
+                    panel.Children.Add(separators[i - 1]);
+                }
+
+                tiles[i] = CreateTile();
+                panel.Children.Add(tiles[i]);
+            }
+
+            return panel;
+        }
+
+        private WidgetSummary CreateTile()
+        {
+            var summary = new WidgetSummary
+            {
+                Margin = new Microsoft.UI.Xaml.Thickness(2, 0, 2, 0),
+                HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
+                VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Stretch,
+                Visibility = Microsoft.UI.Xaml.Visibility.Collapsed,
+            };
+            summary.DesiredHostWidthChanged += WidgetSummary_DesiredHostWidthChanged;
+            summary.PointerPressed += WidgetSummary_PointerPressed;
+            summary.PointerMoved += WidgetSummary_PointerMoved;
+            summary.PointerReleased += WidgetSummary_PointerReleased;
+            summary.PointerCanceled += WidgetSummary_PointerCanceled;
+            summary.Clicked += OnTileClicked;
+            return summary;
+        }
+
+        private static Microsoft.UI.Xaml.Controls.TextBlock CreateSeparator() => new()
+        {
+            Text = "|",
+            Width = TileSeparatorLogicalPx,
+            FontSize = 12,
+            Opacity = 0.35,
+            TextAlignment = Microsoft.UI.Xaml.TextAlignment.Center,
+            HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
+            VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Center,
+            Visibility = Microsoft.UI.Xaml.Visibility.Collapsed,
+            IsHitTestVisible = false,
+        };
+
+        private void OnTileClicked() => Clicked?.Invoke();
+
+        private void WidgetSummary_DesiredHostWidthChanged(int logicalWidth) => RecomputeLayout();
+
+        /// <summary>
+        /// Binds the tile slots to <paramref name="providers"/> in order (leftmost first) and re-lays out.
+        /// Providers beyond the slot pool are ignored — <see cref="UsageCoordinator.WidgetDisplayProviders"/>
+        /// already caps the list at <see cref="UsageCoordinator.MaxWidgetTiles"/>.
+        /// </summary>
+        public void SetDisplayProviders(IReadOnlyList<ProviderId> providers, ProviderId? activeProvider)
+        {
+            if (summaryPanel is null)
+                return;
+
+            activeTileProvider = activeProvider;
+
+            bool changed = false;
+            for (int i = 0; i < tiles.Length; i++)
+            {
+                ProviderId? desired = i < providers.Count ? providers[i] : null;
+                if (tileProviders[i] == desired)
+                    continue;
+
+                tileProviders[i] = desired;
+                changed = true;
+                // Repaint the slot for its new provider straight away, so a re-order never leaves a tile
+                // showing the previous provider's rows under the new provider's turn to be fetched. The
+                // cross-fade is suppressed because the movement is carried by the slide animation instead;
+                // doing both at once is what made adding a third provider look like a flicker.
+                if (desired is { } provider && HydrateProvider?.Invoke(provider) is { } seed)
+                {
+                    tiles[i].SuppressNextTransition = true;
+                    tiles[i].Apply(seed, force: true);
+                }
+            }
+
+            // Always re-run the layout, even when the set is unchanged: the same providers in the same order
+            // can still swap which one is active (nothing focused -> Claude focused), and that alone changes
+            // how many rows each tile is allowed.
+            RecomputeLayout(forceReposition: changed);
+        }
+
+        /// <summary>Routes a fetch result to the slot that owns its provider; no-op if it isn't shown.</summary>
+        public void ApplyResult(UsageResult result, bool force = false)
+        {
+            for (int i = 0; i < tiles.Length; i++)
+            {
+                if (tileProviders[i] != result.Id)
+                    continue;
+
+                tiles[i].Apply(result, force);
+                tiles[i].SetActiveToolVisible(true);
+                return;
+            }
+        }
+
+        /// <summary>Re-runs the fit math against the currently measured taskbar gap.</summary>
+        public void RefreshLayout() => RecomputeLayout();
+
+        /// <summary>
+        /// Fits the tiles into the free taskbar space and resizes the host to the result, degrading only as
+        /// far as it has to:
+        ///
+        /// 1. every tile shows every row the user enabled — the normal case, and what runs whenever there
+        ///    is room, so a pinned tile is never trimmed just for being pinned;
+        /// 2. tiles other than the active tool's drop to <see cref="PinnedTileMaxRows"/> rows, becoming
+        ///    fixed-width summaries;
+        /// 3. tiles collapse to their provider glyph, from the right, so the active tile keeps its detail
+        ///    longest.
+        ///
+        /// A pinned tile is never dropped — pinning is a promise that the provider stays on the bar, and
+        /// even a collapsed tile keeps its numbers in its tooltip.
+        ///
+        /// Every tile is measured fresh in both variants on each pass rather than measured once and cached.
+        /// Caching was wrong twice over: the cache was keyed by slot, but a provider switch re-orders which
+        /// provider a slot holds, and a collapsed tile renders as a glyph so it cannot restate its own
+        /// expanded width — together that left a tile stuck collapsed on a width belonging to a different
+        /// provider. Measuring is cheap (RenderRows only walks columns) and the tree is not painted until
+        /// the pass returns, so the intermediate states are never visible.
+        /// </summary>
+        private void RecomputeLayout(bool forceReposition = false)
+        {
+            if (summaryPanel is null)
+                return;
+
+            // Re-entrant calls are this pass's own re-renders raising DesiredHostWidthChanged. Everything
+            // runs on the UI thread with no awaits, so nothing external can interleave — the pass already
+            // has the settled widths and re-running would just repeat itself.
+            if (isRecomputingLayout)
+            {
+                layoutRepositionPending |= forceReposition;
+                return;
+            }
+
+            isRecomputingLayout = true;
+            try
+            {
+                int iconWidth = WidgetSummary.IconOnlyWidth(WidgetSettingsService.Current);
+
+                Array.Clear(tileSuppressed);
+                var slots = new List<int>(tiles.Length);
+                for (int i = 0; i < tiles.Length; i++)
+                {
+                    if (tileProviders[i] is not null)
+                        slots.Add(i);
+                }
+
+                HoldBackTilesThatDoNotFit(slots);
+
+                // Candidate layouts are measured, never rendered — MeasureDesiredWidth is a pure
+                // calculation. Rendering to measure made the tile restart its refresh animation on every
+                // usage publish, which read as a tile flashing about once a second.
+                var rowCounts = new List<int>(slots.Count);
+                int activeIndex = -1;
+                for (int n = 0; n < slots.Count; n++)
+                {
+                    rowCounts.Add(tiles[slots[n]].RowCount);
+                    if (IsActiveTile(slots[n]))
+                        activeIndex = n;
+                }
+
+                var forms = SolveTileLayout(
+                    rowCounts,
+                    activeIndex,
+                    (position, form) => tiles[slots[position]].MeasureDesiredWidth(form),
+                    availableLogicalWidth);
+
+                var widths = new List<int>(slots.Count);
+                int total = 0;
+                for (int n = 0; n < slots.Count; n++)
+                {
+                    int i = slots[n];
+                    tileIconOnly[i] = forms[n].IsGlyph;
+                    int width = tiles[i].MeasureDesiredWidth(forms[n]);
+                    widths.Add(width);
+                    if (tileProviders[i] is { } measuredProvider)
+                        TaskbarSpace.RecordTileWidth(measuredProvider, width);
+                    total += width + TileHorizontalMarginLogicalPx + (n > 0 ? TileSeparatorLogicalPx : 0);
+                    tiles[i].SetSummaryMode(forms[n]);
+                }
+
+                for (int i = 0; i < tiles.Length; i++)
+                {
+                    // A suppressed slot still HAS a provider — it is the courtesy tile that had to give way
+                    // — so visibility has to consult the suppression too, or this loop hands it straight
+                    // back with no form or width assigned, which is what left a stray divider on the bar.
+                    bool shown = tileProviders[i] is not null && !tileSuppressed[i];
+                    tileFits[i] = shown;
+                    tiles[i].Visibility = shown ? Microsoft.UI.Xaml.Visibility.Visible : Microsoft.UI.Xaml.Visibility.Collapsed;
+                    tiles[i].SetActiveToolVisible(shown);
+                }
+
+                for (int i = 0; i < separators.Length; i++)
+                {
+                    separators[i].Visibility = tileFits[i] && tileFits[i + 1]
+                        ? Microsoft.UI.Xaml.Visibility.Visible
+                        : Microsoft.UI.Xaml.Visibility.Collapsed;
+                    separators[i].Foreground = TaskbarForegroundBrush();
+                }
+
+                AnimateTileMovement(slots, widths);
+
+                // The layout is recomputed on every usage publish, so only report an actual change.
+                var signature = $"budget={availableLogicalWidth} rows=[{string.Join(",", rowCounts)}] "
+                    + $"forms=[{string.Join(",", forms)}] widths=[{string.Join(",", widths)}] total={total}";
+                if (signature != lastLayoutSignature)
+                {
+                    lastLayoutSignature = signature;
+                    Log.Debug($"[widget] layout {signature}");
+                }
+
+                bool resized = ResizeWidgetHost(slots.Count == 0 ? DefaultWidgetHostWidth : total);
+                if (resized || forceReposition)
+                    UpdatePosition();
+            }
+            finally
+            {
+                isRecomputingLayout = false;
+            }
+
+            if (!layoutRepositionPending)
+                return;
+
+            layoutRepositionPending = false;
+            UpdatePosition();
+        }
+
+        private bool IsActiveTile(int slot)
+            => tileProviders[slot] is { } provider && activeTileProvider == provider;
+
+        /// <summary>
+        /// Holds tiles back until the row fits the free taskbar span, so the widget never grows over the
+        /// shell's own buttons.
+        ///
+        /// The ACTIVE tool's tile is the one thing never given up — showing the quota of whatever you are
+        /// working in is the widget's original job, and a pinned provider you are not currently touching is
+        /// the cheaper thing to lose for a moment. Pinned tiles yield least-recently-used first and come
+        /// straight back when you switch away, so a pin still guarantees presence the rest of the time.
+        /// </summary>
+        private void HoldBackTilesThatDoNotFit(List<int> slots)
+        {
+            if (slots.Count <= 1)
+                return;
+
+            // Least recently used first, and never the active tile.
+            var recent = UsageCoordinator.Instance.RecentProviders;
+            var recency = new Dictionary<ProviderId, int>();
+            for (int i = 0; i < recent.Count; i++)
+                recency.TryAdd(recent[i], i);
+
+            var dropOrder = slots
+                .Where(slot => !IsActiveTile(slot))
+                .OrderByDescending(slot => tileProviders[slot] is { } p && recency.TryGetValue(p, out int index)
+                    ? index
+                    : int.MaxValue)
+                .ToList();
+
+            foreach (int slot in dropOrder)
+            {
+                if (MeasureRow(slots) <= availableLogicalWidth)
+                    return;
+
+                slots.Remove(slot);
+                tileSuppressed[slot] = true;
+            }
+        }
+
+        private int MeasureRow(List<int> slots)
+        {
+            int total = 0;
+            for (int n = 0; n < slots.Count; n++)
+            {
+                total += tiles[slots[n]].MeasureDesiredWidth(
+                        new WidgetSummary.SummaryForm(Math.Max(1, tiles[slots[n]].RowCount), HideReset: false))
+                    + TileHorizontalMarginLogicalPx
+                    + (n > 0 ? TileSeparatorLogicalPx : 0);
+            }
+
+            return total;
+        }
+
+        /// <summary>
+        /// Animates tiles from wherever their provider sat last time to wherever it sits now, so a set or
+        /// order change reads as movement: the tiles already on the bar travel sideways to make room and a
+        /// newly shown provider eases in rather than appearing fully formed.
+        ///
+        /// Positions are tracked per PROVIDER, not per slot, which is what makes this work at all — the
+        /// slots are a fixed pool and providers move between them, so slot identity says nothing about what
+        /// the user saw move.
+        /// </summary>
+        private void AnimateTileMovement(List<int> slots, List<int> widths)
+        {
+            var positions = new Dictionary<ProviderId, int>(slots.Count);
+            int x = TileHorizontalMarginLogicalPx / 2;
+            for (int n = 0; n < slots.Count; n++)
+            {
+                if (tileProviders[slots[n]] is { } provider)
+                    positions[provider] = x;
+                x += widths[n] + TileHorizontalMarginLogicalPx + TileSeparatorLogicalPx;
+            }
+
+            // First layout of the session: the tiles have their own reveal animation, nothing to move from.
+            bool hadPositions = lastTilePositions.Count > 0;
+            for (int n = 0; n < slots.Count; n++)
+            {
+                if (tileProviders[slots[n]] is not { } provider)
+                    continue;
+
+                int target = positions[provider];
+                if (lastTilePositions.TryGetValue(provider, out int previous))
+                {
+                    // Ignore sub-threshold drift from a value changing width; only real moves animate.
+                    if (Math.Abs(previous - target) >= TileMoveThresholdLogicalPx)
+                        tiles[slots[n]].AnimateSlide(previous - target);
+                }
+                else if (hadPositions)
+                {
+                    tiles[slots[n]].AnimateSlide(-TileEntryOffsetLogicalPx);
+                }
+            }
+
+            lastTilePositions = positions;
+        }
+
+        /// <summary>
+        /// Total logical width of the tile row when the trailing <paramref name="collapsed"/> tiles render
+        /// as glyphs only. Works off cached widths, so a layout that isn't on screen yet can be measured —
+        /// which is what lets the collapse count be solved outright instead of by trial and error.
+        /// </summary>
+        internal static int MeasureRowWidth(IReadOnlyList<int> fullWidths, int collapsed, int iconWidth)
+        {
+            var icons = new bool[fullWidths.Count];
+            for (int i = fullWidths.Count - collapsed; i < fullWidths.Count; i++)
+                icons[i] = true;
+            return MeasureRowWidth(fullWidths, icons, iconWidth);
+        }
+
+        /// <summary>Row width with an explicit set of collapsed tiles, which need not be contiguous.</summary>
+        internal static int MeasureRowWidth(IReadOnlyList<int> fullWidths, IReadOnlyList<bool> icons, int iconWidth)
+        {
+            int total = 0;
+            for (int i = 0; i < fullWidths.Count; i++)
+            {
+                total += (icons[i] ? iconWidth : fullWidths[i])
+                    + TileHorizontalMarginLogicalPx
+                    + (i > 0 ? TileSeparatorLogicalPx : 0);
+            }
+
+            return total;
+        }
+
+        /// <summary>
+        /// Picks the least-degraded layout that fits <paramref name="budget"/>.
+        ///
+        /// Every tile renders in full — all of its rows, with their reset countdowns. When the row does not
+        /// fit, tiles fall back to a bare glyph rather than being trimmed, and the search picks which ones:
+        /// giving up a NARROW tile can be the better trade when it lets a wide neighbour render, which a
+        /// positional rule cannot see. At most three tiles is a search space of eight, evaluated with pure
+        /// arithmetic.
+        ///
+        /// The active tool's tile is never the one given up unless nothing fits at all.
+        /// </summary>
+        /// <param name="rowCounts">Rows each tile wants to show, left to right.</param>
+        /// <param name="activeIndex">Position of the active tool's tile, or -1 when none is active.</param>
+        /// <param name="measure">
+        /// (position, level) =&gt; rendered width, where level is a positive row count,
+        /// <see cref="WidgetSummary.LevelCompact"/>, or <see cref="WidgetSummary.LevelGlyph"/>.
+        /// </param>
+        /// <returns>The chosen detail level per tile.</returns>
+        internal static WidgetSummary.SummaryForm[] SolveTileLayout(
+            IReadOnlyList<int> rowCounts,
+            int activeIndex,
+            Func<int, WidgetSummary.SummaryForm, int> measure,
+            int budget)
+        {
+            int count = rowCounts.Count;
+            if (count == 0)
+                return Array.Empty<WidgetSummary.SummaryForm>();
+
+            // A pinned provider shows everything the user asked it to show, countdowns included — that is
+            // the whole point of pinning it (issue #25). There is no fallback form: a tile is never trimmed
+            // and never reduced to a bare glyph, because a logo with no figures is worse than no pin at all.
+            //
+            // Keeping the row inside the taskbar is therefore the PIN BUDGET's job, not this method's —
+            // PinBudgetService refuses a pin that would not fit, so by the time a provider gets here it is
+            // known to have room.
+            var ladders = new List<WidgetSummary.SummaryForm>[count];
+            for (int i = 0; i < count; i++)
+                ladders[i] = [new WidgetSummary.SummaryForm(Math.Max(1, rowCounts[i]), HideReset: false)];
+
+            // Pass 1 keeps the active tile above the floor; pass 2 drops that guard so a bar with no room
+            // at all still renders something rather than nothing.
+            for (int pass = 0; pass < 2; pass++)
+            {
+                var best = SearchLevels(ladders, rowCounts, activeIndex, measure, budget, guardActive: pass == 0);
+                if (best is not null)
+                    return best;
+            }
+
+            // The row overflows the free span. Render it in full regardless: there is deliberately no
+            // reduced form to fall back to, and the pin budget should have refused the pin that caused
+            // this. Overflowing visibly is the honest outcome — and the signal that the budget is wrong.
+            var full = new WidgetSummary.SummaryForm[count];
+            for (int i = 0; i < count; i++)
+                full[i] = ladders[i][0];
+            return full;
+        }
+
+        private static WidgetSummary.SummaryForm[]? SearchLevels(
+            IReadOnlyList<List<WidgetSummary.SummaryForm>> ladders,
+            IReadOnlyList<int> rowCounts,
+            int activeIndex,
+            Func<int, WidgetSummary.SummaryForm, int> measure,
+            int budget,
+            bool guardActive)
+        {
+            int count = ladders.Count;
+            int combinations = 1;
+            for (int i = 0; i < count; i++)
+                combinations *= ladders[i].Count;
+
+            WidgetSummary.SummaryForm[]? bestForms = null;
+            (int Detail, int Shown, int Rightness) bestScore = (-1, -1, -1);
+
+            for (int combo = 0; combo < combinations; combo++)
+            {
+                var forms = new WidgetSummary.SummaryForm[count];
+                int rest = combo;
+                for (int i = 0; i < count; i++)
+                {
+                    forms[i] = ladders[i][rest % ladders[i].Count];
+                    rest /= ladders[i].Count;
+                }
+
+                if (guardActive && activeIndex >= 0
+                    && forms[activeIndex].Rows < Math.Min(MinActiveRows, Math.Max(1, rowCounts[activeIndex])))
+                {
+                    continue;
+                }
+
+                int total = 0;
+                for (int i = 0; i < count; i++)
+                {
+                    total += measure(i, forms[i])
+                        + TileHorizontalMarginLogicalPx
+                        + (i > 0 ? TileSeparatorLogicalPx : 0);
+                }
+
+                if (total > budget)
+                    continue;
+
+                // Rank by how much is actually readable. A row is worth four points, so a row always beats a
+                // countdown and dropping the countdown is the cheapest step down. A countdown on the ACTIVE
+                // tile is worth more than one on a pinned tile: when you are working in a tool, when its
+                // window resets is the number you care about, whereas a pinned provider you are only
+                // monitoring can lose its countdown to the tooltip. Without that weighting every countdown
+                // scored the same, ties fell to enumeration order, and the active tile — evaluated first —
+                // was always the one stripped.
+                int detail = 0, shown = 0, rightness = 0;
+                for (int i = 0; i < count; i++)
+                {
+                    if (forms[i].Rows >= 1)
+                    {
+                        detail += forms[i].Rows * 4;
+                        if (forms[i].HideReset)
+                            rightness += i;
+                        else
+                            detail += i == activeIndex ? ActiveResetWeight : PinnedResetWeight;
+                        shown++;
+                    }
+                    else if (forms[i].IsCompact)
+                    {
+                        detail += 1;
+                        shown++;
+                        rightness += i;
+                    }
+                    else
+                    {
+                        rightness += i;
+                    }
+                }
+
+                var score = (detail, shown, rightness);
+                if (score.CompareTo(bestScore) <= 0)
+                    continue;
+
+                bestScore = score;
+                bestForms = forms;
+            }
+
+            return bestForms;
+        }
+
+        /// <summary>
+        /// How many trailing tiles must collapse to their glyph for the row to fit <paramref name="budget"/>.
+        /// Collapsing from the right means the active tile (slot 0) keeps its detail longest. Can return the
+        /// full count when even a row of glyphs overflows — that's the floor, and a clipped row of glyphs
+        /// still beats a pinned provider disappearing.
+        /// </summary>
+        internal static int SolveCollapseCount(IReadOnlyList<int> fullWidths, int iconWidth, int budget)
+        {
+            int collapsed = 0;
+            while (collapsed < fullWidths.Count && MeasureRowWidth(fullWidths, collapsed, iconWidth) > budget)
+                collapsed++;
+            return collapsed;
+        }
+
+        private static Microsoft.UI.Xaml.Media.Brush TaskbarForegroundBrush()
+        {
+            bool light = SystemInfos.IsSystemLightThemeUsed() == true;
+            return new Microsoft.UI.Xaml.Media.SolidColorBrush(
+                light ? Windows.UI.Color.FromArgb(255, 28, 28, 28) : Colors.White);
+        }
+
+        // Records the widest free gap (logical px) as the budget for how many tiles may render. Called from
+        // the background position pass, so it only writes the field — the UI-thread entry points
+        // (SetDisplayProviders / a tile re-render / the manager's health tick) re-run the fit math.
+        private void UpdateAvailableWidth(List<(int start, int end)> gaps)
+        {
+            int widest = 0;
+            foreach (var (start, end) in gaps)
+                widest = Math.Max(widest, end - start);
+            if (widest <= 0)
+                return;
+
+            availableLogicalWidth = (int)Math.Floor(widest / dpiScale);
+            // Published so the pin budget can refuse a pin that would not fit this taskbar.
+            TaskbarSpace.AvailableLogicalWidth = availableLogicalWidth;
         }
 
         private bool ResizeWidgetHost(int logicalWidth)
@@ -414,6 +1005,9 @@ namespace TaskbarQuota.Taskbar
                 // Only ever rest inside a gap that FULLY fits the widget; if none does, don't move it into an
                 // overlap — keep the last valid spot (issue #17). First run with no fit hugs the tray.
                 var gaps = ComputeFreeGaps(leftBound, rightBound, obstacles);
+                // The widget is not one of its own obstacles, so the gap it sits in measures the full space
+                // it may occupy. That is the budget the tile-fit math trims against.
+                UpdateAvailableWidth(gaps);
                 int? placed = PlaceInFittingGap(preferredX, gaps, WidgetHostWidth);
                 if (placed is not { } fitX)
                 {
@@ -471,9 +1065,9 @@ namespace TaskbarQuota.Taskbar
 
         public void StartDragging()
         {
-            if (isDragging || appWindow is null || hostContent is null || widgetSummary is null) return;
+            if (isDragging || appWindow is null || hostContent is null || summaryPanel is null) return;
             SetVisible(true);
-            widgetSummary.IsHitTestVisible = false;
+            SetTilesHitTestVisible(false);
             User32.GetWindowRect(hwndShell, out var taskbarRect);
             User32.SetCursorPos(
                 taskbarRect.left + appWindow.Position.X + appWindow.Size.Width / 2,
@@ -489,14 +1083,14 @@ namespace TaskbarQuota.Taskbar
 
         public void EndDragging(bool revert)
         {
-            if (!isDragging || appWindow is null || hostContent is null || widgetSummary is null) return;
+            if (!isDragging || appWindow is null || hostContent is null || summaryPanel is null) return;
             isDragging = false;
             hostContent.ReleasePointerCaptures();
             hostContent.KeyUp -= Content_KeyUp;
             hostContent.PointerMoved -= Content_PointerMoved;
             hostContent.PointerPressed -= Content_PointerPressed;
             hostContent.PointerReleased -= Content_PointerReleased;
-            widgetSummary.IsHitTestVisible = true;
+            SetTilesHitTestVisible(true);
             if (revert)
             {
                 dragPreviewX = null;
@@ -537,11 +1131,11 @@ namespace TaskbarQuota.Taskbar
 
         private void WidgetSummary_PointerPressed(object sender, PointerRoutedEventArgs e)
         {
-            if (appWindow is null || widgetSummary is null) return;
+            if (appWindow is null || sender is not WidgetSummary summary) return;
             isPointerTracking = true;
             isDirectDrag = false;
             PrimeObstacleCacheForDrag();
-            widgetSummary.CapturePointer(e.Pointer);
+            summary.CapturePointer(e.Pointer);
             User32.GetCursorPos(out var point);
             pressCursorPositionX = point.x;
             lastCursorPositionX = point.x;
@@ -551,30 +1145,28 @@ namespace TaskbarQuota.Taskbar
 
         private void WidgetSummary_PointerMoved(object sender, PointerRoutedEventArgs e)
         {
-            if (!isPointerTracking || appWindow is null || widgetSummary is null) return;
+            if (!isPointerTracking || appWindow is null || sender is not WidgetSummary) return;
             User32.GetCursorPos(out var point);
             if (!isDirectDrag)
             {
                 if (Math.Abs(point.x - pressCursorPositionX) < Math.Ceiling(4 * dpiScale))
                     return;
                 isDirectDrag = true;
-                widgetSummary.SuppressNextClick = true;
+                SuppressTileClicks();
                 e.Handled = true;
             }
 
             MoveWidgetWithCursor(point.x);
-            widgetSummary.SuppressNextClick = true;
+            SuppressTileClicks();
         }
 
         private void WidgetSummary_PointerReleased(object sender, PointerRoutedEventArgs e)
         {
-            if (widgetSummary is not null)
-                widgetSummary.ReleasePointerCaptures();
+            (sender as WidgetSummary)?.ReleasePointerCaptures();
             if (isDirectDrag && appWindow is not null)
             {
                 _ = SnapToValidPositionAsync(dragPreviewX ?? appWindow.Position.X);
-                if (widgetSummary is not null)
-                    widgetSummary.SuppressNextClick = true;
+                SuppressTileClicks();
                 e.Handled = true;
             }
             isPointerTracking = false;
@@ -585,7 +1177,27 @@ namespace TaskbarQuota.Taskbar
         {
             isPointerTracking = false;
             isDirectDrag = false;
-            widgetSummary?.ReleasePointerCaptures();
+            (sender as WidgetSummary)?.ReleasePointerCaptures();
+        }
+
+        private void SetTilesHitTestVisible(bool visible)
+        {
+            foreach (var tile in tiles)
+            {
+                if (tile is not null)
+                    tile.IsHitTestVisible = visible;
+            }
+        }
+
+        // A drag can cross tiles, so every tile swallows the click that ends it — otherwise releasing over
+        // a neighbour opens the flyout right after a reposition.
+        private void SuppressTileClicks()
+        {
+            foreach (var tile in tiles)
+            {
+                if (tile is not null)
+                    tile.SuppressNextClick = true;
+            }
         }
 
         /// <summary>
@@ -820,8 +1432,13 @@ namespace TaskbarQuota.Taskbar
         {
             var result = new List<RECT>();
 
-            if (hwndStart != IntPtr.Zero && User32.GetWindowRect(hwndStart, out RECT startRect) && startRect.right > startRect.left)
+            if (hwndStart != IntPtr.Zero
+                && User32.IsWindowVisible(hwndStart)
+                && User32.GetWindowRect(hwndStart, out RECT startRect)
+                && startRect.right > startRect.left)
+            {
                 result.Add(ToTaskbarClientRect(startRect, taskbarScreenRect));
+            }
 
             // Classic taskbars (Win10 / third-party shells) expose Start/search as child windows here; on
             // Win11 these return little and the UIA button set below carries the app icons.
@@ -1154,6 +1771,12 @@ namespace TaskbarQuota.Taskbar
             if (className is not ("Start" or "TrayDummySearchControl" or "ReBarWindow32" or "MSTaskSwWClass" or "MSTaskListWClass"))
                 return true;
 
+            // A hidden shell element takes up no room on screen, so reserving its bounds costs the widget
+            // real width for nothing. Windows keeps the Start button and the legacy task list around as
+            // hidden windows with live rects, which was quietly stealing ~45px from the free span.
+            if (!User32.IsWindowVisible(hWnd))
+                return true;
+
             if (!User32.GetWindowRect(hWnd, out RECT bounds))
                 return true;
             int width = bounds.right - bounds.left;
@@ -1271,7 +1894,9 @@ namespace TaskbarQuota.Taskbar
 
         private bool EnumWindow(IntPtr hWnd, IntPtr lParam)
         {
-            if (hWnd != hwnd && User32.GetAncestor(hWnd, GetAncestorFlags.GA_PARENT) == hwndShell)
+            if (hWnd != hwnd
+                && User32.IsWindowVisible(hWnd)
+                && User32.GetAncestor(hWnd, GetAncestorFlags.GA_PARENT) == hwndShell)
             {
                 var builder = new StringBuilder(256);
                 User32.GetClassName(hWnd, builder, builder.Capacity);
@@ -1299,13 +1924,17 @@ namespace TaskbarQuota.Taskbar
             isVisible = false;
             positionUpdateCancellation.Cancel();
             try { appWindow?.Hide(); } catch { }
-            if (widgetSummary is not null)
+            foreach (var tile in tiles)
             {
-                widgetSummary.PointerPressed -= WidgetSummary_PointerPressed;
-                widgetSummary.DesiredHostWidthChanged -= WidgetSummary_DesiredHostWidthChanged;
-                widgetSummary.PointerMoved -= WidgetSummary_PointerMoved;
-                widgetSummary.PointerReleased -= WidgetSummary_PointerReleased;
-                widgetSummary.PointerCanceled -= WidgetSummary_PointerCanceled;
+                if (tile is null)
+                    continue;
+
+                tile.PointerPressed -= WidgetSummary_PointerPressed;
+                tile.DesiredHostWidthChanged -= WidgetSummary_DesiredHostWidthChanged;
+                tile.PointerMoved -= WidgetSummary_PointerMoved;
+                tile.PointerReleased -= WidgetSummary_PointerReleased;
+                tile.PointerCanceled -= WidgetSummary_PointerCanceled;
+                tile.Clicked -= OnTileClicked;
             }
             _ = CompleteDisposeAfterPositionUpdatesAsync();
             GC.SuppressFinalize(this);
@@ -1391,7 +2020,14 @@ namespace TaskbarQuota.Taskbar
             appWindow = null;
             host = null;
             hostContent = null;
-            widgetSummary = null;
+            summaryPanel = null;
+            Array.Clear(tiles);
+            Array.Clear(separators);
+            Array.Clear(tileProviders);
+            Array.Clear(tileFits);
+            Array.Clear(tileIconOnly);
+            Array.Clear(tileSuppressed);
+            lastTilePositions = new Dictionary<ProviderId, int>();
         }
     }
 }

--- a/src/TaskbarQuota.App/Taskbar/TaskbarSpace.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskbarSpace.cs
@@ -1,0 +1,34 @@
+namespace TaskbarQuota.Taskbar;
+
+/// <summary>
+/// The free width the taskbar widget last measured for itself, shared so the pin budget can answer
+/// "would this fit?" without owning a widget.
+///
+/// The measurement only exists in <see cref="TaskBarWidget"/> — it comes from the gap solver that already
+/// knows where the shell's own elements are — while the decision to allow a pin is made in the dashboard,
+/// which has no widget. Rather than a fixed guess at how much room a taskbar has, the real number is
+/// published here as it changes.
+/// </summary>
+internal static class TaskbarSpace
+{
+    /// <summary>Assumed free width before any measurement has been taken.</summary>
+    public const int UnknownWidth = 0;
+
+    /// <summary>Widest free span on the taskbar, in logical pixels. Zero until first measured.</summary>
+    public static int AvailableLogicalWidth { get; set; } = UnknownWidth;
+
+    // Real rendered width per provider. The budget used to model this — an icon plus a column group per
+    // two rows — which is close but not close enough: a Credits row or a long label puts a tile tens of
+    // pixels over the model, and at that error a set that genuinely fits gets refused. The widget measures
+    // every tile it lays out anyway, so the exact numbers are recorded here and used in preference.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<Usage.ProviderId, int> Measured = new();
+
+    public static void RecordTileWidth(Usage.ProviderId provider, int logicalWidth)
+    {
+        if (logicalWidth > 0)
+            Measured[provider] = logicalWidth;
+    }
+
+    public static bool TryGetTileWidth(Usage.ProviderId provider, out int logicalWidth)
+        => Measured.TryGetValue(provider, out logicalWidth);
+}

--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -26,6 +26,10 @@ namespace TaskbarQuota
         private readonly SemaphoreSlim _detectGate = new(1, 1);
         private readonly object _recentLock = new();
         private readonly List<ProviderId> _recentProviders = new();
+        // Providers with a pinned-tile refresh in flight, so the 5s health timer never stacks a second
+        // fetch for one that is still running — a slow or offline endpoint would otherwise accumulate
+        // concurrent requests and could publish an older snapshot out of order.
+        private readonly HashSet<ProviderId> _widgetRefreshInFlight = new();
         private Timer? _timer;
         // Synara persists provider switches through a 300 ms-debounced localStorage writer, and Chromium
         // then flushes that to its on-disk LevelDB on its own (variable, sometimes >1 s) cadence. The
@@ -89,6 +93,71 @@ namespace TaskbarQuota
                         return p;
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Hard cap on taskbar tiles. Three is the most that fits beside the tray on a normal bar even in
+        /// the narrow display modes; <see cref="Taskbar.TaskBarWidget"/> trims further when the measured
+        /// widths don't fit the free gap it actually has.
+        /// </summary>
+        public const int MaxWidgetTiles = 3;
+
+        /// <summary>
+        /// Every provider the taskbar widget should render as its own tile, left to right: the ACTIVE
+        /// provider always first, then the pinned providers (most recently active first, then enum order).
+        /// So with Claude pinned + Z.AI pinned and Codex active you get "Codex | Claude | Z.AI", and
+        /// focusing Claude re-orders to "Claude | Z.AI" + whatever else is pinned — the active provider
+        /// keeps the leading slot while the pinned tiles stay put behind it (issue #25).
+        /// With nothing pinned this returns exactly <see cref="WidgetDisplayProvider"/>, so the existing
+        /// single-tile behavior is unchanged.
+        /// </summary>
+        public IReadOnlyList<ProviderId> WidgetDisplayProviders
+            => ComputeWidgetDisplayProviders(
+                _lastActive,
+                IsActiveToolPresent,
+                RecentProviders,
+                Enum.GetValues<ProviderId>(),
+                WidgetSettingsService.IsProviderPinned,
+                WidgetSettingsService.IsProviderVisible,
+                IsProviderAvailable,
+                WidgetDisplayProvider);
+
+        /// <summary>Pure, testable core of <see cref="WidgetDisplayProviders"/>.</summary>
+        internal static IReadOnlyList<ProviderId> ComputeWidgetDisplayProviders(
+            ProviderId? active,
+            bool present,
+            IReadOnlyList<ProviderId> recent,
+            IReadOnlyList<ProviderId> ordered,
+            Func<ProviderId, bool> isPinned,
+            Func<ProviderId, bool> isVisible,
+            Func<ProviderId, bool> isAvailable,
+            ProviderId? fallback)
+        {
+            var result = new List<ProviderId>();
+
+            // The active provider leads even when it is itself pinned — it is the one the user is looking
+            // at right now, so it gets the stable leftmost slot and the pinned tiles trail it.
+            if (present && active is { } a && isVisible(a))
+                result.Add(a);
+
+            var recentIndex = new Dictionary<ProviderId, int>();
+            for (int i = 0; i < recent.Count; i++)
+                recentIndex.TryAdd(recent[i], i);
+
+            var pinned = ordered
+                .Where(p => isPinned(p) && isVisible(p) && isAvailable(p) && !result.Contains(p))
+                .OrderBy(p => recentIndex.TryGetValue(p, out int index) ? index : int.MaxValue)
+                .ToList();
+            result.AddRange(pinned);
+
+            // Nothing active and nothing pinned: keep today's single-tile fallback so users with no pins
+            // still see the last-used / first-enabled provider.
+            if (result.Count == 0 && present && fallback is { } fb)
+                result.Add(fb);
+
+            if (result.Count > MaxWidgetTiles)
+                result.RemoveRange(MaxWidgetTiles, result.Count - MaxWidgetTiles);
+            return result;
         }
 
         // A provider can back the widget only if it is actually installed or has been configured — so we
@@ -597,6 +666,37 @@ namespace TaskbarQuota
 
             LastState = snapshot;
             StateChanged?.Invoke(snapshot);
+        }
+
+        /// <summary>
+        /// Refreshes one pinned tile's provider and publishes it through <see cref="StateChanged"/> so the
+        /// widget routes it to that tile. The tick only ever fetches the ACTIVE provider, so without this a
+        /// pinned tile would freeze on its boot snapshot. Cheap: <see cref="UsageService.FetchAsync"/> is
+        /// cache-TTL gated, so most calls return the cached snapshot without touching the network. Leaves
+        /// <see cref="LastState"/> and the active provider alone.
+        /// </summary>
+        public async Task RefreshWidgetProviderAsync(ProviderId id)
+        {
+            lock (_widgetRefreshInFlight)
+            {
+                if (!_widgetRefreshInFlight.Add(id))
+                    return;
+            }
+
+            try
+            {
+                var result = (await _service.FetchAsync(id).ConfigureAwait(false)).WithSource(SourceFor(id));
+                StateChanged?.Invoke(result);
+            }
+            catch (Exception ex)
+            {
+                Diagnostics.Log.Warning(ex, $"Widget provider refresh for {id} failed");
+            }
+            finally
+            {
+                lock (_widgetRefreshInFlight)
+                    _widgetRefreshInFlight.Remove(id);
+            }
         }
 
         /// <summary>Fetch all providers (cached) for the multi-provider view.</summary>

--- a/src/TaskbarQuota.App/ViewModels/ProviderCardViewModel.cs
+++ b/src/TaskbarQuota.App/ViewModels/ProviderCardViewModel.cs
@@ -175,6 +175,12 @@ namespace TaskbarQuota.ViewModels
         public string ProviderWidgetToggleName { get; }
         public string ProviderWidgetToggleText => IsProviderWidgetVisible ? "Widget" : "Ignored";
         public Visibility ProviderWidgetToggleVisibility => IsSetupRequired ? Visibility.Collapsed : Visibility.Visible;
+        public bool IsProviderPinned { get; internal set; }
+        public string ProviderPinToggleName { get; }
+        public string ProviderPinToggleText => IsProviderPinned ? "Pinned" : "Pin";
+        /// <summary>Pinning only makes sense for a provider the widget is allowed to draw at all.</summary>
+        public bool IsProviderPinToggleEnabled => IsProviderWidgetVisible;
+        public Visibility ProviderPinToggleVisibility => ProviderWidgetToggleVisibility;
         public Visibility WidgetOptionsVisibility => IsSetupRequired ? Visibility.Collapsed : ContentVisibility;
 
         public IReadOnlyList<BarViewModel> Bars { get; }
@@ -227,6 +233,8 @@ namespace TaskbarQuota.ViewModels
             ProviderId = r.Id;
             IsProviderWidgetVisible = WidgetSettingsService.IsProviderVisible(r.Id);
             ProviderWidgetToggleName = $"Show {DisplayName} in taskbar widget";
+            IsProviderPinned = WidgetSettingsService.IsProviderPinned(r.Id);
+            ProviderPinToggleName = $"Pin {DisplayName} to the taskbar widget";
 
             var bars = new List<BarViewModel>();
             var textMetrics = new List<TextMetricViewModel>();
@@ -401,6 +409,7 @@ namespace TaskbarQuota.ViewModels
         internal void RefreshVisibility()
         {
             IsProviderWidgetVisible = WidgetSettingsService.IsProviderVisible(ProviderId);
+            IsProviderPinned = WidgetSettingsService.IsProviderPinned(ProviderId);
             foreach (var bar in Bars) bar.RefreshVisibility();
             foreach (var metric in TextMetrics) metric.RefreshVisibility();
             CreditWidgetToggle.RefreshVisibility();

--- a/src/TaskbarQuota.App/ViewModels/SettingsViewModel.cs
+++ b/src/TaskbarQuota.App/ViewModels/SettingsViewModel.cs
@@ -13,15 +13,23 @@ namespace TaskbarQuota.ViewModels
 
         [ObservableProperty] public partial bool IsDashboardVisible { get; set; }
         [ObservableProperty] public partial bool IsWidgetVisible { get; set; }
+        [ObservableProperty] public partial bool IsPinned { get; set; }
 
         public string StatusText { get; private set; }
 
-        public ProviderSettingItemViewModel(ProviderId id, string displayName, bool dashboardVisible, bool widgetVisible, string statusText)
+        public ProviderSettingItemViewModel(
+            ProviderId id,
+            string displayName,
+            bool dashboardVisible,
+            bool widgetVisible,
+            bool pinned,
+            string statusText)
         {
             Id = id;
             DisplayName = displayName;
             IsDashboardVisible = dashboardVisible;
             IsWidgetVisible = widgetVisible;
+            IsPinned = pinned;
             StatusText = statusText;
         }
 
@@ -102,6 +110,7 @@ namespace TaskbarQuota.ViewModels
                     provider.DisplayName,
                     WidgetSettingsService.IsProviderDashboardVisible(provider.Id),
                     WidgetSettingsService.IsProviderVisible(provider.Id),
+                    WidgetSettingsService.IsProviderPinned(provider.Id),
                     status));
             }
         }
@@ -113,12 +122,26 @@ namespace TaskbarQuota.ViewModels
             else
                 ProviderDiscoveryService.DisableProvider(item.Id);
 
+            // Enable/DisableProvider also flips widget visibility (and a pin rides on that), so refresh
+            // all three so the toggles reflect reality.
             item.IsDashboardVisible = WidgetSettingsService.IsProviderDashboardVisible(item.Id);
+            item.IsWidgetVisible = WidgetSettingsService.IsProviderVisible(item.Id);
+            item.IsPinned = WidgetSettingsService.IsProviderPinned(item.Id);
         }
 
         public void ApplyWidgetVisibility(ProviderSettingItemViewModel item, bool visible)
         {
             WidgetSettingsService.SetProviderVisible(item.Id, visible);
+            item.IsWidgetVisible = WidgetSettingsService.IsProviderVisible(item.Id);
+            // Hiding a provider from the widget drops its pin.
+            item.IsPinned = WidgetSettingsService.IsProviderPinned(item.Id);
+        }
+
+        public void ApplyPinned(ProviderSettingItemViewModel item, bool pinned)
+        {
+            WidgetSettingsService.SetProviderPinned(item.Id, pinned);
+            item.IsPinned = WidgetSettingsService.IsProviderPinned(item.Id);
+            // Pinning implies widget-visible, so reflect the possibly-flipped widget toggle.
             item.IsWidgetVisible = WidgetSettingsService.IsProviderVisible(item.Id);
         }
     }

--- a/src/TaskbarQuota.App/Views/DashboardPage.xaml
+++ b/src/TaskbarQuota.App/Views/DashboardPage.xaml
@@ -547,6 +547,22 @@
                                           Click="ProviderWidgetToggle_Click">
                                 <TextBlock Text="{x:Bind ViewModel.SelectedCard.ProviderWidgetToggleText, Mode=OneWay}"/>
                             </ToggleButton>
+                            <ToggleButton x:Name="ProviderPinToggle"
+                                          AutomationProperties.AutomationId="ProviderWidgetPinToggle"
+                                          AutomationProperties.Name="{x:Bind ViewModel.SelectedCard.ProviderPinToggleName, Mode=OneWay}"
+                                          IsChecked="{x:Bind ViewModel.SelectedCard.IsProviderPinned, Mode=OneWay}"
+                                          IsEnabled="{x:Bind ViewModel.SelectedCard.IsProviderPinToggleEnabled, Mode=OneWay}"
+                                          Visibility="{x:Bind ViewModel.SelectedCard.ProviderPinToggleVisibility, Mode=OneWay}"
+                                          Tag="{x:Bind ViewModel.SelectedCard, Mode=OneWay}"
+                                          VerticalAlignment="Center"
+                                          MinWidth="76"
+                                          ToolTipService.ToolTip="Keep this provider on the taskbar even when another tool is active"
+                                          Click="ProviderPinToggle_Click">
+                                <StackPanel Orientation="Horizontal" Spacing="6">
+                                    <FontIcon Glyph="&#xE718;" FontSize="14"/>
+                                    <TextBlock Text="{x:Bind ViewModel.SelectedCard.ProviderPinToggleText, Mode=OneWay}"/>
+                                </StackPanel>
+                            </ToggleButton>
                         </StackPanel>
 
                         <VisualStateManager.VisualStateGroups>
@@ -604,5 +620,12 @@
                 </Grid>
             </StackPanel>
         </ScrollViewer>
+
+        <!-- Explains a refused pin. A tooltip on the button is no use here: the user has just clicked it
+             and watched nothing happen, so the reason has to appear without being hunted for. -->
+        <muxc:TeachingTip x:Name="PinBlockedTip"
+                          Title="Can't pin this provider"
+                          PreferredPlacement="Bottom"
+                          IsLightDismissEnabled="True"/>
     </Grid>
 </Page>

--- a/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
@@ -353,7 +353,43 @@ namespace TaskbarQuota.Views
                 return;
 
             WidgetSettingsService.SetProviderVisible(card.ProviderId, toggle.IsChecked == true);
+            card.IsProviderWidgetVisible = WidgetSettingsService.IsProviderVisible(card.ProviderId);
+            // Hiding a provider from the widget also drops its pin, so keep the pin button in step.
+            card.IsProviderPinned = WidgetSettingsService.IsProviderPinned(card.ProviderId);
+            ProviderPinToggle.IsChecked = card.IsProviderPinned;
+            ProviderPinToggle.IsEnabled = card.IsProviderPinToggleEnabled;
         }
+
+        private void ProviderPinToggle_Click(object sender, RoutedEventArgs e)
+        {
+            if (_suppressWidgetEvents)
+                return;
+            if (sender is not ToggleButton toggle || toggle.Tag is not ProviderCardViewModel card)
+                return;
+
+            bool wantPinned = toggle.IsChecked == true;
+            if (wantPinned && !Services.PinBudgetService.CanPin(card.ProviderId, out var reason))
+            {
+                // Over budget: refuse rather than silently unpinning something the user still wants, and
+                // show why plus what to change — a toggle that springs back with no explanation reads as
+                // a broken button.
+                toggle.IsChecked = false;
+                PinBlockedTip.Target = toggle;
+                PinBlockedTip.Subtitle = reason;
+                PinBlockedTip.IsOpen = true;
+                return;
+            }
+
+            PinBlockedTip.IsOpen = false;
+
+            WidgetSettingsService.SetProviderPinned(card.ProviderId, wantPinned);
+            card.IsProviderPinned = WidgetSettingsService.IsProviderPinned(card.ProviderId);
+            card.IsProviderWidgetVisible = WidgetSettingsService.IsProviderVisible(card.ProviderId);
+            ToolTipService.SetToolTip(toggle, DefaultPinTooltip);
+        }
+
+        private const string DefaultPinTooltip =
+            "Keep this provider on the taskbar even when another tool is active";
 
         private void OpenSetupUrl_Click(object sender, RoutedEventArgs e)
         {

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml
@@ -20,6 +20,15 @@
 
             <TextBlock Text="Settings" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,8"/>
 
+            <!-- Explains a refused pin, matching DashboardPage. A tooltip is no use here: the user has just
+                 flicked the switch and watched it spring back, so the reason has to appear unprompted. -->
+            <muxc:InfoBar x:Name="PinBlockedBar"
+                          Severity="Warning"
+                          Title="Can't pin this provider"
+                          IsOpen="False"
+                          IsClosable="True"
+                          Margin="0,0,0,4"/>
+
             <TextBlock Text="Appearance" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,8,0,2"/>
             <tk:SettingsCard Header="Theme" Description="Choose how TaskbarQuota looks.">
                 <tk:SettingsCard.HeaderIcon>

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
@@ -208,11 +208,12 @@ namespace TaskbarQuota.Views
                 _suppressProviderToggleEvents = true;
                 try { toggle.IsOn = false; }
                 finally { _suppressProviderToggleEvents = false; }
-                ToolTipService.SetToolTip(toggle, reason);
+                PinBlockedBar.Message = reason;
+                PinBlockedBar.IsOpen = true;
                 return;
             }
 
-            ToolTipService.SetToolTip(toggle, null);
+            PinBlockedBar.IsOpen = false;
             ViewModel.ApplyPinned(item, toggle.IsOn);
             RefreshProviderRow(item);
         }

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
@@ -1,9 +1,11 @@
+using System.Collections.Generic;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
 using TaskbarQuota.Helpers;
 using TaskbarQuota.Services;
+using TaskbarQuota.Usage;
 using TaskbarQuota.ViewModels;
 
 namespace TaskbarQuota.Views
@@ -12,6 +14,17 @@ namespace TaskbarQuota.Views
     {
         public SettingsViewModel ViewModel { get; } = new();
         private bool _isInitializing;
+        // Suppresses the Toggled handlers while a row's toggles are synced programmatically.
+        private bool _suppressProviderToggleEvents;
+        // Per-provider toggles, so changing one updates only its own row instead of rebuilding the list.
+        private readonly Dictionary<ProviderId, ProviderToggleRow> _providerRows = new();
+
+        private sealed class ProviderToggleRow
+        {
+            public ToggleSwitch? Dashboard;
+            public ToggleSwitch? Widget;
+            public ToggleSwitch? Pinned;
+        }
 
         public SettingsPage()
         {
@@ -47,6 +60,7 @@ namespace TaskbarQuota.Views
         private void RebuildProviderSettings()
         {
             ProviderSettingsPanel.Children.Clear();
+            _providerRows.Clear();
             foreach (var item in ViewModel.Providers)
             {
                 var card = new CommunityToolkit.WinUI.Controls.SettingsCard
@@ -68,16 +82,26 @@ namespace TaskbarQuota.Views
                 });
                 card.Header = header;
 
+                var toggles = new ProviderToggleRow();
+                _providerRows[item.Id] = toggles;
+
                 var content = new StackPanel { Spacing = 8, MinWidth = 180 };
-                content.Children.Add(CreateProviderToggleRow("Dashboard", item, dashboard: true));
-                content.Children.Add(CreateProviderToggleRow("Widget", item, dashboard: false));
+                content.Children.Add(CreateProviderToggleRow("Dashboard", item, ProviderToggleKind.Dashboard, toggles));
+                content.Children.Add(CreateProviderToggleRow("Widget", item, ProviderToggleKind.Widget, toggles));
+                content.Children.Add(CreateProviderToggleRow("Pinned", item, ProviderToggleKind.Pinned, toggles));
                 card.Content = content;
 
                 ProviderSettingsPanel.Children.Add(card);
             }
         }
 
-        private FrameworkElement CreateProviderToggleRow(string label, ProviderSettingItemViewModel item, bool dashboard)
+        private enum ProviderToggleKind { Dashboard, Widget, Pinned }
+
+        private FrameworkElement CreateProviderToggleRow(
+            string label,
+            ProviderSettingItemViewModel item,
+            ProviderToggleKind kind,
+            ProviderToggleRow toggles)
         {
             var row = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
             row.Children.Add(new TextBlock
@@ -90,12 +114,54 @@ namespace TaskbarQuota.Views
 
             var toggle = new ToggleSwitch
             {
-                IsOn = dashboard ? item.IsDashboardVisible : item.IsWidgetVisible,
+                IsOn = kind switch
+                {
+                    ProviderToggleKind.Dashboard => item.IsDashboardVisible,
+                    ProviderToggleKind.Pinned => item.IsPinned,
+                    _ => item.IsWidgetVisible,
+                },
+                // A provider can only be pinned to the taskbar when the widget may draw it at all.
+                IsEnabled = kind != ProviderToggleKind.Pinned || item.IsWidgetVisible,
                 Tag = item,
             };
-            toggle.Toggled += dashboard ? OnProviderDashboardToggled : OnProviderWidgetToggled;
+            switch (kind)
+            {
+                case ProviderToggleKind.Dashboard: toggles.Dashboard = toggle; break;
+                case ProviderToggleKind.Pinned: toggles.Pinned = toggle; break;
+                default: toggles.Widget = toggle; break;
+            }
+            toggle.Toggled += kind switch
+            {
+                ProviderToggleKind.Dashboard => OnProviderDashboardToggled,
+                ProviderToggleKind.Pinned => OnProviderPinnedToggled,
+                _ => OnProviderWidgetToggled,
+            };
             row.Children.Add(toggle);
             return row;
+        }
+
+        // Syncs one provider's toggles to its current state in place. Enabling/disabling a provider and
+        // pinning both flip sibling toggles, and a whole-list rebuild would flash the page.
+        private void RefreshProviderRow(ProviderSettingItemViewModel item)
+        {
+            if (!_providerRows.TryGetValue(item.Id, out var row))
+                return;
+
+            _suppressProviderToggleEvents = true;
+            try
+            {
+                if (row.Dashboard is { } dashboard) dashboard.IsOn = item.IsDashboardVisible;
+                if (row.Widget is { } widget) widget.IsOn = item.IsWidgetVisible;
+                if (row.Pinned is { } pinned)
+                {
+                    pinned.IsOn = item.IsPinned;
+                    pinned.IsEnabled = item.IsWidgetVisible;
+                }
+            }
+            finally
+            {
+                _suppressProviderToggleEvents = false;
+            }
         }
 
         private void OnAutoHideUnavailableToggled(object sender, RoutedEventArgs e)
@@ -108,22 +174,47 @@ namespace TaskbarQuota.Views
 
         private void OnProviderDashboardToggled(object sender, RoutedEventArgs e)
         {
-            if (_isInitializing)
+            if (_isInitializing || _suppressProviderToggleEvents)
                 return;
             if (sender is not ToggleSwitch toggle || toggle.Tag is not ProviderSettingItemViewModel item)
                 return;
 
             ViewModel.ApplyDashboardVisibility(item, toggle.IsOn);
+            // Enabling/disabling a provider also flips widget visibility (and with it the pin).
+            RefreshProviderRow(item);
         }
 
         private void OnProviderWidgetToggled(object sender, RoutedEventArgs e)
         {
-            if (_isInitializing)
+            if (_isInitializing || _suppressProviderToggleEvents)
                 return;
             if (sender is not ToggleSwitch toggle || toggle.Tag is not ProviderSettingItemViewModel item)
                 return;
 
             ViewModel.ApplyWidgetVisibility(item, toggle.IsOn);
+            // Widget visibility gates whether Pinned can be toggled at all.
+            RefreshProviderRow(item);
+        }
+
+        private void OnProviderPinnedToggled(object sender, RoutedEventArgs e)
+        {
+            if (_isInitializing || _suppressProviderToggleEvents)
+                return;
+            if (sender is not ToggleSwitch toggle || toggle.Tag is not ProviderSettingItemViewModel item)
+                return;
+
+            if (toggle.IsOn && !PinBudgetService.CanPin(item.Id, out var reason))
+            {
+                _suppressProviderToggleEvents = true;
+                try { toggle.IsOn = false; }
+                finally { _suppressProviderToggleEvents = false; }
+                ToolTipService.SetToolTip(toggle, reason);
+                return;
+            }
+
+            ToolTipService.SetToolTip(toggle, null);
+            ViewModel.ApplyPinned(item, toggle.IsOn);
+            RefreshProviderRow(item);
         }
 
         private void OnThemeChanged(object sender, SelectionChangedEventArgs e)

--- a/tests/TaskbarQuota.Tests/PinBudgetServiceTests.cs
+++ b/tests/TaskbarQuota.Tests/PinBudgetServiceTests.cs
@@ -5,101 +5,22 @@ using TaskbarQuota.Usage;
 namespace TaskbarQuota.Tests;
 
 /// <summary>
-/// Pinned providers are priced by weight rather than counted: a provider showing three or more rows is
-/// twice as wide as one showing two, because rows pack two to a column group. The user spends a budget of
-/// five slots however they like — three short, two long, or a long plus two short.
+/// Pinning is limited by one thing: whether the tiles fit the taskbar space actually measured. A pinned
+/// tile is never trimmed, so a set that would not fit has to be refused rather than rendered badly.
 /// </summary>
 public class PinBudgetServiceTests
 {
+    // Measured tile widths: a two-row provider renders around 223px, a three-row one around 405px.
+    private const int ShortTile = 223;
+    private const int LongTile = 405;
+
     [Theory]
-    [InlineData(1, PinBudgetService.ShortSlots)]
-    [InlineData(2, PinBudgetService.ShortSlots)]
-    [InlineData(3, PinBudgetService.LongSlots)]
-    [InlineData(4, PinBudgetService.LongSlots)]
-    [InlineData(6, PinBudgetService.LongSlots)]
-    public void RowsDecideWhetherAProviderIsShortOrLong(int rows, int expected)
-        => Assert.Equal(expected, PinBudgetService.SlotCostForRows(rows));
-
-    [Fact]
-    public void TheCombinationsFromTheDesignAllFitTheBudget()
-    {
-        // three short
-        Assert.Equal(3, 3 * PinBudgetService.ShortSlots);
-        // a long plus two short
-        Assert.Equal(4, PinBudgetService.LongSlots + (2 * PinBudgetService.ShortSlots));
-        // two long
-        Assert.Equal(4, 2 * PinBudgetService.LongSlots);
-        // two long plus a short — the widest allowed
-        Assert.Equal(PinBudgetService.TotalSlots, (2 * PinBudgetService.LongSlots) + PinBudgetService.ShortSlots);
-    }
-
-    [Fact]
-    public void ThreeLongProvidersExceedTheBudget()
-        => Assert.True(3 * PinBudgetService.LongSlots > PinBudgetService.TotalSlots);
-
-    [Fact]
-    public void NothingIsDroppedWhileTheSetFits()
-    {
-        var pinned = Pinned((ProviderId.Zai, 1), (ProviderId.Claude, 2), (ProviderId.Codex, 2));
-
-        Assert.Empty(PinBudgetService.SelectDrops(pinned, budget: 5, maxCount: 3));
-    }
-
-    [Fact]
-    public void DropsFromTheFrontUntilTheWeightFits()
-    {
-        // Least worth keeping first: three long providers weigh six against a budget of five.
-        var pinned = Pinned((ProviderId.Zai, 2), (ProviderId.Claude, 2), (ProviderId.Codex, 2));
-
-        var dropped = PinBudgetService.SelectDrops(pinned, budget: 5, maxCount: 3);
-
-        Assert.Equal(new[] { ProviderId.Zai }, dropped);
-    }
-
-    [Fact]
-    public void DropsMoreThanOneWhenASingleDropIsNotEnough()
-    {
-        var pinned = Pinned((ProviderId.Zai, 2), (ProviderId.Claude, 2), (ProviderId.Codex, 2));
-
-        var dropped = PinBudgetService.SelectDrops(pinned, budget: 2, maxCount: 3);
-
-        Assert.Equal(new[] { ProviderId.Zai, ProviderId.Claude }, dropped);
-    }
-
-    // A provider growing from two rows to three doubles its weight, which can push an already-pinned set
-    // over budget. The row toggle wins and the least recently used pin makes way.
-    [Fact]
-    public void GrowingAProviderCanEvictTheLeastRecentPin()
-    {
-        var pinned = Pinned((ProviderId.Zai, 1), (ProviderId.Claude, 2), (ProviderId.Codex, 2));
-        Assert.Empty(PinBudgetService.SelectDrops(pinned, budget: 5, maxCount: 3));
-
-        // Z.AI gains a third row: 1 -> 2, total 6.
-        var grown = Pinned((ProviderId.Zai, 2), (ProviderId.Claude, 2), (ProviderId.Codex, 2));
-        Assert.Equal(new[] { ProviderId.Zai }, PinBudgetService.SelectDrops(grown, budget: 5, maxCount: 3));
-    }
-
-    [Fact]
-    public void TheTileCapAppliesEvenWhenTheWeightFits()
-    {
-        // Four one-row providers weigh four of five, but the taskbar only renders three tiles.
-        var pinned = Pinned(
-            (ProviderId.Zai, 1), (ProviderId.Claude, 1), (ProviderId.Codex, 1), (ProviderId.Cursor, 1));
-
-        var dropped = PinBudgetService.SelectDrops(pinned, budget: 5, maxCount: 3);
-
-        Assert.Equal(new[] { ProviderId.Zai }, dropped);
-    }
-
-    // Width, not weight, is the constraint that actually decides whether a row renders. A tile is one icon
-    // plus a column group per two rows, so three rows costs a whole extra group.
-    [Fact]
-    public void ATileGrowsByAColumnGroupEveryTwoRows()
-    {
-        Assert.Equal(PinBudgetService.EstimateTileWidth(1), PinBudgetService.EstimateTileWidth(2));
-        Assert.Equal(PinBudgetService.EstimateTileWidth(3), PinBudgetService.EstimateTileWidth(4));
-        Assert.True(PinBudgetService.EstimateTileWidth(3) > PinBudgetService.EstimateTileWidth(2));
-    }
+    [InlineData(1, 225)]
+    [InlineData(2, 225)]
+    [InlineData(3, 405)]
+    [InlineData(4, 405)]
+    public void ATileGrowsByAColumnGroupEveryTwoRows(int rows, int expected)
+        => Assert.Equal(expected, PinBudgetService.EstimateTileWidth(rows));
 
     [Fact]
     public void RowWidthCountsMarginsAndDividers()
@@ -111,43 +32,10 @@ public class PinBudgetServiceTests
         Assert.Equal(one + 200 + 4 + 7, two);
     }
 
-    // The reported case: Claude (2 rows) + Copilot (1 row) + ClinePass (3 rows) on a 684px bar. It was
-    // being allowed, then the middle tile rendered as a bare glyph.
-    [Fact]
-    public void RefusesASetThatWouldNotFitTheMeasuredTaskbar()
-    {
-        Assert.False(PinBudgetService.FitsTaskbar(new List<int> { 2, 1, 3 }, availableWidth: 684));
-        Assert.True(PinBudgetService.FitsTaskbar(new List<int> { 2, 1 }, availableWidth: 684));
-    }
-
-    [Fact]
-    public void AWiderTaskbarAcceptsTheSameSet()
-        => Assert.True(PinBudgetService.FitsTaskbar(new List<int> { 2, 1, 3 }, availableWidth: 1326));
-
-    // Reported bug: with only Cline (3 rows) pinned, pinning Claude (2 rows) was refused even though the
-    // two render side by side perfectly well. The budget was reserving room for a THIRD active tile that
-    // does not exist when the provider being pinned is the one in use.
-    [Fact]
-    public void JudgesOnlyThePinnedSet()
-    {
-        // Cline + Claude comes to 655 plus the safety margin — comfortably inside a 750px bar.
-        Assert.True(PinBudgetService.FitsTaskbar(new List<int> { 3, 2 }, availableWidth: 750));
-    }
-
-    // Before a widget has measured anything there is no free-span figure to judge against; refusing every
-    // pin at that point would make pinning look broken on a cold start.
-    [Fact]
-    public void FallsBackToTheWeightBudgetBeforeAnythingIsMeasured()
-        => Assert.True(PinBudgetService.FitsTaskbar(new List<int> { 2, 3, 3 }, availableWidth: 0));
-
-    // Measured tile widths: a two-row provider renders around 223px, a three-row one around 405px.
-    private const int ShortTile = 223;
-    private const int LongTile = 405;
-
     /// <summary>
-    /// What each combination actually costs, so the weight rule is never mistaken for the real limit. The
-    /// slot budget allows two long providers plus a short one; the taskbar it has to fit does not, unless
-    /// the bar is unusually wide. Width is the binding constraint and these are the numbers.
+    /// What each combination costs against real taskbar spans. These are the limits users actually hit,
+    /// and they depend entirely on how much room the bar has — which is why an abstract slot allowance was
+    /// removed: it refused three long providers outright, though they fit a left-aligned taskbar.
     /// </summary>
     [Theory]
     // A centre-aligned Windows taskbar leaves roughly 684-750px between the icon cluster and the tray.
@@ -156,15 +44,81 @@ public class PinBudgetServiceTests
     [InlineData(728, new[] { LongTile, ShortTile }, true)]
     [InlineData(728, new[] { LongTile, ShortTile, ShortTile }, false)]
     [InlineData(728, new[] { LongTile, LongTile }, false)]
-    [InlineData(728, new[] { LongTile, LongTile, ShortTile }, false)]
     // A narrower span drops the three-short case too.
     [InlineData(684, new[] { ShortTile, ShortTile, ShortTile }, false)]
     [InlineData(684, new[] { LongTile, ShortTile }, true)]
-    // Left-aligning the taskbar frees roughly 1326px, where the wide combinations do fit.
+    // Left-aligning the taskbar frees roughly 1326px, where the wide combinations fit — including three
+    // long providers, which the old weight budget refused as "six slots of five".
     [InlineData(1326, new[] { LongTile, LongTile }, true)]
     [InlineData(1326, new[] { LongTile, LongTile, ShortTile }, true)]
-    public void WidthIsTheBindingConstraintNotTheSlotBudget(int available, int[] tiles, bool expected)
+    [InlineData(1326, new[] { LongTile, LongTile, LongTile }, true)]
+    public void SpaceIsTheOnlyLimit(int available, int[] tiles, bool expected)
         => Assert.Equal(expected, PinBudgetService.RowWidth(tiles) <= available);
+
+    // Before a widget has measured anything there is no span to judge against; refusing every pin at that
+    // point would make pinning look broken on a cold start.
+    [Fact]
+    public void FallsBackToTheTileCapBeforeAnythingIsMeasured()
+        => Assert.True(PinBudgetService.FitsTaskbar(new List<int> { 2, 3, 3 }, availableWidth: 0));
+
+    [Fact]
+    public void NothingIsDroppedWhileTheSetFits()
+    {
+        var pinned = Pinned((ProviderId.Zai, ShortTile), (ProviderId.Claude, ShortTile));
+
+        Assert.Empty(PinBudgetService.SelectDrops(pinned, availableWidth: 728, maxCount: 3));
+    }
+
+    // Least recently used first, so what the user has just been working in is what survives.
+    [Fact]
+    public void DropsFromTheFrontUntilTheRowFits()
+    {
+        var pinned = Pinned(
+            (ProviderId.Zai, LongTile), (ProviderId.Claude, LongTile), (ProviderId.Codex, ShortTile));
+
+        var dropped = PinBudgetService.SelectDrops(pinned, availableWidth: 728, maxCount: 3);
+
+        Assert.Equal(new[] { ProviderId.Zai }, dropped);
+    }
+
+    [Fact]
+    public void DropsMoreThanOneWhenASingleDropIsNotEnough()
+    {
+        var pinned = Pinned(
+            (ProviderId.Zai, LongTile), (ProviderId.Claude, LongTile), (ProviderId.Codex, LongTile));
+
+        var dropped = PinBudgetService.SelectDrops(pinned, availableWidth: 500, maxCount: 3);
+
+        Assert.Equal(new[] { ProviderId.Zai, ProviderId.Claude }, dropped);
+    }
+
+    // Enabling a row can add a whole column group, which is what pushes an already-pinned set over.
+    [Fact]
+    public void GrowingAProviderCanEvictTheLeastRecentPin()
+    {
+        var before = Pinned(
+            (ProviderId.Zai, ShortTile), (ProviderId.Claude, ShortTile), (ProviderId.Codex, ShortTile));
+        Assert.Empty(PinBudgetService.SelectDrops(before, availableWidth: 728, maxCount: 3));
+
+        // Z.AI gains a third row and becomes a two-group tile.
+        var after = Pinned(
+            (ProviderId.Zai, LongTile), (ProviderId.Claude, ShortTile), (ProviderId.Codex, ShortTile));
+        Assert.Equal(
+            new[] { ProviderId.Zai },
+            PinBudgetService.SelectDrops(after, availableWidth: 728, maxCount: 3));
+    }
+
+    [Fact]
+    public void TheTileCapAppliesEvenWhenTheWidthFits()
+    {
+        // Four narrow providers would fit a wide bar, but the widget only renders three tiles.
+        var pinned = Pinned(
+            (ProviderId.Zai, 100), (ProviderId.Claude, 100), (ProviderId.Codex, 100), (ProviderId.Cursor, 100));
+
+        var dropped = PinBudgetService.SelectDrops(pinned, availableWidth: 2000, maxCount: 3);
+
+        Assert.Equal(new[] { ProviderId.Zai }, dropped);
+    }
 
     private static List<(ProviderId, int)> Pinned(params (ProviderId, int)[] entries) => [.. entries];
 }

--- a/tests/TaskbarQuota.Tests/PinBudgetServiceTests.cs
+++ b/tests/TaskbarQuota.Tests/PinBudgetServiceTests.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+using TaskbarQuota.Services;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.Tests;
+
+/// <summary>
+/// Pinned providers are priced by weight rather than counted: a provider showing three or more rows is
+/// twice as wide as one showing two, because rows pack two to a column group. The user spends a budget of
+/// five slots however they like — three short, two long, or a long plus two short.
+/// </summary>
+public class PinBudgetServiceTests
+{
+    [Theory]
+    [InlineData(1, PinBudgetService.ShortSlots)]
+    [InlineData(2, PinBudgetService.ShortSlots)]
+    [InlineData(3, PinBudgetService.LongSlots)]
+    [InlineData(4, PinBudgetService.LongSlots)]
+    [InlineData(6, PinBudgetService.LongSlots)]
+    public void RowsDecideWhetherAProviderIsShortOrLong(int rows, int expected)
+        => Assert.Equal(expected, PinBudgetService.SlotCostForRows(rows));
+
+    [Fact]
+    public void TheCombinationsFromTheDesignAllFitTheBudget()
+    {
+        // three short
+        Assert.Equal(3, 3 * PinBudgetService.ShortSlots);
+        // a long plus two short
+        Assert.Equal(4, PinBudgetService.LongSlots + (2 * PinBudgetService.ShortSlots));
+        // two long
+        Assert.Equal(4, 2 * PinBudgetService.LongSlots);
+        // two long plus a short — the widest allowed
+        Assert.Equal(PinBudgetService.TotalSlots, (2 * PinBudgetService.LongSlots) + PinBudgetService.ShortSlots);
+    }
+
+    [Fact]
+    public void ThreeLongProvidersExceedTheBudget()
+        => Assert.True(3 * PinBudgetService.LongSlots > PinBudgetService.TotalSlots);
+
+    [Fact]
+    public void NothingIsDroppedWhileTheSetFits()
+    {
+        var pinned = Pinned((ProviderId.Zai, 1), (ProviderId.Claude, 2), (ProviderId.Codex, 2));
+
+        Assert.Empty(PinBudgetService.SelectDrops(pinned, budget: 5, maxCount: 3));
+    }
+
+    [Fact]
+    public void DropsFromTheFrontUntilTheWeightFits()
+    {
+        // Least worth keeping first: three long providers weigh six against a budget of five.
+        var pinned = Pinned((ProviderId.Zai, 2), (ProviderId.Claude, 2), (ProviderId.Codex, 2));
+
+        var dropped = PinBudgetService.SelectDrops(pinned, budget: 5, maxCount: 3);
+
+        Assert.Equal(new[] { ProviderId.Zai }, dropped);
+    }
+
+    [Fact]
+    public void DropsMoreThanOneWhenASingleDropIsNotEnough()
+    {
+        var pinned = Pinned((ProviderId.Zai, 2), (ProviderId.Claude, 2), (ProviderId.Codex, 2));
+
+        var dropped = PinBudgetService.SelectDrops(pinned, budget: 2, maxCount: 3);
+
+        Assert.Equal(new[] { ProviderId.Zai, ProviderId.Claude }, dropped);
+    }
+
+    // A provider growing from two rows to three doubles its weight, which can push an already-pinned set
+    // over budget. The row toggle wins and the least recently used pin makes way.
+    [Fact]
+    public void GrowingAProviderCanEvictTheLeastRecentPin()
+    {
+        var pinned = Pinned((ProviderId.Zai, 1), (ProviderId.Claude, 2), (ProviderId.Codex, 2));
+        Assert.Empty(PinBudgetService.SelectDrops(pinned, budget: 5, maxCount: 3));
+
+        // Z.AI gains a third row: 1 -> 2, total 6.
+        var grown = Pinned((ProviderId.Zai, 2), (ProviderId.Claude, 2), (ProviderId.Codex, 2));
+        Assert.Equal(new[] { ProviderId.Zai }, PinBudgetService.SelectDrops(grown, budget: 5, maxCount: 3));
+    }
+
+    [Fact]
+    public void TheTileCapAppliesEvenWhenTheWeightFits()
+    {
+        // Four one-row providers weigh four of five, but the taskbar only renders three tiles.
+        var pinned = Pinned(
+            (ProviderId.Zai, 1), (ProviderId.Claude, 1), (ProviderId.Codex, 1), (ProviderId.Cursor, 1));
+
+        var dropped = PinBudgetService.SelectDrops(pinned, budget: 5, maxCount: 3);
+
+        Assert.Equal(new[] { ProviderId.Zai }, dropped);
+    }
+
+    // Width, not weight, is the constraint that actually decides whether a row renders. A tile is one icon
+    // plus a column group per two rows, so three rows costs a whole extra group.
+    [Fact]
+    public void ATileGrowsByAColumnGroupEveryTwoRows()
+    {
+        Assert.Equal(PinBudgetService.EstimateTileWidth(1), PinBudgetService.EstimateTileWidth(2));
+        Assert.Equal(PinBudgetService.EstimateTileWidth(3), PinBudgetService.EstimateTileWidth(4));
+        Assert.True(PinBudgetService.EstimateTileWidth(3) > PinBudgetService.EstimateTileWidth(2));
+    }
+
+    [Fact]
+    public void RowWidthCountsMarginsAndDividers()
+    {
+        int one = PinBudgetService.RowWidth(new List<int> { 200 });
+        int two = PinBudgetService.RowWidth(new List<int> { 200, 200 });
+
+        // Each extra tile adds its own width plus one margin and one divider.
+        Assert.Equal(one + 200 + 4 + 7, two);
+    }
+
+    // The reported case: Claude (2 rows) + Copilot (1 row) + ClinePass (3 rows) on a 684px bar. It was
+    // being allowed, then the middle tile rendered as a bare glyph.
+    [Fact]
+    public void RefusesASetThatWouldNotFitTheMeasuredTaskbar()
+    {
+        Assert.False(PinBudgetService.FitsTaskbar(new List<int> { 2, 1, 3 }, availableWidth: 684));
+        Assert.True(PinBudgetService.FitsTaskbar(new List<int> { 2, 1 }, availableWidth: 684));
+    }
+
+    [Fact]
+    public void AWiderTaskbarAcceptsTheSameSet()
+        => Assert.True(PinBudgetService.FitsTaskbar(new List<int> { 2, 1, 3 }, availableWidth: 1326));
+
+    // Reported bug: with only Cline (3 rows) pinned, pinning Claude (2 rows) was refused even though the
+    // two render side by side perfectly well. The budget was reserving room for a THIRD active tile that
+    // does not exist when the provider being pinned is the one in use.
+    [Fact]
+    public void JudgesOnlyThePinnedSet()
+    {
+        // Cline + Claude comes to 655 plus the safety margin — comfortably inside a 750px bar.
+        Assert.True(PinBudgetService.FitsTaskbar(new List<int> { 3, 2 }, availableWidth: 750));
+    }
+
+    // Before a widget has measured anything there is no free-span figure to judge against; refusing every
+    // pin at that point would make pinning look broken on a cold start.
+    [Fact]
+    public void FallsBackToTheWeightBudgetBeforeAnythingIsMeasured()
+        => Assert.True(PinBudgetService.FitsTaskbar(new List<int> { 2, 3, 3 }, availableWidth: 0));
+
+    private static List<(ProviderId, int)> Pinned(params (ProviderId, int)[] entries) => [.. entries];
+}

--- a/tests/TaskbarQuota.Tests/PinBudgetServiceTests.cs
+++ b/tests/TaskbarQuota.Tests/PinBudgetServiceTests.cs
@@ -164,7 +164,7 @@ public class PinBudgetServiceTests
     [InlineData(1326, new[] { LongTile, LongTile }, true)]
     [InlineData(1326, new[] { LongTile, LongTile, ShortTile }, true)]
     public void WidthIsTheBindingConstraintNotTheSlotBudget(int available, int[] tiles, bool expected)
-        => Assert.Equal(expected, PinBudgetService.RowWidth(tiles) + 6 <= available);
+        => Assert.Equal(expected, PinBudgetService.RowWidth(tiles) <= available);
 
     private static List<(ProviderId, int)> Pinned(params (ProviderId, int)[] entries) => [.. entries];
 }

--- a/tests/TaskbarQuota.Tests/PinBudgetServiceTests.cs
+++ b/tests/TaskbarQuota.Tests/PinBudgetServiceTests.cs
@@ -140,5 +140,31 @@ public class PinBudgetServiceTests
     public void FallsBackToTheWeightBudgetBeforeAnythingIsMeasured()
         => Assert.True(PinBudgetService.FitsTaskbar(new List<int> { 2, 3, 3 }, availableWidth: 0));
 
+    // Measured tile widths: a two-row provider renders around 223px, a three-row one around 405px.
+    private const int ShortTile = 223;
+    private const int LongTile = 405;
+
+    /// <summary>
+    /// What each combination actually costs, so the weight rule is never mistaken for the real limit. The
+    /// slot budget allows two long providers plus a short one; the taskbar it has to fit does not, unless
+    /// the bar is unusually wide. Width is the binding constraint and these are the numbers.
+    /// </summary>
+    [Theory]
+    // A centre-aligned Windows taskbar leaves roughly 684-750px between the icon cluster and the tray.
+    [InlineData(728, new[] { ShortTile, ShortTile }, true)]
+    [InlineData(728, new[] { ShortTile, ShortTile, ShortTile }, true)]
+    [InlineData(728, new[] { LongTile, ShortTile }, true)]
+    [InlineData(728, new[] { LongTile, ShortTile, ShortTile }, false)]
+    [InlineData(728, new[] { LongTile, LongTile }, false)]
+    [InlineData(728, new[] { LongTile, LongTile, ShortTile }, false)]
+    // A narrower span drops the three-short case too.
+    [InlineData(684, new[] { ShortTile, ShortTile, ShortTile }, false)]
+    [InlineData(684, new[] { LongTile, ShortTile }, true)]
+    // Left-aligning the taskbar frees roughly 1326px, where the wide combinations do fit.
+    [InlineData(1326, new[] { LongTile, LongTile }, true)]
+    [InlineData(1326, new[] { LongTile, LongTile, ShortTile }, true)]
+    public void WidthIsTheBindingConstraintNotTheSlotBudget(int available, int[] tiles, bool expected)
+        => Assert.Equal(expected, PinBudgetService.RowWidth(tiles) + 6 <= available);
+
     private static List<(ProviderId, int)> Pinned(params (ProviderId, int)[] entries) => [.. entries];
 }

--- a/tests/TaskbarQuota.Tests/TaskBarWidgetTileFitTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskBarWidgetTileFitTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TaskbarQuota.Controls;
+using TaskbarQuota.Taskbar;
+
+namespace TaskbarQuota.Tests;
+
+using Form = WidgetSummary.SummaryForm;
+
+/// <summary>
+/// The taskbar row renders pinned providers exactly as configured (issue #25): every row, every reset
+/// countdown, no trimming and no glyph fallback. Keeping the row inside the taskbar is the pin budget's
+/// job — see <see cref="PinBudgetServiceTests"/> — so the layout solver only has one form per tile.
+/// </summary>
+public class TaskBarWidgetTileFitTests
+{
+    private const int GlyphWidth = 44;
+
+    private static int Expected(params int[] widths)
+    {
+        int total = 0;
+        for (int i = 0; i < widths.Length; i++)
+            total += widths[i] + 8 + (i > 0 ? 9 : 0);
+        return total;
+    }
+
+    private static Func<int, Form, int> Measure(params int[] fullWidths)
+        => (position, form) => form.IsGlyph ? GlyphWidth : fullWidths[position];
+
+    [Fact]
+    public void EveryTileRendersInFullWhenThereIsRoom()
+    {
+        var forms = TaskBarWidget.SolveTileLayout(
+            new List<int> { 2, 1, 2 }, activeIndex: 0, Measure(227, 180, 180), Expected(227, 180, 180));
+
+        Assert.Equal(new[] { 2, 1, 2 }, forms.Select(f => f.Rows));
+        Assert.All(forms, f => Assert.False(f.HideReset));
+    }
+
+    // The regression that matters: nothing is ever trimmed or hidden to make room, however tight it is.
+    // A provider that cannot fit should have been refused at pin time, not quietly degraded here.
+    [Fact]
+    public void NeverTrimsOrHidesATileHoweverTightTheSpace()
+    {
+        var forms = TaskBarWidget.SolveTileLayout(
+            new List<int> { 2, 3, 2 }, activeIndex: 0, Measure(227, 407, 242), budget: 100);
+
+        Assert.Equal(new[] { 2, 3, 2 }, forms.Select(f => f.Rows));
+        Assert.All(forms, f =>
+        {
+            Assert.False(f.IsGlyph);
+            Assert.False(f.IsCompact);
+            Assert.False(f.HideReset);
+        });
+    }
+
+    [Fact]
+    public void RowCountsAreHonouredExactly()
+    {
+        var forms = TaskBarWidget.SolveTileLayout(
+            new List<int> { 4, 1 }, activeIndex: 1, Measure(405, 225), budget: 700);
+
+        Assert.Equal(new[] { 4, 1 }, forms.Select(f => f.Rows));
+    }
+
+    [Fact]
+    public void EmptyRowSolvesToNothing()
+        => Assert.Empty(TaskBarWidget.SolveTileLayout(
+            new List<int>(), activeIndex: -1, Measure(), budget: 500));
+}

--- a/tests/TaskbarQuota.Tests/TaskBarWidgetTileFitTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskBarWidgetTileFitTests.cs
@@ -1,71 +1,53 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using TaskbarQuota.Controls;
 using TaskbarQuota.Taskbar;
+using TaskbarQuota.Usage;
 
 namespace TaskbarQuota.Tests;
 
-using Form = WidgetSummary.SummaryForm;
-
 /// <summary>
 /// The taskbar row renders pinned providers exactly as configured (issue #25): every row, every reset
-/// countdown, no trimming and no glyph fallback. Keeping the row inside the taskbar is the pin budget's
-/// job — see <see cref="PinBudgetServiceTests"/> — so the layout solver only has one form per tile.
+/// countdown, no trimming and no glyph fallback. That used to be enforced by a layout solver whose ladder
+/// held a single rung — a search that could only ever return one answer — so the guarantee is structural
+/// now instead: there is no reduced form for a tile to fall back to, and keeping the row inside the
+/// taskbar is the pin budget's job (see <see cref="PinBudgetServiceTests"/>).
+///
+/// What survives as testable logic is the order in which the widget holds a tile back when the row still
+/// overflows the measured gap: least recently used first, so whatever the user was last working in stays.
 /// </summary>
 public class TaskBarWidgetTileFitTests
 {
-    private const int GlyphWidth = 44;
-
-    private static int Expected(params int[] widths)
+    [Fact]
+    public void RecencyFollowsTheRecentlyActiveOrder()
     {
-        int total = 0;
-        for (int i = 0; i < widths.Length; i++)
-            total += widths[i] + 8 + (i > 0 ? 9 : 0);
-        return total;
+        var recent = new List<ProviderId> { ProviderId.Codex, ProviderId.Claude, ProviderId.Zai };
+
+        Assert.Equal(0, TaskBarWidget.RecencyOf(ProviderId.Codex, recent));
+        Assert.Equal(1, TaskBarWidget.RecencyOf(ProviderId.Claude, recent));
+        Assert.Equal(2, TaskBarWidget.RecencyOf(ProviderId.Zai, recent));
     }
 
-    private static Func<int, Form, int> Measure(params int[] fullWidths)
-        => (position, form) => form.IsGlyph ? GlyphWidth : fullWidths[position];
-
+    // A provider that has never been focused is the first thing to give up its tile, so it has to sort
+    // behind every provider that has been.
     [Fact]
-    public void EveryTileRendersInFullWhenThereIsRoom()
+    public void NeverActiveSortsLeastRecent()
     {
-        var forms = TaskBarWidget.SolveTileLayout(
-            new List<int> { 2, 1, 2 }, activeIndex: 0, Measure(227, 180, 180), Expected(227, 180, 180));
+        var recent = new List<ProviderId> { ProviderId.Codex };
 
-        Assert.Equal(new[] { 2, 1, 2 }, forms.Select(f => f.Rows));
-        Assert.All(forms, f => Assert.False(f.HideReset));
-    }
-
-    // The regression that matters: nothing is ever trimmed or hidden to make room, however tight it is.
-    // A provider that cannot fit should have been refused at pin time, not quietly degraded here.
-    [Fact]
-    public void NeverTrimsOrHidesATileHoweverTightTheSpace()
-    {
-        var forms = TaskBarWidget.SolveTileLayout(
-            new List<int> { 2, 3, 2 }, activeIndex: 0, Measure(227, 407, 242), budget: 100);
-
-        Assert.Equal(new[] { 2, 3, 2 }, forms.Select(f => f.Rows));
-        Assert.All(forms, f =>
-        {
-            Assert.False(f.IsGlyph);
-            Assert.False(f.IsCompact);
-            Assert.False(f.HideReset);
-        });
+        Assert.Equal(int.MaxValue, TaskBarWidget.RecencyOf(ProviderId.Cursor, recent));
+        Assert.True(TaskBarWidget.RecencyOf(ProviderId.Cursor, recent)
+            > TaskBarWidget.RecencyOf(ProviderId.Codex, recent));
     }
 
     [Fact]
-    public void RowCountsAreHonouredExactly()
-    {
-        var forms = TaskBarWidget.SolveTileLayout(
-            new List<int> { 4, 1 }, activeIndex: 1, Measure(405, 225), budget: 700);
-
-        Assert.Equal(new[] { 4, 1 }, forms.Select(f => f.Rows));
-    }
+    public void EmptySlotSortsLeastRecent()
+        => Assert.Equal(int.MaxValue, TaskBarWidget.RecencyOf(null, Array.Empty<ProviderId>()));
 
     [Fact]
-    public void EmptyRowSolvesToNothing()
-        => Assert.Empty(TaskBarWidget.SolveTileLayout(
-            new List<int>(), activeIndex: -1, Measure(), budget: 500));
+    public void FirstOccurrenceWinsWhenAProviderRepeats()
+    {
+        var recent = new List<ProviderId> { ProviderId.Codex, ProviderId.Claude, ProviderId.Codex };
+
+        Assert.Equal(0, TaskBarWidget.RecencyOf(ProviderId.Codex, recent));
+    }
 }

--- a/tests/TaskbarQuota.Tests/WidgetCreditValueSampleTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetCreditValueSampleTests.cs
@@ -1,0 +1,37 @@
+using TaskbarQuota.Controls;
+
+namespace TaskbarQuota.Tests;
+
+/// <summary>
+/// The credits column reserves enough width that the value doesn't twitch as the used side grows, but no
+/// more. It used to reserve a fixed "10,000/10,000" for every plan, padding tiles on small plans with tens
+/// of pixels of dead space.
+/// </summary>
+public class WidgetCreditValueSampleTests
+{
+    [Theory]
+    // The used side can never exceed the limit, so the limit's own width is the reserve.
+    [InlineData("12/300", "000/300")]
+    [InlineData("1,234/10,000", "000000/10,000")]
+    [InlineData("0/50", "00/50")]
+    public void ReservesTheLimitsWidthOnEachSide(string value, string expected)
+        => Assert.Equal(expected, WidgetSummary.CreditValueSample(value));
+
+    [Theory]
+    // Nothing to derive a limit from: reserve exactly what is shown.
+    [InlineData("300")]
+    [InlineData("")]
+    [InlineData("/")]
+    [InlineData("500/")]
+    public void FallsBackToTheValueWhenThereIsNoLimit(string value)
+        => Assert.Equal(value, WidgetSummary.CreditValueSample(value));
+
+    // The used side keeps growing, so the reserve has to cover the widest it can ever get — the limit —
+    // even when today's value is narrower. Otherwise the column shifts as the number climbs.
+    [Fact]
+    public void ReserveCoversTheWidestTheValueCanEverGet()
+    {
+        Assert.Equal("10,000/10,000".Length, WidgetSummary.CreditValueSample("9,999/10,000").Length);
+        Assert.Equal("300/300".Length, WidgetSummary.CreditValueSample("7/300").Length);
+    }
+}

--- a/tests/TaskbarQuota.Tests/WidgetDisplayProvidersTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetDisplayProvidersTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.Tests;
+
+/// <summary>
+/// Ordering and capping rules for the taskbar's multi-provider tile list (issue #25): the active
+/// provider always leads, pinned providers trail it most-recently-active first, and the list never
+/// exceeds the tile cap.
+/// </summary>
+public class WidgetDisplayProvidersTests
+{
+    private static IReadOnlyList<ProviderId> Compute(
+        ProviderId? active,
+        IReadOnlyList<ProviderId> pinned,
+        IReadOnlyList<ProviderId>? recent = null,
+        bool present = true,
+        ProviderId? fallback = null,
+        Func<ProviderId, bool>? isVisible = null,
+        Func<ProviderId, bool>? isAvailable = null)
+        => UsageCoordinator.ComputeWidgetDisplayProviders(
+            active,
+            present,
+            recent ?? Array.Empty<ProviderId>(),
+            Enum.GetValues<ProviderId>(),
+            p => pinned.Contains(p),
+            isVisible ?? (_ => true),
+            isAvailable ?? (_ => true),
+            fallback);
+
+    [Fact]
+    public void ActiveProviderLeadsAndPinnedTrailInRecencyOrder()
+    {
+        // The scenario from the issue thread: Claude used just before Codex, Z.AI never focused.
+        var result = Compute(
+            active: ProviderId.Codex,
+            pinned: new[] { ProviderId.Claude, ProviderId.Zai },
+            recent: new[] { ProviderId.Codex, ProviderId.Claude });
+
+        Assert.Equal(new[] { ProviderId.Codex, ProviderId.Claude, ProviderId.Zai }, result);
+    }
+
+    [Fact]
+    public void ActiveProviderLeadsEvenWhenItIsItselfPinned()
+    {
+        var result = Compute(
+            active: ProviderId.Zai,
+            pinned: new[] { ProviderId.Claude, ProviderId.Zai },
+            recent: new[] { ProviderId.Zai, ProviderId.Claude });
+
+        Assert.Equal(new[] { ProviderId.Zai, ProviderId.Claude }, result);
+    }
+
+    [Fact]
+    public void PinnedProvidersStayWhenNoToolIsActive()
+    {
+        var result = Compute(
+            active: null,
+            pinned: new[] { ProviderId.Claude },
+            present: false);
+
+        Assert.Equal(new[] { ProviderId.Claude }, result);
+    }
+
+    [Fact]
+    public void WithoutPinsFallsBackToTheSingleDisplayProvider()
+    {
+        var result = Compute(
+            active: null,
+            pinned: Array.Empty<ProviderId>(),
+            fallback: ProviderId.Codex);
+
+        Assert.Equal(new[] { ProviderId.Codex }, result);
+    }
+
+    [Fact]
+    public void HiddenOrUnavailablePinnedProvidersAreDropped()
+    {
+        var hidden = Compute(
+            active: ProviderId.Codex,
+            pinned: new[] { ProviderId.Claude },
+            isVisible: p => p != ProviderId.Claude);
+        Assert.Equal(new[] { ProviderId.Codex }, hidden);
+
+        var unavailable = Compute(
+            active: ProviderId.Codex,
+            pinned: new[] { ProviderId.Claude },
+            isAvailable: p => p != ProviderId.Claude);
+        Assert.Equal(new[] { ProviderId.Codex }, unavailable);
+    }
+
+    [Fact]
+    public void ActiveProviderHiddenFromTheWidgetDoesNotTakeATile()
+    {
+        var result = Compute(
+            active: ProviderId.Cursor,
+            pinned: new[] { ProviderId.Claude },
+            isVisible: p => p != ProviderId.Cursor);
+
+        Assert.Equal(new[] { ProviderId.Claude }, result);
+    }
+
+    [Fact]
+    public void NeverExceedsTheTileCap()
+    {
+        var result = Compute(
+            active: ProviderId.Codex,
+            pinned: new[] { ProviderId.Claude, ProviderId.Zai, ProviderId.Cursor, ProviderId.Grok });
+
+        Assert.Equal(UsageCoordinator.MaxWidgetTiles, result.Count);
+        Assert.Equal(ProviderId.Codex, result[0]);
+    }
+
+    [Fact]
+    public void EmptyWhenNothingIsPinnedActiveOrAvailable()
+    {
+        var result = Compute(
+            active: null,
+            pinned: Array.Empty<ProviderId>(),
+            present: false,
+            fallback: ProviderId.Codex);
+
+        Assert.Empty(result);
+    }
+}


### PR DESCRIPTION
Lets providers be pinned so their quota stays on the taskbar regardless of which tool is active, instead of the widget only ever showing one provider.

Closes #25 — pin providers so several are visible at once.
Closes #22 — a narrow provider can now share the bar with a wide one instead of having to choose.

## Approach

Per the discussion on #25, the active provider always takes the leftmost slot and pinned providers trail it, most recently active first. So with Claude and Z.AI pinned and Codex in the foreground you get `Codex | Claude | Z.AI`; focusing Claude re-orders to `Claude | Z.AI` rather than duplicating it. The active-tool mechanism is preserved rather than replaced.

Pinned providers render **exactly what they are configured to show** — every row, reset countdowns included. The widget never trims rows or falls back to a bare glyph to make room: how much a provider shows is already a per-provider setting, and silently overriding it is worse than refusing the pin.

## What limits pinning

Two things, and nothing else: **at most 3 tiles**, and **whether they fit the taskbar space actually measured**. `TaskBarWidget` publishes the free span it measures and records each tile's real rendered width; `PinBudgetService` refuses a pin that would not fit and says what to change.

A two-row provider renders around 223px and a three-row one around 405px, plus 4px margin per tile and a 7px divider. A centre-aligned Windows taskbar leaves roughly 684–750px between the icon cluster and the tray; left-aligning it frees one contiguous span of roughly 1326px:

| combination | needs | ~728px bar | left-aligned (~1326px) |
|---|---:|---|---|
| short + short | 467 | ✓ | ✓ |
| short + short + short | 701 | ✓ | ✓ |
| long + short | 649 | ✓ | ✓ |
| long + short + short | 883 | ✗ | ✓ |
| long + long | 831 | ✗ | ✓ |
| long + long + long | 1241 | ✗ | ✓ |

So on a typical centre-aligned bar the practical limit is three short providers, or one long plus one short — and on a wide one, three of anything. These numbers are asserted in `PinBudgetServiceTests.SpaceIsTheOnlyLimit`.

An earlier revision also carried an abstract weight budget (a provider costing one or two "slots" out of five). It has been removed: it duplicated the width check and contradicted it, refusing three long providers as "six slots of five" although they fit a left-aligned taskbar with room to spare. One measured rule beats two rules that disagree.

Two behaviours follow from "a pinned provider is never trimmed":

- **Enabling a row on a pinned provider always works.** If the wider tile no longer fits, the least recently used pin makes way — a display setting must not be refused because of an unrelated pin.
- **When the active tool is not pinned and the row would overflow**, pinned tiles yield least-recently-used first and return the moment you switch away. The widget never grows over the Start button or the tray.

## UI

- Pin toggle in the dashboard card header, mirrored in Settings, with a teaching tip naming the reason a pin was refused and what to change.
- Pin marks on the flyout's provider strip and the main window's navigation items, refreshed in place as pins change.
- Tiles are divided by a thin separator, and re-ordering animates — tiles slide from where their provider previously sat, so gaining a provider reads as movement rather than three tiles cross-fading at once.

## Incidental fixes

- The credits column reserved room for `10,000/10,000` on every plan; it is now sized from the provider's own limit, which was costing tens of pixels of dead space on smaller plans.
- Hidden shell windows (a legacy Start stub, the old task list) were counted as obstacles when measuring free taskbar space despite occupying none.
- Tile chrome trimmed from 42px to 22px for three tiles, which is the difference between a third provider fitting and being refused on a typical bar.

## Notes

- Built on `main`; unrelated to the in-flight `test/combined-fixes` work.
- 474 tests pass. New coverage: display ordering and the tile cap, taskbar fit across real spans, eviction ordering by recency, and the credits reserve.
- A refused pin logs the widths and span it decided from, marking modelled widths with a tilde — a refusal that turns on measurements the user cannot see is otherwise undiagnosable.
- Thanks to @Raphiiko, whose fork on #25 prototyped the multi-tile host and prompted the design discussion.
