### PR TITLE
Release 1.1.0: pinned providers, single instance, drag and deadband fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ After detection, usage is fetched from **local credentials** or **provider APIs*
 
 ## Features
 
+### What's new in 1.1.0
+
+- **Pinned providers** — providers can be pinned so their quota stays on the taskbar no matter which tool is in the foreground. The active provider takes the leftmost slot and pinned ones trail it, up to 3 tiles and only while they fit the measured taskbar space. (#32)
+- **Single instance** — launching TaskbarQuota again activates the running app instead of spawning a second widget, with a fallback to a normal launch if the activation redirect fails. (#30)
+- **Drag fixed in both directions** — off-band obstacles (the Widgets flyout, overflow popups, hidden sibling windows) no longer erase the free gap left of the icon cluster, so the widget drags left as well as right. (#33)
+- **Reposition deadband fix** — the deadband no longer overflows before the widget's first placement. (#31)
+
 ### What's new in 1.0.19
 
 - **Widgets on every taskbar** — multi-monitor setups get a widget on each taskbar instead of only the primary one, each confined to its own monitor. (#23)

--- a/src/TaskbarQuota.App/Package.appxmanifest
+++ b/src/TaskbarQuota.App/Package.appxmanifest
@@ -8,7 +8,7 @@
   <Identity
     Name="ZiedKallel.TaskbarQuota"
     Publisher="CN=C23CD2AD-C8FB-4147-9E06-4C046EC0A3AD"
-    Version="1.0.19.0" />
+    Version="1.1.0.0" />
 
   <Properties>
     <DisplayName>TaskbarQuota</DisplayName>

--- a/src/TaskbarQuota.App/TaskbarQuota.App.csproj
+++ b/src/TaskbarQuota.App/TaskbarQuota.App.csproj
@@ -31,9 +31,9 @@
     <Product>TaskbarQuota</Product>
     <AssemblyName>TaskbarQuota</AssemblyName>
     <ApplicationIcon>Assets\TaskBarQuota.ico</ApplicationIcon>
-    <Version>1.0.19</Version>
-    <AssemblyVersion>1.0.19.0</AssemblyVersion>
-    <FileVersion>1.0.19.0</FileVersion>
+    <Version>1.1.0</Version>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Version bump for 1.1.0. Rolls up the work merged into main since 1.0.19.

- Pinned providers (#32)
- Single-instance activation (#30)
- Drag fixed in both directions via off-band obstacle filtering (#33)
- Reposition deadband overflow fix (#31)

Updates `TaskbarQuota.App.csproj`, `Package.appxmanifest`, and the README changelog.

`dotnet test` — 484 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pinned provider support.
  - Added single-instance launch behavior.

- **Bug Fixes**
  - Fixed dragging in both directions.
  - Improved repositioning behavior by correcting movement deadband issues.

- **Release**
  - Updated the application version to 1.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->