### PR TITLE
feat(widget): hide when provider is not in focus

### DIFF
--- a/src/TaskbarQuota.App/ActiveApp/ActiveAppDetector.cs
+++ b/src/TaskbarQuota.App/ActiveApp/ActiveAppDetector.cs
@@ -361,6 +361,76 @@ namespace TaskbarQuota.ActiveApp
                 return DetectCore();
         }
 
+        /// <summary>
+        /// Fast foreground check for the WinEvent hook path: resolves the provider without any UIA scan
+        /// or WMI query so it completes in under a millisecond even when a browser like Zen is focused.
+        /// <list type="bullet">
+        ///   <item>Known GUI provider process (Cursor, Claude, Codex …) → resolved instantly by name.</item>
+        ///   <item>Synara / T3 Code host → resolved instantly by name, no localStorage read.</item>
+        ///   <item>Browser → uses the <em>already-cached</em> tab URL if it is still within its TTL; does
+        ///         NOT issue a new UI-Automation scan (that is the slow part).</item>
+        ///   <item>Terminal or anything else → returns <see langword="null"/> immediately; the 500 ms tick
+        ///         will sort it out with a full Detect() call.</item>
+        /// </list>
+        /// This is intentionally less accurate than <see cref="Detect"/>: a false-negative (returning null
+        /// when a terminal has a provider CLI) is fine here because the grace timer still runs and the tick
+        /// will correct any wrong hide within 500 ms. A false-positive is impossible — we only return a
+        /// provider when we are certain.
+        /// </summary>
+        public ProviderId? DetectForegroundFast()
+        {
+            var hwnd = GetForegroundWindow();
+            if (hwnd == IntPtr.Zero) return null;
+
+            GetWindowThreadProcessId(hwnd, out uint pid);
+            if (pid == 0) return null;
+
+            var foregroundPid = (int)pid;
+            string? procName;
+            lock (_detectGate)
+            {
+                // Reuse the last-known name for the same pid — avoids an OpenProcess call on every hook fire.
+                procName = foregroundPid == _lastForegroundPid ? _lastForegroundProcessName : null;
+            }
+            procName ??= TryGetProcessName(foregroundPid);
+
+            if (procName == null) return null;
+
+            // Synara / T3 Code host: resolve by process name only (no LevelDB read).
+            if (SynaraStateReader.ResolveHost(procName) is not null)
+                return _lastForegroundResult; // treat it as "provider present"; tick has the accurate value
+
+            // Known GUI provider process (Cursor, Claude, Codex, OpenCode …).
+            if (TryResolveGuiProcess(procName) is { } gui)
+                return gui;
+
+            // Browser: use the cached URL only — never issue a new UIA address-bar scan here.
+            if (BrowserActiveTabDetector.IsBrowserProcessName(procName))
+                return _browserTabs.DetectProvider(hwnd, procName, windowTitle: null);
+                // DetectProvider skips UIA when the cache is fresh (TTL=350ms); returns null on a cold cache,
+                // which correctly starts the grace timer — the tick will re-read and potentially cancel it.
+
+            // Terminal or anything else: unknown without a WMI scan. Return null and let the tick decide.
+            return null;
+        }
+
+
+        /// <summary>
+        /// True when TaskbarQuota itself owns the foreground window (its main window, or the flyout the
+        /// user just opened from the widget). Focus-follows-provider hiding must treat this as "no change"
+        /// rather than as leaving the AI app, or interacting with our own UI would hide the widget under
+        /// the pointer.
+        /// </summary>
+        public static bool IsOwnProcessForeground()
+        {
+            var hwnd = GetForegroundWindow();
+            if (hwnd == IntPtr.Zero)
+                return false;
+
+            GetWindowThreadProcessId(hwnd, out uint pid);
+            return pid != 0 && (int)pid == Environment.ProcessId;
+        }
+
         private ProviderId? DetectCore()
         {
             var hwnd = GetForegroundWindow();

--- a/src/TaskbarQuota.App/ActiveApp/ActiveAppDetector.cs
+++ b/src/TaskbarQuota.App/ActiveApp/ActiveAppDetector.cs
@@ -406,9 +406,9 @@ namespace TaskbarQuota.ActiveApp
 
             // Browser: use the cached URL only — never issue a new UIA address-bar scan here.
             if (BrowserActiveTabDetector.IsBrowserProcessName(procName))
-                return _browserTabs.DetectProvider(hwnd, procName, windowTitle: null);
-                // DetectProvider skips UIA when the cache is fresh (TTL=350ms); returns null on a cold cache,
-                // which correctly starts the grace timer — the tick will re-read and potentially cancel it.
+                return _browserTabs.DetectCachedProvider(hwnd, procName);
+                // A cold cache correctly starts the grace timer — the tick will re-read and potentially
+                // cancel it. The hook path never touches UI Automation or the detector's mutable state.
 
             // Terminal or anything else: unknown without a WMI scan. Return null and let the tick decide.
             return null;

--- a/src/TaskbarQuota.App/ActiveApp/BrowserActiveTabDetector.cs
+++ b/src/TaskbarQuota.App/ActiveApp/BrowserActiveTabDetector.cs
@@ -33,6 +33,8 @@ namespace TaskbarQuota.ActiveApp
 
         private static readonly TimeSpan CacheTtl = TimeSpan.FromMilliseconds(350);
 
+        private readonly object _cacheGate = new();
+        private readonly object _automationGate = new();
         private IUIAutomation? _automation;
         private IntPtr _cachedHwnd;
         private string? _cachedUrl;
@@ -44,6 +46,24 @@ namespace TaskbarQuota.ActiveApp
 
         internal ProviderId? DetectProvider(IntPtr hwnd, string? processName, string? windowTitle = null)
             => Detect(hwnd, processName, windowTitle)?.Provider;
+
+        /// <summary>
+        /// Resolves a browser provider from the short-lived URL cache only. This path is used by
+        /// foreground hooks and must never start a UI Automation scan.
+        /// </summary>
+        internal ProviderId? DetectCachedProvider(IntPtr hwnd, string? processName)
+        {
+            if (!IsBrowserProcessName(processName) || hwnd == IntPtr.Zero)
+                return null;
+
+            lock (_cacheGate)
+            {
+                if (hwnd != _cachedHwnd || DateTime.UtcNow - _cachedAtUtc >= CacheTtl)
+                    return null;
+
+                return TryResolveProviderFromUrl(_cachedUrl);
+            }
+        }
 
         internal BrowserProviderDetection? Detect(IntPtr hwnd, string? processName, string? windowTitle = null)
         {
@@ -65,14 +85,20 @@ namespace TaskbarQuota.ActiveApp
             if (hwnd == IntPtr.Zero)
                 return null;
 
-            var now = DateTime.UtcNow;
-            if (hwnd == _cachedHwnd && now - _cachedAtUtc < CacheTtl)
-                return _cachedUrl;
+            lock (_cacheGate)
+            {
+                var now = DateTime.UtcNow;
+                if (hwnd == _cachedHwnd && now - _cachedAtUtc < CacheTtl)
+                    return _cachedUrl;
+            }
 
             var url = TryReadActiveTabUrlCore(hwnd);
-            _cachedHwnd = hwnd;
-            _cachedUrl = url;
-            _cachedAtUtc = now;
+            lock (_cacheGate)
+            {
+                _cachedHwnd = hwnd;
+                _cachedUrl = url;
+                _cachedAtUtc = DateTime.UtcNow;
+            }
             return url;
         }
 
@@ -129,22 +155,25 @@ namespace TaskbarQuota.ActiveApp
 
         private string? TryReadActiveTabUrlCore(IntPtr hwnd)
         {
-            try
+            lock (_automationGate)
             {
-                _automation ??= new CUIAutomation();
-                var root = _automation.ElementFromHandle(hwnd);
-                if (root is null)
-                    return null;
+                try
+                {
+                    _automation ??= new CUIAutomation();
+                    var root = _automation.ElementFromHandle(hwnd);
+                    if (root is null)
+                        return null;
 
-                if (TryFindUrlInEdits(root) is { } editUrl)
-                    return editUrl;
-            }
-            catch (Exception ex)
-            {
-                Diagnostics.Log.Debug($"[browser] URL UIA read failed: {ex.Message}");
-            }
+                    if (TryFindUrlInEdits(root) is { } editUrl)
+                        return editUrl;
+                }
+                catch (Exception ex)
+                {
+                    Diagnostics.Log.Debug($"[browser] URL UIA read failed: {ex.Message}");
+                }
 
-            return null;
+                return null;
+            }
         }
 
         private string? TryFindUrlInEdits(IUIAutomationElement root)

--- a/src/TaskbarQuota.App/ActiveApp/ForegroundWatcher.cs
+++ b/src/TaskbarQuota.App/ActiveApp/ForegroundWatcher.cs
@@ -1,0 +1,75 @@
+using System;
+using TaskbarQuota.Interop;
+
+namespace TaskbarQuota.ActiveApp
+{
+    /// <summary>
+    /// Raises <see cref="ForegroundChanged"/> the moment Windows switches the foreground window, so the
+    /// focus-follows-provider widget reacts on the switch itself instead of on the next 500 ms detect
+    /// tick. Must be created on a thread with a message pump (the UI thread): WINEVENT_OUTOFCONTEXT
+    /// callbacks are delivered through that thread's message queue.
+    /// </summary>
+    internal sealed class ForegroundWatcher : IDisposable
+    {
+        private readonly User32.WinEventProc _callback;
+        private IntPtr _hook;
+        private bool _disposed;
+
+        public event Action? ForegroundChanged;
+
+        public ForegroundWatcher()
+        {
+            // Held in a field: the delegate is passed to native code, and a collected callback would take
+            // the process down the first time the user alt-tabs.
+            _callback = OnWinEvent;
+        }
+
+        public void Start()
+        {
+            if (_hook != IntPtr.Zero || _disposed)
+                return;
+
+            _hook = User32.SetWinEventHook(
+                User32.EVENT_SYSTEM_FOREGROUND,
+                User32.EVENT_SYSTEM_FOREGROUND,
+                IntPtr.Zero,
+                _callback,
+                idProcess: 0,
+                idThread: 0,
+                User32.WINEVENT_OUTOFCONTEXT);
+
+            if (_hook == IntPtr.Zero)
+                Diagnostics.Log.Warning("[focus] foreground hook could not be installed; falling back to the detect tick");
+        }
+
+        private void OnWinEvent(IntPtr hook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint thread, uint time)
+        {
+            // idObject/idChild filter out the per-control accessibility noise that shares this event id.
+            if (eventType != User32.EVENT_SYSTEM_FOREGROUND || hwnd == IntPtr.Zero || idObject != 0)
+                return;
+
+            try
+            {
+                ForegroundChanged?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                Diagnostics.Log.Warning(ex, "[focus] foreground change handler failed");
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            if (_hook == IntPtr.Zero)
+                return;
+
+            try { User32.UnhookWinEvent(_hook); }
+            catch { }
+            _hook = IntPtr.Zero;
+        }
+    }
+}

--- a/src/TaskbarQuota.App/Interop/Native.cs
+++ b/src/TaskbarQuota.App/Interop/Native.cs
@@ -54,6 +54,32 @@ namespace TaskbarQuota.Interop
         [DllImport("user32.dll")]
         public static extern bool EnumChildWindows(IntPtr hWndParent, EnumWindowProc lpEnumFunc, IntPtr lParam);
 
+        public const uint EVENT_SYSTEM_FOREGROUND = 0x0003;
+        public const uint WINEVENT_OUTOFCONTEXT = 0x0000;
+        public const uint WINEVENT_SKIPOWNPROCESS = 0x0002;
+
+        public delegate void WinEventProc(
+            IntPtr hWinEventHook,
+            uint eventType,
+            IntPtr hwnd,
+            int idObject,
+            int idChild,
+            uint dwEventThread,
+            uint dwmsEventTime);
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr SetWinEventHook(
+            uint eventMin,
+            uint eventMax,
+            IntPtr hmodWinEventProc,
+            WinEventProc lpfnWinEventProc,
+            uint idProcess,
+            uint idThread,
+            uint dwFlags);
+
+        [DllImport("user32.dll")]
+        public static extern bool UnhookWinEvent(IntPtr hWinEventHook);
+
         [DllImport("user32.dll", SetLastError = true)]
         public static extern bool EnumWindows(EnumWindowProc lpEnumFunc, IntPtr lParam);
 

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -57,6 +57,9 @@ public static class WidgetSettingsService
     private static readonly string AutoHideUnavailablePath =
         Path.Combine(AppStorage.AppDataDirectory, "auto-hide-unavailable.txt");
 
+    private static readonly string HideWhenUnfocusedPath =
+        Path.Combine(AppStorage.AppDataDirectory, "hide-when-unfocused.txt");
+
     private static readonly Dictionary<string, bool> RowVisibility = LoadRowVisibility();
     private static readonly Dictionary<string, bool> ProviderVisibility = LoadProviderVisibility();
     private static readonly Dictionary<string, bool> DashboardProviderVisibility = LoadDashboardProviderVisibility();
@@ -65,6 +68,13 @@ public static class WidgetSettingsService
     public static WidgetDisplayMode Current { get; private set; } = LoadWidgetDisplayMode();
     public static PercentageDisplayMode CurrentPercentageMode { get; private set; } = LoadPercentageDisplayMode();
     public static bool AutoHideUnavailable { get; private set; } = LoadAutoHideUnavailable();
+    /// <summary>
+    /// Opt-in: the active provider's tile only stays on the taskbar while that provider's app is the
+    /// foreground window. Off (the default) keeps today's behaviour, where the last active provider
+    /// remains on the bar after the user switches to a browser or any other unrelated app. Pinned tiles
+    /// are never affected — a pin is an explicit "always show this" request.
+    /// </summary>
+    public static bool HideWhenProviderUnfocused { get; private set; } = LoadHideWhenUnfocused();
     public static event EventHandler? Changed;
     public static event EventHandler? DashboardCompositionChanged;
     public static event EventHandler? PercentageModeChanged;
@@ -224,6 +234,16 @@ public static class WidgetSettingsService
         AutoHideUnavailable = enabled;
         Save(AutoHideUnavailablePath, enabled ? 1 : 0);
         DashboardCompositionChanged?.Invoke(null, EventArgs.Empty);
+        Changed?.Invoke(null, EventArgs.Empty);
+    }
+
+    public static void ApplyHideWhenProviderUnfocused(bool enabled)
+    {
+        if (HideWhenProviderUnfocused == enabled)
+            return;
+
+        HideWhenProviderUnfocused = enabled;
+        Save(HideWhenUnfocusedPath, enabled ? 1 : 0);
         Changed?.Invoke(null, EventArgs.Empty);
     }
 
@@ -600,6 +620,24 @@ public static class WidgetSettingsService
         catch
         {
             return true;
+        }
+    }
+
+    // Opt-in, so an absent file means off — the opposite default from AutoHideUnavailable, whose file
+    // absence means "on". Existing installs must not silently start hiding the widget after an update.
+    private static bool LoadHideWhenUnfocused()
+    {
+        try
+        {
+            if (!File.Exists(HideWhenUnfocusedPath))
+                return false;
+
+            string raw = File.ReadAllText(HideWhenUnfocusedPath);
+            return int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value) && value != 0;
+        }
+        catch
+        {
+            return false;
         }
     }
 

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -27,6 +27,9 @@ namespace TaskbarQuota.Taskbar
         private static bool _initialized;
         private static bool _isReconcilingWidgets;
         private static ProviderId? _lastLoggedWidgetApplyProvider;
+        // Foreground hook: fires the instant Windows switches windows so the focus-follows-provider
+        // widget reacts on the switch itself instead of waiting for the next 500 ms detect tick.
+        private static ActiveApp.ForegroundWatcher? _foregroundWatcher;
 
         public static void Initialize(DispatcherQueue dispatcher, Action showMainWindow)
         {
@@ -41,8 +44,17 @@ namespace TaskbarQuota.Taskbar
                 UsageCoordinator.Instance.StateChanged += OnStateChanged;
                 UsageCoordinator.Instance.ActiveProviderChanged += OnActiveProviderChanged;
                 UsageCoordinator.Instance.ActiveToolPresenceChanged += OnActiveToolPresenceChanged;
+                UsageCoordinator.Instance.ProviderForegroundChanged += OnProviderForegroundChanged;
+                // Lets the coordinator's focus tracker treat "our flyout is open" as neutral instead of as
+                // the user having left the provider app.
+                UsageCoordinator.Instance.IsOwnUiEngaged = () => _flyout?.IsShown == true;
                 WidgetSettingsService.Changed += OnWidgetSettingsChanged;
                 App.Quitting += OnQuitting;
+                // Installed from the UI thread on purpose: WINEVENT_OUTOFCONTEXT callbacks arrive through
+                // that thread's message pump, which this one has and background threads do not.
+                _foregroundWatcher = new ActiveApp.ForegroundWatcher();
+                _foregroundWatcher.ForegroundChanged += OnForegroundChanged;
+                _foregroundWatcher.Start();
                 _initialized = true;
             }
 
@@ -221,11 +233,18 @@ namespace TaskbarQuota.Taskbar
             var providers = coordinator.WidgetDisplayProviders;
 
             // No provider to show -> hide the native host instead of leaving a transparent taskbar child
-            // window over the notification area (#10).
-            widget.SetVisible(providers.Count > 0);
-            widget.SetDisplayProviders(providers, coordinator.ActiveProvider);
+            // window over the notification area (#10). The tiles are deliberately left bound while it
+            // hides: unbinding collapses them in the same frame, which wiped out the fade and made the
+            // widget look like it had blinked out of existence. SetVisible re-binds nothing on the way
+            // back in either — the set below runs first on show.
             if (providers.Count == 0)
+            {
+                widget.SetVisible(false);
                 return;
+            }
+
+            widget.SetDisplayProviders(providers, coordinator.ActiveProvider);
+            widget.SetVisible(true);
 
             bool needsFetch = false;
             foreach (var provider in providers)
@@ -329,8 +348,16 @@ namespace TaskbarQuota.Taskbar
 
                 // Reconcile the tile set first, so a provider that just became active already owns a slot
                 // before its result is routed. SetDisplayProviders is a cheap no-op when nothing changed.
-                widget.SetVisible(providers.Count > 0);
+                // As in SyncWidgetState, an empty set only hides — rebinding the slots here would collapse
+                // the tiles mid-fade.
+                if (providers.Count == 0)
+                {
+                    widget.SetVisible(false);
+                    continue;
+                }
+
                 widget.SetDisplayProviders(providers, coordinator.ActiveProvider);
+                widget.SetVisible(true);
                 if (!isDisplayed)
                     continue;
 
@@ -365,8 +392,21 @@ namespace TaskbarQuota.Taskbar
         // so updating the widget here would only duplicate dispatcher work and add latency.
         private static void OnActiveProviderChanged(ProviderId? _) { }
 
+        /// <summary>
+        /// Fired from the WinEvent hook the instant the foreground window changes. Relays to the
+        /// coordinator so it can re-detect whether a provider is in front without waiting for the
+        /// next 500 ms tick — this is what makes "switch away" hide the widget right away.
+        /// </summary>
+        private static void OnForegroundChanged()
+            => UsageCoordinator.Instance.NotifyForegroundChanged();
+
         private static void OnActiveToolPresenceChanged(bool isPresent)
             => _dispatcher?.TryEnqueue(() => ApplyActiveToolPresenceChanged(isPresent));
+
+        // Focus-follows-provider flip (opt-in setting): the tile set changes even though presence and the
+        // active provider did not, so the widget has to be re-synced from the recomputed set.
+        private static void OnProviderForegroundChanged(bool _)
+            => _dispatcher?.TryEnqueue(SyncWidgetState);
 
         private static void ApplyActiveToolPresenceChanged(bool isPresent)
         {
@@ -389,10 +429,18 @@ namespace TaskbarQuota.Taskbar
             UsageCoordinator.Instance.StateChanged -= OnStateChanged;
             UsageCoordinator.Instance.ActiveProviderChanged -= OnActiveProviderChanged;
             UsageCoordinator.Instance.ActiveToolPresenceChanged -= OnActiveToolPresenceChanged;
+            UsageCoordinator.Instance.ProviderForegroundChanged -= OnProviderForegroundChanged;
+            UsageCoordinator.Instance.IsOwnUiEngaged = null;
             WidgetSettingsService.Changed -= OnWidgetSettingsChanged;
             _initialized = false;
             _widgetHealthTimer?.Stop();
             _widgetHealthTimer = null;
+            if (_foregroundWatcher is { } watcher)
+            {
+                watcher.ForegroundChanged -= OnForegroundChanged;
+                watcher.Dispose();
+                _foregroundWatcher = null;
+            }
             if (_trayIcon != null) { _trayIcon.TryRemove(); _trayIcon.Dispose(); _trayIcon = null; }
             try { _flyout?.Close(); } catch { }
             _flyout = null;

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -18,6 +18,7 @@ using TaskbarQuota.Controls;
 using TaskbarQuota.Diagnostics;
 using TaskbarQuota.Interop;
 using TaskbarQuota.Usage;
+using Anim = Microsoft.UI.Xaml.Media.Animation;
 
 namespace TaskbarQuota.Taskbar
 {
@@ -121,6 +122,11 @@ namespace TaskbarQuota.Taskbar
         private bool loggedMissingPanel;
         private DesktopWindowXamlSource? host;
         private Microsoft.UI.Xaml.FrameworkElement? hostContent;
+        // Show/hide cross-fade state. Short on purpose: the widget lives on the taskbar, so anything
+        // slower reads as lag rather than as a transition.
+        private const int HostFadeMilliseconds = 100;
+        private Anim.Storyboard? hostFadeStoryboard;
+        private int hostFadeGeneration;
         private int WidgetHostWidth;
         private int currentOffsetX = int.MinValue;
         private int currentOffsetY = 0;
@@ -303,23 +309,100 @@ namespace TaskbarQuota.Taskbar
                 && target.IsPrimary == isPrimaryTaskbar
                 && string.Equals(target.DisplayKey, displayKey, StringComparison.Ordinal);
 
+        /// <summary>
+        /// Shows or hides the widget with a short cross-fade. A native window can't be animated, so the
+        /// XAML content carries the fade and the window is only hidden once it has finished — otherwise
+        /// the "hide when no provider is focused" setting made the widget vanish in a single frame.
+        /// </summary>
         public void SetVisible(bool visible)
         {
             if (appWindow is null || isVisible == visible)
                 return;
 
             isVisible = visible;
+            // Invalidates any fade still in flight, so a show landing mid-hide cancels that hide's window
+            // teardown instead of racing it.
+            hostFadeGeneration++;
+
             if (visible)
             {
                 QueuePositionUpdate(TaskbarChangeReason.None);
+                if (hostContent is not null)
+                    hostContent.Opacity = 0;
                 appWindow.Show(false);
+                AnimateHostOpacity(1);
+                return;
             }
-            else
+
+            if (isDragging)
+                EndDragging(revert: true);
+
+            if (hostContent is null)
             {
-                if (isDragging)
-                    EndDragging(revert: true);
                 appWindow.Hide();
+                return;
             }
+
+            int generation = hostFadeGeneration;
+            AnimateHostOpacity(0, () =>
+            {
+                if (generation != hostFadeGeneration || destroyed || appWindow is null)
+                    return;
+
+                appWindow.Hide();
+                // Leave the content opaque again so the next Show has nothing to undo if it takes the
+                // no-animation path (e.g. the host was rebuilt in between).
+                if (hostContent is { } content)
+                    content.Opacity = 1;
+            });
+        }
+
+        private void AnimateHostOpacity(double to, Action? completed = null)
+        {
+            if (hostContent is not { } content)
+            {
+                completed?.Invoke();
+                return;
+            }
+
+            hostFadeStoryboard?.Stop();
+
+            double from = content.Opacity;
+
+            // When hiding (to == 0) we always run the storyboard, even if the content is already
+            // near-transparent: skipping it would call the completion immediately, which hides the
+            // window without any animation and is the "instant disappear" the user saw.
+            // When showing (to == 1) skip is fine — nothing to animate if we're already opaque.
+            bool skip = Math.Abs(from - to) < 0.01 && to > 0.5;
+            if (skip)
+            {
+                content.Opacity = to;
+                completed?.Invoke();
+                return;
+            }
+
+            // Park the local value at the destination and let the animation supply the start through From,
+            // the same rule the tile animations follow: an interrupted fade then settles visible rather
+            // than leaving the host stuck transparent.
+            content.Opacity = to;
+
+            var animation = new Anim.DoubleAnimation
+            {
+                From = from < 0.01 ? 0.15 : from, // guarantee at least a short visible flash so the fade is perceptible
+                To = to,
+                Duration = new Microsoft.UI.Xaml.Duration(TimeSpan.FromMilliseconds(HostFadeMilliseconds)),
+                EasingFunction = new Anim.CubicEase { EasingMode = Anim.EasingMode.EaseOut },
+            };
+            Anim.Storyboard.SetTarget(animation, content);
+            Anim.Storyboard.SetTargetProperty(animation, "Opacity");
+
+            var storyboard = new Anim.Storyboard();
+            storyboard.Children.Add(animation);
+            if (completed is not null)
+                storyboard.Completed += (_, _) => completed();
+
+            hostFadeStoryboard = storyboard;
+            storyboard.Begin();
         }
 
         public void Destroy() => appWindow?.Destroy();

--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -259,8 +259,9 @@ namespace TaskbarQuota
                 if (_providerForegroundActive == next)
                 {
                     // Inside the grace window: come back exactly when it expires rather than drifting to
-                    // whenever the next detect tick happens to land.
-                    if (next && unfocusedSince != DateTime.MinValue)
+                    // whenever the next detect tick happens to land. Skip re-arming when ownUiEngaged froze
+                    // the state — the next genuine foreground change will re-evaluate normally.
+                    if (!ownUiEngaged && next && unfocusedSince != DateTime.MinValue)
                         ArmUnfocusHideCheck(unfocusedSince);
                     return;
                 }

--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -67,6 +67,23 @@ namespace TaskbarQuota
         private bool? _lastHasDetectedTool;
         private DateTime _lastPresenceProbeAt = DateTime.MinValue;
         private ProviderSource _activeProviderSource = ProviderSource.Unknown;
+        // Focus-follows-provider state, only consulted when WidgetSettingsService.HideWhenProviderUnfocused
+        // is on. Starts true so the widget shows from launch and only ever hides after a detect that
+        // actually saw an unrelated foreground app.
+        private bool _providerForegroundActive = true;
+        private DateTime _providerUnfocusedSinceUtc = DateTime.MinValue;
+        // Grace period before the tile is dropped, counted from the first provider-free foreground. Kept
+        // short: it only exists to swallow the momentary focusless gap while a window is being raised, and
+        // anything longer reads as the widget lagging behind the window switch. Showing is always instant.
+        // 120ms: enough to absorb the transient focus gap during Alt-Tab/window transitions (~80ms max),
+        // short enough that the hide feels instant to the user rather than sluggish.
+        private static readonly TimeSpan ProviderUnfocusHideDelay = TimeSpan.FromMilliseconds(120);
+        // Re-check scheduled when a foreground switch starts the grace period, so the hide lands as soon as
+        // it expires instead of waiting for the next 500 ms detect tick.
+        private Timer? _unfocusHideTimer;
+        // The focus state is written from the detect tick, the foreground hook and the grace timer — three
+        // different threads.
+        private readonly object _focusLock = new();
 
         public UsageService Service => _service;
         public ProviderId? ActiveProvider => _lastActive;
@@ -114,7 +131,7 @@ namespace TaskbarQuota
         public IReadOnlyList<ProviderId> WidgetDisplayProviders
             => ComputeWidgetDisplayProviders(
                 _lastActive,
-                IsActiveToolPresent,
+                IsActiveToolPresent && IsActiveTileAllowedByFocus,
                 RecentProviders,
                 Enum.GetValues<ProviderId>(),
                 WidgetSettingsService.IsProviderPinned,
@@ -173,6 +190,139 @@ namespace TaskbarQuota
         /// <summary>Last usage snapshot pushed to listeners; used to hydrate the taskbar widget if it was created late.</summary>
         public UsageResult? LastState { get; private set; }
         public bool IsActiveToolPresent => _lastHasDetectedTool ?? _detector.HasAnyKnownToolRunning();
+
+        /// <summary>
+        /// Whether the active provider currently earns a tile. Always true unless the user opted into
+        /// <see cref="WidgetSettingsService.HideWhenProviderUnfocused"/>, in which case it follows whether
+        /// a provider app is actually in the foreground.
+        /// </summary>
+        public bool IsActiveTileAllowedByFocus
+            => !WidgetSettingsService.HideWhenProviderUnfocused || _providerForegroundActive;
+
+        /// <summary>
+        /// Set by the taskbar layer to report that our own UI is on screen (the flyout). While it returns
+        /// true the focus tracker holds its current state, so opening the flyout — which takes the
+        /// foreground away from the provider app — never hides the widget the user is interacting with.
+        /// </summary>
+        public Func<bool>? IsOwnUiEngaged { get; set; }
+
+        /// <summary>Raised when <see cref="IsActiveTileAllowedByFocus"/> flips, so the widget can re-sync.</summary>
+        public event Action<bool>? ProviderForegroundChanged;
+
+        /// <summary>
+        /// Called by the taskbar layer's foreground hook the instant Windows switches windows. Re-runs
+        /// detection off the UI thread (it can hit WMI) so leaving or returning to a provider app is
+        /// reflected on the switch itself rather than up to one detect tick later.
+        /// </summary>
+        public void NotifyForegroundChanged()
+        {
+            if (!WidgetSettingsService.HideWhenProviderUnfocused)
+                return;
+
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    // DetectForegroundFast() never issues a UIA scan or WMI query, so switching to Zen
+                    // (or any browser that is not currently serving a provider URL) returns in <1 ms.
+                    // The grace timer's final re-check still uses full Detect() for accuracy.
+                    UpdateProviderForeground(_detector.DetectForegroundFast() is not null);
+                }
+                catch (Exception ex)
+                {
+                    Diagnostics.Log.Debug($"[focus] foreground re-detect failed: {ex.Message}");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Folds one detect pass into the focus state. Called from every path that resolves a provider, so
+        /// the fast Synara/OpenCode/Cline switch handlers keep the widget up without waiting for a tick.
+        /// </summary>
+        private void UpdateProviderForeground(bool providerForeground)
+        {
+            bool changedTo;
+            lock (_focusLock)
+            {
+                bool ownUiEngaged = !providerForeground
+                    && (ActiveAppDetector.IsOwnProcessForeground() || IsOwnUiEngaged?.Invoke() == true);
+
+                var (next, unfocusedSince) = ResolveProviderForegroundState(
+                    providerForeground,
+                    ownUiEngaged,
+                    _providerForegroundActive,
+                    _providerUnfocusedSinceUtc,
+                    DateTime.UtcNow,
+                    ProviderUnfocusHideDelay);
+
+                _providerUnfocusedSinceUtc = unfocusedSince;
+                if (_providerForegroundActive == next)
+                {
+                    // Inside the grace window: come back exactly when it expires rather than drifting to
+                    // whenever the next detect tick happens to land.
+                    if (next && unfocusedSince != DateTime.MinValue)
+                        ArmUnfocusHideCheck(unfocusedSince);
+                    return;
+                }
+
+                _providerForegroundActive = next;
+                changedTo = next;
+            }
+
+            Diagnostics.Log.Debug($"[focus] provider foreground={changedTo} (hide-when-unfocused={WidgetSettingsService.HideWhenProviderUnfocused})");
+            ProviderForegroundChanged?.Invoke(changedTo);
+        }
+
+        /// <summary>One-shot re-check at the end of the hide grace period. Caller holds <see cref="_focusLock"/>.</summary>
+        private void ArmUnfocusHideCheck(DateTime unfocusedSinceUtc)
+        {
+            var remaining = ProviderUnfocusHideDelay - (DateTime.UtcNow - unfocusedSinceUtc) + TimeSpan.FromMilliseconds(15);
+            if (remaining < TimeSpan.Zero)
+                remaining = TimeSpan.Zero;
+
+            if (_unfocusHideTimer is { } timer)
+            {
+                timer.Change(remaining, Timeout.InfiniteTimeSpan);
+                return;
+            }
+
+            _unfocusHideTimer = new Timer(
+                _ =>
+                {
+                    try { UpdateProviderForeground(_detector.Detect() is not null); }
+                    catch (Exception ex) { Diagnostics.Log.Debug($"[focus] grace re-check failed: {ex.Message}"); }
+                },
+                null,
+                remaining,
+                Timeout.InfiniteTimeSpan);
+        }
+
+        /// <summary>
+        /// Pure core of <see cref="UpdateProviderForeground"/>. Shows instantly, hides only after the
+        /// foreground has been provider-free for <paramref name="hideDelay"/>, and treats our own UI in
+        /// front as neither — it holds both the state and the running grace period untouched.
+        /// </summary>
+        internal static (bool Active, DateTime UnfocusedSinceUtc) ResolveProviderForegroundState(
+            bool providerForeground,
+            bool ownUiEngaged,
+            bool current,
+            DateTime unfocusedSinceUtc,
+            DateTime nowUtc,
+            TimeSpan hideDelay)
+        {
+            if (ownUiEngaged && !providerForeground)
+                return (current, unfocusedSinceUtc);
+
+            if (providerForeground)
+                return (true, DateTime.MinValue);
+
+            if (unfocusedSinceUtc == DateTime.MinValue)
+                unfocusedSinceUtc = nowUtc;
+
+            return nowUtc - unfocusedSinceUtc < hideDelay
+                ? (current, unfocusedSinceUtc)
+                : (false, unfocusedSinceUtc);
+        }
         public IReadOnlyList<ProviderId> RecentProviders
         {
             get
@@ -356,6 +506,8 @@ namespace TaskbarQuota
                     ActiveToolPresenceChanged?.Invoke(true);
                 }
 
+                UpdateProviderForeground(true);
+
                 // Synara fires on every localStorage write (incl. composer keystrokes). Only act when the
                 // provider/model/thread selection actually changed — otherwise it's already on screen.
                 if (!providerChanged && !hostChanged)
@@ -511,6 +663,8 @@ namespace TaskbarQuota
                     _lastHasDetectedTool = true;
                     ActiveToolPresenceChanged?.Invoke(true);
                 }
+
+                UpdateProviderForeground(true);
             }
             catch (Exception ex)
             {
@@ -605,6 +759,7 @@ namespace TaskbarQuota
                     ActiveProviderChanged?.Invoke(target);
 
                 PublishImmediateState(target);
+                UpdateProviderForeground(true);
             }
             catch (Exception ex)
             {
@@ -816,6 +971,10 @@ namespace TaskbarQuota
                     ActiveSynaraHost = null;
                     ClearSynaraHold();
                 }
+
+                // Foreground bookkeeping runs on every tick, including the ones that end in the no-tool
+                // early-out below, so the hide grace period keeps counting while nothing is detected.
+                UpdateProviderForeground(detected is not null);
 
                 var hasDetectedTool = detected != null || ShouldAssumeToolStillRunning() || ProbeToolPresence();
                 if (!hasDetectedTool)

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml
@@ -62,6 +62,16 @@
                 </ComboBox>
             </tk:SettingsCard>
 
+            <tk:SettingsCard Header="Hide widget when no AI app is focused"
+                             Description="Fade the active provider's tile out when you switch to a browser or any other app, and bring it back when you return. Pinned providers always stay on the taskbar.">
+                <tk:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE890;"/>
+                </tk:SettingsCard.HeaderIcon>
+                <ToggleSwitch x:Name="HideWhenUnfocusedToggle"
+                              AutomationProperties.Name="Hide widget when no AI app is focused"
+                              Toggled="OnHideWhenUnfocusedToggled"/>
+            </tk:SettingsCard>
+
             <TextBlock Text="Providers" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,16,0,2"/>
             <tk:SettingsCard Header="Hide unavailable providers"
                              Description="Automatically hide providers that are not installed or signed in. You can still add them from the dashboard or below.">

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
@@ -46,6 +46,7 @@ namespace TaskbarQuota.Views
             StartupToggle.IsOn = StartupSettingsService.IsEnabled;
             ApplyQuotaAlertSettingsToControls();
             AutoHideUnavailableToggle.IsOn = WidgetSettingsService.AutoHideUnavailable;
+            HideWhenUnfocusedToggle.IsOn = WidgetSettingsService.HideWhenProviderUnfocused;
             ViewModel.ReloadProviders();
             RebuildProviderSettings();
             VersionLabel.Text = $"Version {AppVersion.GetDisplayLabel()}";
@@ -170,6 +171,14 @@ namespace TaskbarQuota.Views
                 return;
 
             WidgetSettingsService.ApplyAutoHideUnavailable(AutoHideUnavailableToggle.IsOn);
+        }
+
+        private void OnHideWhenUnfocusedToggled(object sender, RoutedEventArgs e)
+        {
+            if (_isInitializing)
+                return;
+
+            WidgetSettingsService.ApplyHideWhenProviderUnfocused(HideWhenUnfocusedToggle.IsOn);
         }
 
         private void OnProviderDashboardToggled(object sender, RoutedEventArgs e)

--- a/tests/TaskbarQuota.Tests/ClaudeProviderCredentialTests.cs
+++ b/tests/TaskbarQuota.Tests/ClaudeProviderCredentialTests.cs
@@ -8,6 +8,7 @@ using TaskbarQuota.Usage.Providers;
 
 namespace TaskbarQuota.Tests;
 
+[Collection(WidgetRowSettingsCollection.Name)]
 public class ClaudeProviderCredentialTests
 {
     [Fact]

--- a/tests/TaskbarQuota.Tests/CodexProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/CodexProviderTests.cs
@@ -5,6 +5,7 @@ using TaskbarQuota.Usage;
 
 namespace TaskbarQuota.Tests;
 
+[Collection(WidgetRowSettingsCollection.Name)]
 public class CodexProviderTests
 {
     [Theory]

--- a/tests/TaskbarQuota.Tests/ProviderForegroundStateTests.cs
+++ b/tests/TaskbarQuota.Tests/ProviderForegroundStateTests.cs
@@ -1,0 +1,94 @@
+using System;
+
+namespace TaskbarQuota.Tests;
+
+/// <summary>
+/// Focus-follows-provider state machine behind the opt-in "hide the widget when no AI app is focused"
+/// setting: showing is instant, hiding waits out a grace period so alt-tab transits don't blink the
+/// widget, and our own UI taking the foreground (the flyout) changes nothing.
+/// </summary>
+public class ProviderForegroundStateTests
+{
+    private static readonly TimeSpan HideDelay = TimeSpan.FromMilliseconds(1200);
+    private static readonly DateTime Now = new(2026, 7, 28, 12, 0, 0, DateTimeKind.Utc);
+
+    private static (bool Active, DateTime UnfocusedSinceUtc) Resolve(
+        bool providerForeground,
+        bool ownUiEngaged = false,
+        bool current = true,
+        DateTime? unfocusedSince = null,
+        DateTime? now = null)
+        => UsageCoordinator.ResolveProviderForegroundState(
+            providerForeground,
+            ownUiEngaged,
+            current,
+            unfocusedSince ?? DateTime.MinValue,
+            now ?? Now,
+            HideDelay);
+
+    [Fact]
+    public void FocusingAProviderShowsImmediatelyAndClearsTheGracePeriod()
+    {
+        var result = Resolve(providerForeground: true, current: false, unfocusedSince: Now.AddSeconds(-30));
+
+        Assert.True(result.Active);
+        Assert.Equal(DateTime.MinValue, result.UnfocusedSinceUtc);
+    }
+
+    [Fact]
+    public void LeavingTheProviderStartsTheGracePeriodWithoutHiding()
+    {
+        var result = Resolve(providerForeground: false);
+
+        Assert.True(result.Active);
+        Assert.Equal(Now, result.UnfocusedSinceUtc);
+    }
+
+    [Fact]
+    public void StillInsideTheGracePeriodKeepsTheTile()
+    {
+        var since = Now.AddMilliseconds(-500);
+        var result = Resolve(providerForeground: false, unfocusedSince: since);
+
+        Assert.True(result.Active);
+        Assert.Equal(since, result.UnfocusedSinceUtc);
+    }
+
+    [Fact]
+    public void PastTheGracePeriodHidesTheTile()
+    {
+        var since = Now.AddMilliseconds(-1500);
+        var result = Resolve(providerForeground: false, unfocusedSince: since);
+
+        Assert.False(result.Active);
+    }
+
+    [Fact]
+    public void OurOwnUiInFrontNeitherHidesNorStartsTheGracePeriod()
+    {
+        var result = Resolve(providerForeground: false, ownUiEngaged: true);
+
+        Assert.True(result.Active);
+        Assert.Equal(DateTime.MinValue, result.UnfocusedSinceUtc);
+    }
+
+    [Fact]
+    public void OurOwnUiInFrontDoesNotResumeAnExpiredGracePeriod()
+    {
+        // Flyout opened after the widget had already faded out: it must stay hidden, not flicker back.
+        var since = Now.AddMilliseconds(-5000);
+        var result = Resolve(providerForeground: false, ownUiEngaged: true, current: false, unfocusedSince: since);
+
+        Assert.False(result.Active);
+        Assert.Equal(since, result.UnfocusedSinceUtc);
+    }
+
+    [Fact]
+    public void ReturningToTheProviderAfterAHideShowsAgain()
+    {
+        var result = Resolve(providerForeground: true, current: false, unfocusedSince: Now.AddMinutes(-5));
+
+        Assert.True(result.Active);
+        Assert.Equal(DateTime.MinValue, result.UnfocusedSinceUtc);
+    }
+}

--- a/tests/TaskbarQuota.Tests/ProviderForegroundStateTests.cs
+++ b/tests/TaskbarQuota.Tests/ProviderForegroundStateTests.cs
@@ -47,7 +47,7 @@ public class ProviderForegroundStateTests
     [Fact]
     public void StillInsideTheGracePeriodKeepsTheTile()
     {
-        var since = Now.AddMilliseconds(-500);
+        var since = Now.AddMilliseconds(-50);
         var result = Resolve(providerForeground: false, unfocusedSince: since);
 
         Assert.True(result.Active);
@@ -57,7 +57,7 @@ public class ProviderForegroundStateTests
     [Fact]
     public void PastTheGracePeriodHidesTheTile()
     {
-        var since = Now.AddMilliseconds(-1500);
+        var since = Now.AddMilliseconds(-150);
         var result = Resolve(providerForeground: false, unfocusedSince: since);
 
         Assert.False(result.Active);

--- a/tests/TaskbarQuota.Tests/ProviderForegroundStateTests.cs
+++ b/tests/TaskbarQuota.Tests/ProviderForegroundStateTests.cs
@@ -9,7 +9,7 @@ namespace TaskbarQuota.Tests;
 /// </summary>
 public class ProviderForegroundStateTests
 {
-    private static readonly TimeSpan HideDelay = TimeSpan.FromMilliseconds(1200);
+    private static readonly TimeSpan HideDelay = TimeSpan.FromMilliseconds(120);
     private static readonly DateTime Now = new(2026, 7, 28, 12, 0, 0, DateTimeKind.Utc);
 
     private static (bool Active, DateTime UnfocusedSinceUtc) Resolve(

--- a/tests/TaskbarQuota.Tests/WidgetRowSettingsCollection.cs
+++ b/tests/TaskbarQuota.Tests/WidgetRowSettingsCollection.cs
@@ -1,0 +1,14 @@
+namespace TaskbarQuota.Tests;
+
+/// <summary>
+/// Serializes the test classes that drive <see cref="WidgetSettingsService"/>'s row-visibility state.
+/// That state is process-wide static: xUnit runs separate classes in parallel, so one class's
+/// SetRowVisibleForTesting / ResetRowVisibilityForTesting could land in the middle of another's
+/// assertions and flip a row it expected to be hidden. Sharing one collection makes them run
+/// sequentially instead.
+/// </summary>
+[CollectionDefinition(WidgetRowSettingsCollection.Name, DisableParallelization = true)]
+public sealed class WidgetRowSettingsCollection
+{
+    public const string Name = "widget-row-settings";
+}

--- a/tests/TaskbarQuota.Tests/ZaiProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/ZaiProviderTests.cs
@@ -7,6 +7,7 @@ using TaskbarQuota.Usage.Providers;
 
 namespace TaskbarQuota.Tests;
 
+[Collection(WidgetRowSettingsCollection.Name)]
 public class ZaiProviderTests
 {
     [Fact]


### PR DESCRIPTION
## What this does

Adds a new opt-in behaviour: the taskbar widget **smoothly fades out the moment you switch away from your AI tool**, and **instantly reappears** the moment you switch back.

When enabled, the taskbar returns to a clean slate whenever your AI agent is not the active window. The widget is only there when it is relevant - when you are actually inside Cursor, Claude, Codex, or whichever tool you use. Switch to your browser, your file explorer, or your desktop and it quietly disappears. Switch back and it is instantly there again.

This is opt-in under Settings -> 'Hide when provider unfocused'. Off by default, since many developers prefer the usage counter always visible - a background agent consuming quota while they browse is exactly the kind of thing they want to monitor at a glance.

## How it feels

- **Leaving a provider app** - the widget fades out in about 100 ms, smooth and unobtrusive
- **Returning to a provider app** - the widget appears instantly, no delay
- **Switching between windows** (e.g. Alt-Tab) - a short 120 ms grace period absorbs the momentary gap so the widget never flickers during normal window management
- **Browsers (Zen, Chrome, Firefox...)** - switching away is just as instant as switching to the desktop; no perceptible lag

## Enabling it

Open TaskbarQuota -> Settings -> toggle **Hide when provider unfocused**.