### PR TITLE
Fix widget drag stuck in one direction (issue #21 follow-up)

### DIFF
--- a/src/TaskbarQuota.App/Interop/Native.cs
+++ b/src/TaskbarQuota.App/Interop/Native.cs
@@ -21,6 +21,9 @@ namespace TaskbarQuota.Interop
         public static extern bool IsWindow([In] IntPtr hWnd);
 
         [DllImport("user32.dll")]
+        public static extern bool IsWindowVisible([In] IntPtr hWnd);
+
+        [DllImport("user32.dll")]
         public static extern IntPtr DefWindowProc(IntPtr hWnd, uint uMsg, IntPtr wParam, IntPtr lParam);
 
         [DllImport("user32.dll", SetLastError = true)]

--- a/src/TaskbarQuota.App/Interop/Native.cs
+++ b/src/TaskbarQuota.App/Interop/Native.cs
@@ -20,7 +20,8 @@ namespace TaskbarQuota.Interop
         [DllImport("user32.dll")]
         public static extern bool IsWindow([In] IntPtr hWnd);
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool IsWindowVisible([In] IntPtr hWnd);
 
         [DllImport("user32.dll")]

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -94,7 +94,7 @@ namespace TaskbarQuota.Taskbar
         private (int start, int end)? activeDragGap;
         // Last drag solve written to the log, so a held drag logs on change instead of once per pointer sample.
         private (int start, int end)? loggedDragZone;
-        private int loggedDragGapCount = -1;
+        private int loggedDragGapHash;
         private int lastCursorPositionX;
         private int pressCursorPositionX;
         private bool initialized;
@@ -650,6 +650,9 @@ namespace TaskbarQuota.Taskbar
         /// itself changed). One line per change keeps the log small while still showing exactly which
         /// obstacle pinned the widget — a drag that only moves one way looks identical to the user whether the
         /// cause is a phantom obstacle, a bad grab offset, or clamped bounds.
+        ///
+        /// The gap set is compared by SHAPE, not by count: obstacles move and resize far more often than they
+        /// appear or disappear, so counting alone silently swallowed the changes most worth seeing.
         /// </summary>
         private void LogDragState(
             int cursorClientX,
@@ -661,23 +664,63 @@ namespace TaskbarQuota.Taskbar
             (int start, int end)? zone,
             int targetX)
         {
-            if (zone == loggedDragZone && gaps.Count == loggedDragGapCount)
+            int gapHash = HashSpans(gaps);
+            if (zone == loggedDragZone && gapHash == loggedDragGapHash)
                 return;
 
             loggedDragZone = zone;
-            loggedDragGapCount = gaps.Count;
-            Log.Debug(
-                $"drag solve: cursor={cursorClientX} grab={draggingInnerOffsetX} desired={desiredX} " +
-                $"width={WidgetHostWidth} bounds=[{leftBound},{rightBound}) " +
-                $"zone={(zone is { } z ? $"[{z.start},{z.end})" : "none")} target={targetX} " +
-                $"gaps={FormatSpans(gaps)} obstacles={FormatObstacles(obstacles)}");
+            loggedDragGapHash = gapHash;
+
+            // Built in one buffer rather than via ConvertAll + Join, which allocated two intermediate
+            // string lists per line on a path that runs inside a live drag.
+            var text = new StringBuilder(256);
+            text.Append("drag solve: cursor=").Append(cursorClientX)
+                .Append(" grab=").Append(draggingInnerOffsetX)
+                .Append(" desired=").Append(desiredX)
+                .Append(" width=").Append(WidgetHostWidth)
+                .Append(" bounds=[").Append(leftBound).Append(',').Append(rightBound).Append(')')
+                .Append(" zone=");
+            if (zone is { } z)
+                text.Append('[').Append(z.start).Append(',').Append(z.end).Append(')');
+            else
+                text.Append("none");
+            text.Append(" target=").Append(targetX).Append(" gaps=");
+            AppendSpans(text, gaps);
+            text.Append(" obstacles=");
+            AppendObstacles(text, obstacles);
+            Log.Debug(text.ToString());
         }
 
-        private static string FormatSpans(List<(int start, int end)> spans)
-            => spans.Count == 0 ? "-" : string.Join(",", spans.ConvertAll(s => $"[{s.start},{s.end})"));
+        private static int HashSpans(List<(int start, int end)> spans)
+        {
+            var hash = new HashCode();
+            foreach (var (start, end) in spans)
+            {
+                hash.Add(start);
+                hash.Add(end);
+            }
+            return hash.ToHashCode();
+        }
 
-        private static string FormatObstacles(List<RECT> obstacles)
-            => obstacles.Count == 0 ? "-" : string.Join(",", obstacles.ConvertAll(o => $"[{o.left},{o.right})"));
+        private static void AppendSpans(StringBuilder text, List<(int start, int end)> spans)
+        {
+            if (spans.Count == 0) { text.Append('-'); return; }
+            for (int i = 0; i < spans.Count; i++)
+            {
+                if (i > 0) text.Append(',');
+                text.Append('[').Append(spans[i].start).Append(',').Append(spans[i].end).Append(')');
+            }
+        }
+
+        private static void AppendObstacles(StringBuilder text, List<RECT> obstacles)
+        {
+            if (obstacles.Count == 0) { text.Append('-'); return; }
+            for (int i = 0; i < obstacles.Count; i++)
+            {
+                if (i > 0) text.Append(',');
+                text.Append('[').Append(obstacles[i].left).Append(',').Append(obstacles[i].right).Append(')');
+            }
+        }
 
         /// <summary>
         /// Re-anchors the grab point whenever the widget is pinned and the cursor has run past it (span end
@@ -821,7 +864,7 @@ namespace TaskbarQuota.Taskbar
         {
             activeDragGap = null;
             loggedDragZone = null;
-            loggedDragGapCount = -1;
+            loggedDragGapHash = 0;
             User32.GetWindowRect(hwndShell, out RECT taskbarScreenRect);
             _ = PrimeObstacleCacheAsync(taskbarScreenRect);
         }

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -92,6 +92,9 @@ namespace TaskbarQuota.Taskbar
         // Where the drag currently sits, and the free gap it is tracking the cursor inside.
         private int? dragPreviewX;
         private (int start, int end)? activeDragGap;
+        // Last drag solve written to the log, so a held drag logs on change instead of once per pointer sample.
+        private (int start, int end)? loggedDragZone;
+        private int loggedDragGapCount = -1;
         private int lastCursorPositionX;
         private int pressCursorPositionX;
         private bool initialized;
@@ -627,6 +630,7 @@ namespace TaskbarQuota.Taskbar
             if (gap is not { } zone)
             {
                 // No gap can hold the widget at all (very crowded bar): leave it where it is.
+                LogDragState(cursorClientX, desiredX, leftBound, rightBound, gaps, obstacles, null, currentOffsetX);
                 lastCursorPositionX = cursorX;
                 return;
             }
@@ -634,11 +638,46 @@ namespace TaskbarQuota.Taskbar
             activeDragGap = zone;
             int targetX = Math.Clamp(desiredX, zone.start, zone.end - WidgetHostWidth);
 
+            LogDragState(cursorClientX, desiredX, leftBound, rightBound, gaps, obstacles, zone, targetX);
             appWindow.Move(new PointInt32(targetX, currentOffsetY));
             dragPreviewX = targetX;
             ResyncGrabPoint(cursorClientX, targetX, desiredX);
             lastCursorPositionX = cursorX;
         }
+
+        /// <summary>
+        /// Records the drag solve whenever the picture changes (a different gap is tracked, or the gap set
+        /// itself changed). One line per change keeps the log small while still showing exactly which
+        /// obstacle pinned the widget — a drag that only moves one way looks identical to the user whether the
+        /// cause is a phantom obstacle, a bad grab offset, or clamped bounds.
+        /// </summary>
+        private void LogDragState(
+            int cursorClientX,
+            int desiredX,
+            int leftBound,
+            int rightBound,
+            List<(int start, int end)> gaps,
+            List<RECT> obstacles,
+            (int start, int end)? zone,
+            int targetX)
+        {
+            if (zone == loggedDragZone && gaps.Count == loggedDragGapCount)
+                return;
+
+            loggedDragZone = zone;
+            loggedDragGapCount = gaps.Count;
+            Log.Debug(
+                $"drag solve: cursor={cursorClientX} grab={draggingInnerOffsetX} desired={desiredX} " +
+                $"width={WidgetHostWidth} bounds=[{leftBound},{rightBound}) " +
+                $"zone={(zone is { } z ? $"[{z.start},{z.end})" : "none")} target={targetX} " +
+                $"gaps={FormatSpans(gaps)} obstacles={FormatObstacles(obstacles)}");
+        }
+
+        private static string FormatSpans(List<(int start, int end)> spans)
+            => spans.Count == 0 ? "-" : string.Join(",", spans.ConvertAll(s => $"[{s.start},{s.end})"));
+
+        private static string FormatObstacles(List<RECT> obstacles)
+            => obstacles.Count == 0 ? "-" : string.Join(",", obstacles.ConvertAll(o => $"[{o.left},{o.right})"));
 
         /// <summary>
         /// Re-anchors the grab point whenever the widget is pinned and the cursor has run past it (span end
@@ -781,6 +820,8 @@ namespace TaskbarQuota.Taskbar
         private void PrimeObstacleCacheForDrag()
         {
             activeDragGap = null;
+            loggedDragZone = null;
+            loggedDragGapCount = -1;
             User32.GetWindowRect(hwndShell, out RECT taskbarScreenRect);
             _ = PrimeObstacleCacheAsync(taskbarScreenRect);
         }
@@ -837,13 +878,54 @@ namespace TaskbarQuota.Taskbar
             {
                 foreach (var wnd in GetOtherInjectedWindows())
                 {
+                    // Hidden siblings (a widget whose provider is off, or a host left over from an earlier
+                    // taskbar rebuild) keep their last rect. Counting those as obstacles blocks a zone the
+                    // user can see is empty, so the widget refuses to be dragged into it.
+                    if (!User32.IsWindowVisible(wnd))
+                        continue;
                     if (User32.GetWindowRect(wnd, out var injectedBounds) && injectedBounds.right > injectedBounds.left)
                         result.Add(ToTaskbarClientRect(injectedBounds, taskbarScreenRect));
                 }
             }
             catch (Exception ex) { Log.Warning(ex, "overlap scan failed"); }
 
+            result = FilterOffBandRects(result, taskbarScreenRect.bottom - taskbarScreenRect.top);
             return FilterContainerRects(result, taskbarScreenRect.right - taskbarScreenRect.left);
+        }
+
+        /// <summary>
+        /// Drops obstacle rects that do not sit in the taskbar band. Everything reaching the gap solver is in
+        /// taskbar-client coords, so the band is [0, taskbarHeight); rects above it come from popups hosted in
+        /// the taskbar's window/UIA tree (Widgets flyout, icon overflow, jump lists, tooltips). They span wide
+        /// horizontal ranges, and keeping them erases the free gaps under them — the widget then drags in one
+        /// direction only, or not at all.
+        /// </summary>
+        internal static List<RECT> FilterOffBandRects(List<RECT> rects, int taskbarHeight)
+        {
+            if (taskbarHeight <= 0)
+                return rects;
+
+            var kept = new List<RECT>(rects.Count);
+            foreach (var r in rects)
+            {
+                if (IsInVerticalBand(r, 0, taskbarHeight))
+                    kept.Add(r);
+            }
+            return kept;
+        }
+
+        /// <summary>
+        /// True when most of <paramref name="rect"/>'s height falls inside [bandTop, bandBottom). Zero-height
+        /// rects are kept: some shell elements report an empty vertical extent while still occupying the bar.
+        /// </summary>
+        internal static bool IsInVerticalBand(RECT rect, int bandTop, int bandBottom)
+        {
+            int height = rect.bottom - rect.top;
+            if (height <= 0)
+                return true;
+
+            int overlap = Math.Min(rect.bottom, bandBottom) - Math.Max(rect.top, bandTop);
+            return overlap * 2 >= height;
         }
 
         /// <summary>

--- a/src/TaskbarQuota.App/Taskbar/TaskbarStructureWatcher.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskbarStructureWatcher.cs
@@ -97,6 +97,11 @@ namespace TaskbarQuota.Taskbar
                     return CachedWidgetsButtonRect();
 
                 var rect = new RECT { left = r.left, top = r.top, right = r.right, bottom = r.bottom };
+                // The Widgets flyout hosts a "WidgetsButton" element of its own; that one floats above the
+                // bar and its x-span covers the whole left half, which would wipe out every left-hand gap.
+                if (!IsOnTaskbarBand(rect))
+                    return CachedWidgetsButtonRect();
+
                 _lastWidgetsButtonRect = rect;
                 _lastWidgetsButtonRectAt = DateTime.UtcNow;
                 return rect;
@@ -148,8 +153,20 @@ namespace TaskbarQuota.Taskbar
                 for (int i = 0; i < buttons.Length; i++)
                 {
                     var r = buttons.GetElement(i).CurrentBoundingRectangle;
-                    if (r.right > r.left && r.bottom > r.top)
-                        rects.Add(new RECT { left = r.left, top = r.top, right = r.right, bottom = r.bottom });
+                    if (r.right <= r.left || r.bottom <= r.top)
+                        continue;
+
+                    var rect = new RECT { left = r.left, top = r.top, right = r.right, bottom = r.bottom };
+                    // The taskbar UIA tree also carries buttons that are not ON the bar: the Widgets/weather
+                    // flyout, the hidden-icons overflow popup, jump lists and tooltips all hang off the same
+                    // root. Their bounds sit above the taskbar but span wide horizontal ranges, so treating
+                    // them as obstacles erases whole zones and the widget can no longer be dragged into them
+                    // (issue #21 follow-up: drag moved right but never left while the Widgets flyout tree was
+                    // present). Keep only elements that actually live in the taskbar band.
+                    if (!IsOnTaskbarBand(rect))
+                        continue;
+
+                    rects.Add(rect);
                 }
 
                 _lastTaskButtonRects = rects;
@@ -162,6 +179,19 @@ namespace TaskbarQuota.Taskbar
                 _automation = null;
                 return CachedTaskButtonRects();
             }
+        }
+
+        /// <summary>
+        /// True when <paramref name="rect"/> vertically belongs to the taskbar itself rather than to a popup
+        /// hosted in the same UIA tree. Requires most of the element's height to fall inside the bar, which
+        /// keeps genuine bar items (a pixel or two of rounding outside) and drops flyout content above it.
+        /// </summary>
+        private bool IsOnTaskbarBand(RECT rect)
+        {
+            if (!User32.GetWindowRect(hwndTaskbar, out var bar) || bar.bottom <= bar.top)
+                return true;
+
+            return TaskBarWidget.IsInVerticalBand(rect, bar.top, bar.bottom);
         }
 
         private List<RECT>? CachedTaskButtonRects()

--- a/tests/TaskbarQuota.Tests/TaskBarWidgetGapTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskBarWidgetGapTests.cs
@@ -198,6 +198,67 @@ public class TaskBarWidgetGapTests
         Assert.Equal(600, TaskBarWidget.PlaceInFittingGap(450, gaps, 172));
     }
 
+    private static RECT Band(int left, int right, int top, int bottom)
+        => new() { left = left, top = top, right = right, bottom = bottom };
+
+    [Fact]
+    public void FilterOffBandRects_DropsFlyoutContentAboveTheBar()
+    {
+        // Taskbar band is [0,40) in client coords; the Widgets flyout sits above it and spans the left half.
+        var kept = TaskBarWidget.FilterOffBandRects(
+            new List<RECT> { Band(0, 500, -600, -40), R(400, 460) },
+            taskbarHeight: 40);
+
+        Assert.Single(kept);
+        Assert.Equal(400, kept[0].left);
+    }
+
+    [Fact]
+    public void FilterOffBandRects_KeepsBarItemsThatOverhangByAFewPixels()
+    {
+        var kept = TaskBarWidget.FilterOffBandRects(new List<RECT> { Band(100, 160, -3, 38) }, taskbarHeight: 40);
+
+        Assert.Single(kept);
+    }
+
+    [Fact]
+    public void FilterOffBandRects_KeepsEverythingWhenTaskbarHeightUnknown()
+    {
+        var rects = new List<RECT> { Band(0, 500, -600, -40) };
+
+        Assert.Same(rects, TaskBarWidget.FilterOffBandRects(rects, taskbarHeight: 0));
+    }
+
+    [Fact]
+    public void FilterOffBandRects_KeepsZeroHeightRects()
+    {
+        // Some shell elements report an empty vertical extent while still occupying the bar.
+        var kept = TaskBarWidget.FilterOffBandRects(new List<RECT> { Band(100, 160, 20, 20) }, taskbarHeight: 40);
+
+        Assert.Single(kept);
+    }
+
+    [Fact]
+    public void OffBandFlyoutRect_WouldOtherwiseEraseTheLeftDragZone()
+    {
+        // Regression for the "drags right but never left" report: a flyout rect covering [0,500) removes the
+        // whole left zone, so no gap left of the icon cluster remains for the drag to hand over to.
+        var flyout = Band(0, 500, -600, -40);
+        var iconCluster = R(560, 700);
+
+        // Unfiltered, the only free space left of the cluster is the 60px sliver the flyout doesn't cover —
+        // too narrow for the widget, so the drag has nowhere to go on the left.
+        var unfiltered = TaskBarWidget.ComputeFreeGaps(0, 1000, new List<RECT> { flyout, iconCluster });
+        Assert.Equal((500, 560), unfiltered[0]);
+        Assert.Equal(700, TaskBarWidget.PlaceInFittingGap(0, unfiltered, 172));
+
+        var filtered = TaskBarWidget.ComputeFreeGaps(
+            0, 1000, TaskBarWidget.FilterOffBandRects(new List<RECT> { flyout, iconCluster }, taskbarHeight: 40));
+        Assert.Equal(2, filtered.Count);
+        Assert.Equal((0, 560), filtered[0]);
+        Assert.Equal((700, 1000), filtered[1]);
+    }
+
     [Fact]
     public void ComputeUsableHorizontalBounds_PrimaryTaskbar_StopsBeforeTray()
     {

--- a/tests/TaskbarQuota.Tests/TaskBarWidgetGapTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskBarWidgetGapTests.cs
@@ -257,6 +257,11 @@ public class TaskBarWidgetGapTests
         Assert.Equal(2, filtered.Count);
         Assert.Equal((0, 560), filtered[0]);
         Assert.Equal((700, 1000), filtered[1]);
+
+        // The point of the filter: the solver now HANDS the drag the left zone instead of pushing it back
+        // past the cluster. Asserting the gap exists is not enough — the reported symptom was the placement,
+        // and a gap the solver declines to use looks identical to no gap at all.
+        Assert.Equal(0, TaskBarWidget.PlaceInFittingGap(0, filtered, 172));
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #27 / issue #21: a user still reports the widget only drags to the right, never to the left, while the same build behaves on other machines.

## Cause

`TaskbarStructureWatcher.TryGetTaskbarButtonRects` walks the taskbar UIA tree with `FindAll(Descendants, Button)` and treats every hit as an obstacle. That tree also carries elements that are not on the bar — the Widgets/weather flyout, the hidden-icon overflow popup, jump lists, tooltips. Their bounds float above the taskbar, but the gap solver only ever looks at `left`/`right`, so their wide horizontal spans got merged into the blocked set and erased the free gaps underneath.

When that wipes out the zone left of the centred icon cluster, no gap there is wide enough for the widget, so `SelectDragGap` can only ever return the right-hand zone. The drag tracks the cursor to the right and refuses to go left — exactly the report. `FilterContainerRects` did not catch these: it drops only rects wider than half the bar.

The same hole existed for sibling windows: `GetOtherInjectedWindows` had no visibility check, so a hidden widget host (provider turned off, or a leftover from an earlier taskbar rebuild) kept blocking the lane it last occupied.

## Change

- New `FilterOffBandRects` / `IsInVerticalBand` in `TaskBarWidget`: an obstacle is kept only when most of its height falls inside the taskbar band. Bar items that overhang by a pixel or two survive; flyout content above the bar does not. Zero-height rects are kept — some shell elements report an empty vertical extent while still occupying the bar.
- Band check applied at the UIA source too, for the button scan and for the `WidgetsButton` lookup (the Widgets flyout hosts a `WidgetsButton` element of its own).
- `CollectObstacleClientRects` skips sibling windows failing `IsWindowVisible`.
- `LogDragState` writes one `drag solve:` line whenever the tracked gap or the gap set changes, recording cursor, grab offset, bounds, gaps and obstacle spans. One-way-drag reports can now be traced from `%TEMP%\taskbarquota.log` to the obstacle responsible instead of guessed at.

## Tests

`dotnet test` — 438 passing, 5 new, including a regression case where an off-band flyout rect leaves only a 60 px sliver left of the icon cluster and `PlaceInFittingGap` is forced to the right zone.

Verified on a machine where drag already worked; the reporter's configuration (weather pill enabled) is the one that needs confirmation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved widget dragging by ignoring hidden windows and unrelated popups outside the taskbar area.
  * Prevented flyouts and off-taskbar content from incorrectly blocking available placement gaps.
  * Improved handling of taskbar and widget bounds when valid UI positions cannot be detected.
  * Reduced repetitive drag-state logging for clearer diagnostics.

* **Tests**
  * Added coverage for taskbar-band filtering, overhanging items, unknown dimensions, and off-band flyout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->