### PR TITLE
Hotfix 1.1.1: the taskbar widget never appeared in 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ After detection, usage is fetched from **local credentials** or **provider APIs*
 
 ## Features
 
+### What's new in 1.1.1
+
+- **The widget appears again** — 1.1.0 could leave the taskbar tile fully transparent: the window was injected and placed, the tile measured and laid out, and nothing painted. A render that skipped the cross-fade consumed the tile's one reveal, so a tile seeded from the boot snapshot never faded in. Hotfix on top of 1.1.0.
+
 ### What's new in 1.1.0
 
 - **Pinned providers** — providers can be pinned so their quota stays on the taskbar no matter which tool is in the foreground. The active provider takes the leftmost slot and pinned ones trail it, up to 3 tiles and only while they fit the measured taskbar space. (#32)

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -857,15 +857,40 @@ namespace TaskbarQuota.Controls
             _slideStoryboard.Begin();
         }
 
+        /// <summary>
+        /// Whether a render that skips the cross-fade still has to put the tile on screen outright.
+        ///
+        /// True exactly when this is the tile's first render and it is meant to be showing: the root ships
+        /// at Opacity 0, and the reveal is the only thing that raises it. A suppressed transition that
+        /// returned early here left the tile permanently invisible even though it measured, laid out and
+        /// reported itself Visible.
+        /// </summary>
+        internal static bool ShouldRevealWithoutTransition(bool isFirstReveal, bool isActiveToolVisible)
+            => isFirstReveal && isActiveToolVisible;
+
         private void AnimateRender(bool isFirstReveal, bool providerSwitch = false)
         {
-            _hasRevealed = true;
             if (SuppressNextTransition)
             {
                 SuppressNextTransition = false;
                 Panel.Opacity = RestingPanelOpacity;
+
+                // Suppressing the cross-fade must not swallow the first reveal. Root ships at Opacity 0 and
+                // only the reveal raises it, so a tile seeded from the boot snapshot (which suppresses the
+                // transition) used to stay fully transparent for the life of the process: measured, laid
+                // out, Visible, and painting nothing. Show it outright instead — skipping the fade is the
+                // whole point of the suppression, showing it is not.
+                if (ShouldRevealWithoutTransition(isFirstReveal, _isActiveToolVisible))
+                {
+                    Root.Opacity = 1;
+                    RootTranslate.Y = 0;
+                }
+
+                _hasRevealed = true;
                 return;
             }
+
+            _hasRevealed = true;
 
             if (isFirstReveal)
                 AnimateFirstReveal();

--- a/src/TaskbarQuota.App/Package.appxmanifest
+++ b/src/TaskbarQuota.App/Package.appxmanifest
@@ -8,7 +8,7 @@
   <Identity
     Name="ZiedKallel.TaskbarQuota"
     Publisher="CN=C23CD2AD-C8FB-4147-9E06-4C046EC0A3AD"
-    Version="1.1.0.0" />
+    Version="1.1.1.0" />
 
   <Properties>
     <DisplayName>TaskbarQuota</DisplayName>

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -140,6 +140,9 @@ namespace TaskbarQuota.Taskbar
                 {
                     if (targetsByHandle.TryGetValue(pair.Key, out var target)
                         && pair.Value.IsAlive
+                        // A window whose host content was never built renders nothing and cannot recover on
+                        // its own — it is dead in every way that matters to the user, so recreate it.
+                        && pair.Value.IsHostContentReady
                         && pair.Value.IsDpiCurrent
                         && pair.Value.MatchesTarget(target))
                     {

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -110,9 +110,15 @@ namespace TaskbarQuota.Taskbar
         private bool? separatorBrushIsLight;
         private Microsoft.UI.Xaml.Controls.StackPanel? summaryPanel;
         private int availableLogicalWidth = DefaultAvailableLogicalWidth;
+        // Display set handed over before Initialize() built the panel, replayed once it has.
+        private IReadOnlyList<ProviderId>? pendingProviders;
+        private ProviderId? pendingActiveProvider;
         private bool isRecomputingLayout;
         private bool layoutRepositionPending;
-        private int lastLayoutHash;
+        // Null until the first pass, so that pass always logs. A plain int seeded at 0 could match the first
+        // real hash and swallow the only line that says whether the widget ever laid its tiles out.
+        private int? lastLayoutHash;
+        private bool loggedMissingPanel;
         private DesktopWindowXamlSource? host;
         private Microsoft.UI.Xaml.FrameworkElement? hostContent;
         private int WidgetHostWidth;
@@ -158,6 +164,9 @@ namespace TaskbarQuota.Taskbar
 
         public IntPtr Handle => hwnd != IntPtr.Zero ? hwnd : throw new InvalidOperationException("Widget not initialized.");
         public bool IsAlive => hwnd != IntPtr.Zero && User32.IsWindow(hwnd);
+        /// <summary>True once <see cref="Initialize"/> has built the tile panel. A live window without it can
+        /// render nothing at all, so the manager treats that pairing as a dead widget and recreates it.</summary>
+        public bool IsHostContentReady => summaryPanel is not null;
         public bool IsDpiCurrent
         {
             get
@@ -243,6 +252,23 @@ namespace TaskbarQuota.Taskbar
 
             initialized = true;
             Log.Information("Widget host initialization done");
+
+            // A provider set that arrived before the host content existed was dropped, and nothing re-sent
+            // it: the manager only calls SetDisplayProviders when the set changes, and RefreshLayout hit the
+            // same "no panel yet" early-out on every health tick. That left the host injected with every
+            // tile still collapsed — an invisible widget for the life of the process.
+            ApplyPendingDisplayProviders();
+        }
+
+        /// <summary>Replays the provider set that arrived before <see cref="Initialize"/> built the panel.</summary>
+        private void ApplyPendingDisplayProviders()
+        {
+            if (pendingProviders is not { } providers)
+                return;
+
+            pendingProviders = null;
+            Log.Debug($"[widget] replaying {providers.Count} display provider(s) queued before the host was built");
+            SetDisplayProviders(providers, pendingActiveProvider);
         }
 
         private void InjectIntoTaskbar()
@@ -373,8 +399,15 @@ namespace TaskbarQuota.Taskbar
         /// </summary>
         public void SetDisplayProviders(IReadOnlyList<ProviderId> providers, ProviderId? activeProvider)
         {
+            // Before Initialize() there are no tiles to bind. Hold the set instead of dropping it — the
+            // manager re-sends only on a change, so a dropped first set never came back and the widget
+            // stayed empty forever.
             if (summaryPanel is null)
+            {
+                pendingProviders = providers;
+                pendingActiveProvider = activeProvider;
                 return;
+            }
 
             activeTileProvider = activeProvider;
 
@@ -438,7 +471,18 @@ namespace TaskbarQuota.Taskbar
         private void RecomputeLayout(bool forceReposition = false)
         {
             if (summaryPanel is null)
+            {
+                // Silent before Initialize(); a live window with no panel is the invisible-widget state and
+                // has to be visible in the log, but only once — this runs on every health tick.
+                if (IsAlive && !loggedMissingPanel)
+                {
+                    loggedMissingPanel = true;
+                    Log.Warning("[widget] layout skipped: the window is up but the host content is not built");
+                }
                 return;
+            }
+
+            loggedMissingPanel = false;
 
             // Re-entrant calls are this pass's own re-renders raising DesiredHostWidthChanged. Everything
             // runs on the UI thread with no awaits, so nothing external can interleave — the pass already
@@ -513,6 +557,13 @@ namespace TaskbarQuota.Taskbar
                 bool resized = ResizeWidgetHost(count == 0 ? DefaultWidgetHostWidth : total);
                 if (resized || forceReposition)
                     UpdatePosition();
+            }
+            catch (Exception ex)
+            {
+                // A pass that throws before the visibility loop leaves every tile collapsed, which reads as
+                // "the widget never appeared". Swallowing it here keeps the failure to one pass — the health
+                // tick runs the next one five seconds later — and puts it in the log either way.
+                Log.Warning(ex, "[widget] layout pass failed; tiles keep their previous visibility");
             }
             finally
             {
@@ -2012,6 +2063,8 @@ namespace TaskbarQuota.Taskbar
             host = null;
             hostContent = null;
             summaryPanel = null;
+            pendingProviders = null;
+            pendingActiveProvider = null;
             Array.Clear(tiles);
             Array.Clear(separators);
             Array.Clear(tileProviders);

--- a/src/TaskbarQuota.App/TaskbarQuota.App.csproj
+++ b/src/TaskbarQuota.App/TaskbarQuota.App.csproj
@@ -31,9 +31,9 @@
     <Product>TaskbarQuota</Product>
     <AssemblyName>TaskbarQuota</AssemblyName>
     <ApplicationIcon>Assets\TaskBarQuota.ico</ApplicationIcon>
-    <Version>1.1.0</Version>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <Version>1.1.1</Version>
+    <AssemblyVersion>1.1.1.0</AssemblyVersion>
+    <FileVersion>1.1.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/TaskbarQuota.Tests/WidgetSummaryRevealTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetSummaryRevealTests.cs
@@ -1,0 +1,26 @@
+using TaskbarQuota.Controls;
+
+namespace TaskbarQuota.Tests;
+
+/// <summary>
+/// A tile's root ships at Opacity 0 and only the reveal raises it. Suppressing the cross-fade (which the
+/// host does when a slot is seeded from the boot snapshot, so the movement is carried by the slide instead)
+/// must therefore still show the tile — otherwise it measures, lays out and reports itself Visible while
+/// painting nothing, which is what made the taskbar widget never appear in 1.1.0.
+/// </summary>
+public class WidgetSummaryRevealTests
+{
+    [Fact]
+    public void RevealsOutrightWhenTheFirstRenderSkipsTheTransition()
+        => Assert.True(WidgetSummary.ShouldRevealWithoutTransition(isFirstReveal: true, isActiveToolVisible: true));
+
+    [Fact]
+    public void StaysHiddenWhenTheTileIsNotMeantToShow()
+        => Assert.False(WidgetSummary.ShouldRevealWithoutTransition(isFirstReveal: true, isActiveToolVisible: false));
+
+    // Later renders are cross-fades over an already visible tile; forcing the root back to 1 there would
+    // undo a hide that SetActiveToolVisible had just animated.
+    [Fact]
+    public void LeavesLaterRendersAlone()
+        => Assert.False(WidgetSummary.ShouldRevealWithoutTransition(isFirstReveal: false, isActiveToolVisible: true));
+}


### PR DESCRIPTION
1.1.0 shipped a taskbar widget that never appeared. The host window was injected, placed and topmost; the tiles measured, laid out and reported themselves `Visible`; nothing painted.

## Cause

`WidgetSummary`'s root ships at `Opacity="0"` and `AnimateFirstReveal` — gated on `!_hasRevealed` — is the only thing that raises it. `AnimateRender` set `_hasRevealed = true` *before* the `SuppressNextTransition` early-out, so a render that skipped the cross-fade consumed the tile's one reveal without showing anything.

`TaskBarWidget.SetDisplayProviders` seeds a newly assigned slot exactly that way (`SuppressNextTransition = true`, then `Apply(seed, force: true)`), so whenever a boot snapshot was present at slot assignment the tile stayed fully transparent for the life of the process. Later renders took the soft-refresh branch, which only touches `Panel.Opacity`.

That is #27's snapshot seeding meeting #32's re-order suppression. It needs a seed at assignment time, which is why it looked intermittent and why some relaunches dodged it.

## Change

- A suppressed transition now shows the tile outright when it is also the first render. Skipping the animation is the point of the suppression; hiding the tile is not.
- The rule is extracted as `ShouldRevealWithoutTransition` so it is testable without a XAML runtime (3 tests).

Hardens the paths that let this stay invisible so long:

- `SetDisplayProviders` holds a provider set that arrives before `Initialize` built the panel and replays it, instead of dropping it — the manager only re-sends on a change, and `RefreshLayout` hit the same early-out on every health tick.
- `EnsureWidgets` recreates a live window whose host content was never built.
- The layout pass catches and logs exceptions instead of leaving every tile collapsed silently, and the first pass always logs.

## Verification

`dotnet test` — 487 passing, 3 new. Verified on a real taskbar by screenshot, not just logs: the Claude tile renders Session and Weekly rows again after a cold start that reproduced the blank tile on 1.1.0.