### PR TITLE
Fix classic taskbar overlap near the tray

### DIFF
--- a/docs/manual-testing-classic-taskbar-reservation.md
+++ b/docs/manual-testing-classic-taskbar-reservation.md
@@ -1,0 +1,86 @@
+# Manual test: classic taskbar space reservation
+
+This procedure verifies the visual behavior that unit tests cannot cover: whether a classic or restored
+task switcher continues to respect TaskbarQuota's tray-side slot after enough uncombined task buttons are
+opened.
+
+## Test environment
+
+Record these details with the result:
+
+- Windows version and build.
+- Taskbar implementation and version, if a shell customization is installed.
+- Display scaling, resolution, taskbar alignment, UI language direction, and monitor count.
+- Taskbar button combining setting.
+- TaskbarQuota widget display mode.
+
+For the original reproduction, use Windows 11 with StartAllBack and configure taskbar buttons to **Never
+combine**. The automated reservation currently applies only to the default position on a left-to-right,
+primary classic taskbar that exposes `TrayNotifyWnd` and the complete
+`ReBarWindow32` → `MSTaskSwWClass` → `MSTaskListWClass` hierarchy.
+
+## Crowded classic taskbar
+
+1. Close every installed or previously compiled TaskbarQuota instance.
+2. Start the patched build and choose **Reset position** from its tray menu.
+3. Confirm that the widget settles immediately before the notification area, with a small gap, instead of
+   at the far-left edge.
+4. Confirm for at least ten seconds that Start, the task buttons, and the widget do not flicker, jump, or
+   oscillate.
+5. Open separate application windows until the taskbar is as full as the original reproduction. Browser
+   windows with distinct titles make overlaps easy to identify.
+6. Keep opening windows until the taskbar must reduce, clip, scroll, or overflow its task buttons.
+7. Wait at least one watcher interval (two seconds). Confirm that no task-button icon, title, hover
+   background, or progress indicator is painted below the widget.
+8. Close the extra windows one at a time. Confirm that the widget remains stable and no permanent blank
+   region appears.
+9. Capture before/after screenshots with the same number and order of windows as the original report.
+
+Expected result: TaskbarQuota remains immediately before the notification area. Only the right edge of the
+classic `MSTaskSwWClass` container is shortened; Start must stay in place. The task buttons handle crowding
+inside the reduced container instead of drawing below TaskbarQuota.
+
+## Widget width, visibility, and dragging
+
+Repeat the following while enough windows are open to make an incorrect reservation visible:
+
+1. Switch between **Bars only**, **Percentages only**, and **Bars and percentages**. The reserved slot must
+   follow the widget's actual width without overlapping the task buttons or notification area.
+2. Hide and show the widget. Hiding must restore the task switcher's original width; showing must recreate
+   the tray-side reservation.
+3. Begin moving the widget from the tray menu and cancel with Escape. The reservation must be released
+   while moving and restored at the default tray-side position after cancellation.
+4. Complete a drag to a custom position. A custom position must remain usable and the automatic classic
+   reservation must stay released.
+5. Choose **Reset position**. The widget must return to the reserved tray-side slot.
+6. Quit TaskbarQuota. No permanent blank region may remain in the taskbar.
+7. Relaunch TaskbarQuota and restart Explorer once. The widget and reservation must be recreated without
+   requiring a settings change.
+
+## Native Windows 11 regression check
+
+1. Disable the third-party taskbar customization and restart Explorer so the native Windows 11 taskbar is
+   active.
+2. Start TaskbarQuota, reset its position, and repeat the ordinary and crowded-window checks.
+3. Exercise drag, widget width changes, hide/show, and quit.
+
+Expected result: native Windows 11 placement is unchanged. The classic reservation is inactive because the
+native taskbar does not expose the complete classic hierarchy.
+
+## Additional coverage and known limits
+
+- If available, repeat on a non-100% display scale.
+- A secondary taskbar without `TrayNotifyWnd` follows the existing placement behavior and is not reserved.
+- Right-to-left taskbars follow the existing placement behavior; the classic reservation is intentionally
+  limited to shortening the right edge so it never moves Start.
+- Custom widget positions do not resize the classic task switcher. Reset the position to test the automatic
+  reserved slot.
+- The visual result depends on how the active shell lays out and clips its task-button children. Passing the
+  automated tests does not establish compatibility with a particular shell customization.
+
+## Diagnostics and failure reporting
+
+Review `%TEMP%\taskbarquota.log` for `Could not reserve the classic task switcher area`. If the shell resets
+the task-switcher bounds after an interaction, allow one watcher interval (two seconds) and record whether
+the reservation returns cleanly. Do not report the fix as validated for that environment if overlap,
+flicker, taskbar movement, or oscillation remains.

--- a/src/TaskbarQuota.App/Interop/Native.cs
+++ b/src/TaskbarQuota.App/Interop/Native.cs
@@ -36,6 +36,17 @@ namespace TaskbarQuota.Interop
         [DllImport("user32.dll")]
         public static extern IntPtr SetParent([In] IntPtr hWndChild, [In] IntPtr hWndNewParent);
 
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool SetWindowPos(
+            [In] IntPtr hWnd,
+            [In, Optional] IntPtr hWndInsertAfter,
+            int x,
+            int y,
+            int cx,
+            int cy,
+            SetWindowPosFlags uFlags);
+
         [DllImport("User32.dll", CharSet = CharSet.Unicode)]
         public static extern IntPtr FindWindow([In, MarshalAs(UnmanagedType.LPWStr)] string? lpClassName, [In, MarshalAs(UnmanagedType.LPWStr)] string? lpWindowName);
 
@@ -218,6 +229,13 @@ namespace TaskbarQuota.Interop
         GA_PARENT = 1,
         GA_ROOT = 2,
         GA_ROOTOWNER = 3,
+    }
+
+    [Flags]
+    public enum SetWindowPosFlags : uint
+    {
+        SWP_NOZORDER = 0x0004,
+        SWP_NOACTIVATE = 0x0010,
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/TaskbarQuota.App/Taskbar/ClassicTaskbarSpaceReservation.cs
+++ b/src/TaskbarQuota.App/Taskbar/ClassicTaskbarSpaceReservation.cs
@@ -90,14 +90,21 @@ namespace TaskbarQuota.Taskbar
                 || !User32.GetWindowRect(hwndReBar, out RECT rebarScreenRect)
                 || !User32.GetWindowRect(hwndTaskSwitcher, out RECT currentScreenRect))
             {
+                // Keep the baseline and applied rectangles when a transient native read fails so
+                // the next restore attempt can still put the task switcher back.
+                return;
+            }
+
+            if (!RectsEqual(currentScreenRect, appliedScreenRect))
+            {
+                // Another component changed the task switcher after we applied our reservation;
+                // do not overwrite that external layout.
                 taskSwitcherState.Reset();
                 return;
             }
 
-            if (RectsEqual(currentScreenRect, appliedScreenRect))
-                TrySetWindowRect(ToScreenRect(baselineClientRect, rebarScreenRect), rebarScreenRect);
-
-            taskSwitcherState.Reset();
+            if (TrySetWindowRect(ToScreenRect(baselineClientRect, rebarScreenRect), rebarScreenRect))
+                taskSwitcherState.Reset();
         }
 
         internal static bool TryComputeRightPlacement(

--- a/src/TaskbarQuota.App/Taskbar/ClassicTaskbarSpaceReservation.cs
+++ b/src/TaskbarQuota.App/Taskbar/ClassicTaskbarSpaceReservation.cs
@@ -1,0 +1,320 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using TaskbarQuota.Diagnostics;
+using TaskbarQuota.Interop;
+
+namespace TaskbarQuota.Taskbar
+{
+    /// <summary>
+    /// Reserves a tray-side slot by shortening a classic task switcher from its right edge.
+    /// Native Windows 11 taskbars do not expose the complete classic hierarchy and remain untouched.
+    /// </summary>
+    internal sealed class ClassicTaskbarSpaceReservation : IDisposable
+    {
+        private const string ReBarClassName = "ReBarWindow32";
+        private const string TaskSwitcherClassName = "MSTaskSwWClass";
+        private const string TaskListClassName = "MSTaskListWClass";
+        private static readonly SetWindowPosFlags PositionFlags =
+            SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_NOACTIVATE;
+
+        private readonly object syncRoot = new();
+        private readonly IntPtr hwndTaskbar;
+        private readonly ReservationState taskSwitcherState = new();
+        private IntPtr hwndReBar;
+        private IntPtr hwndTaskSwitcher;
+        private IntPtr hwndTaskList;
+        private bool disposed;
+
+        public ClassicTaskbarSpaceReservation(IntPtr hwndTaskbar)
+        {
+            this.hwndTaskbar = hwndTaskbar;
+        }
+
+        public bool TryApplyRight(
+            RECT taskbarScreenRect,
+            RECT notificationScreenRect,
+            int widgetWidth,
+            int clearance,
+            out int widgetOffsetX)
+        {
+            lock (syncRoot)
+            {
+                widgetOffsetX = 0;
+                if (disposed
+                    || !TryComputeRightPlacement(
+                        taskbarScreenRect,
+                        notificationScreenRect,
+                        widgetWidth,
+                        clearance,
+                        out widgetOffsetX,
+                        out RECT widgetScreenRect)
+                    || !TryGetTargets(out RECT rebarScreenRect, out RECT taskSwitcherScreenRect))
+                {
+                    return false;
+                }
+
+                RECT baseline = ObserveBaseline(taskSwitcherScreenRect, rebarScreenRect);
+                if (!TryComputeReservedTaskSwitcherRect(baseline, widgetScreenRect, out RECT target))
+                {
+                    RestoreCore();
+                    return false;
+                }
+                if (!TrySetWindowRect(target, rebarScreenRect))
+                    return false;
+
+                taskSwitcherState.LastAppliedScreenRect = RectsEqual(target, baseline)
+                    ? null
+                    : target;
+                return true;
+            }
+        }
+
+        public void Restore()
+        {
+            lock (syncRoot)
+                RestoreCore();
+        }
+
+        private void RestoreCore()
+        {
+            if (disposed || !HasValidCachedTargets())
+            {
+                if (!disposed)
+                    ResetTargets();
+                return;
+            }
+
+            if (taskSwitcherState.BaselineClientRect is not { } baselineClientRect
+                || taskSwitcherState.LastAppliedScreenRect is not { } appliedScreenRect
+                || !User32.GetWindowRect(hwndReBar, out RECT rebarScreenRect)
+                || !User32.GetWindowRect(hwndTaskSwitcher, out RECT currentScreenRect))
+            {
+                taskSwitcherState.Reset();
+                return;
+            }
+
+            if (RectsEqual(currentScreenRect, appliedScreenRect))
+                TrySetWindowRect(ToScreenRect(baselineClientRect, rebarScreenRect), rebarScreenRect);
+
+            taskSwitcherState.Reset();
+        }
+
+        internal static bool TryComputeRightPlacement(
+            RECT taskbarScreenRect,
+            RECT notificationScreenRect,
+            int widgetWidth,
+            int clearance,
+            out int widgetOffsetX,
+            out RECT widgetScreenRect)
+        {
+            widgetOffsetX = 0;
+            widgetScreenRect = default;
+            if (!IsValid(taskbarScreenRect)
+                || !IsValid(notificationScreenRect)
+                || widgetWidth <= 0
+                || notificationScreenRect.left <= taskbarScreenRect.left
+                || notificationScreenRect.left >= taskbarScreenRect.right
+                || notificationScreenRect.bottom <= taskbarScreenRect.top
+                || notificationScreenRect.top >= taskbarScreenRect.bottom)
+            {
+                return false;
+            }
+
+            int safeClearance = Math.Max(0, clearance);
+            long widgetLeft = (long)notificationScreenRect.left - safeClearance - widgetWidth;
+            long offset = widgetLeft - taskbarScreenRect.left;
+            if (widgetLeft < taskbarScreenRect.left
+                || widgetLeft >= notificationScreenRect.left
+                || offset < int.MinValue
+                || offset > int.MaxValue)
+            {
+                return false;
+            }
+
+            widgetOffsetX = (int)offset;
+            widgetScreenRect = new RECT
+            {
+                left = (int)widgetLeft,
+                top = taskbarScreenRect.top,
+                right = notificationScreenRect.left - safeClearance,
+                bottom = taskbarScreenRect.bottom,
+            };
+            return IsValid(widgetScreenRect);
+        }
+
+        internal static bool TryComputeReservedTaskSwitcherRect(
+            RECT taskSwitcherScreenRect,
+            RECT widgetScreenRect,
+            out RECT result)
+        {
+            result = taskSwitcherScreenRect;
+            if (!IsValid(taskSwitcherScreenRect)
+                || !IsValid(widgetScreenRect)
+                || widgetScreenRect.bottom <= taskSwitcherScreenRect.top
+                || widgetScreenRect.top >= taskSwitcherScreenRect.bottom)
+            {
+                return false;
+            }
+
+            int targetRight = Math.Min(taskSwitcherScreenRect.right, widgetScreenRect.left);
+            if (targetRight <= taskSwitcherScreenRect.left)
+                return false;
+
+            result.right = targetRight;
+            return true;
+        }
+
+        private bool TryGetTargets(
+            out RECT rebarScreenRect,
+            out RECT taskSwitcherScreenRect)
+        {
+            rebarScreenRect = default;
+            taskSwitcherScreenRect = default;
+
+            if (!HasValidCachedTargets())
+            {
+                ResetTargets();
+                hwndReBar = User32.FindWindowEx(hwndTaskbar, IntPtr.Zero, ReBarClassName, null);
+                hwndTaskSwitcher = hwndReBar == IntPtr.Zero
+                    ? IntPtr.Zero
+                    : User32.FindWindowEx(hwndReBar, IntPtr.Zero, TaskSwitcherClassName, null);
+                hwndTaskList = hwndTaskSwitcher == IntPtr.Zero
+                    ? IntPtr.Zero
+                    : User32.FindWindowEx(hwndTaskSwitcher, IntPtr.Zero, TaskListClassName, null);
+                if (!HasValidCachedTargets())
+                {
+                    ResetTargets();
+                    return false;
+                }
+            }
+
+            return User32.GetWindowRect(hwndReBar, out rebarScreenRect)
+                && User32.GetWindowRect(hwndTaskSwitcher, out taskSwitcherScreenRect)
+                && IsValid(rebarScreenRect)
+                && IsValid(taskSwitcherScreenRect);
+        }
+
+        private bool HasValidCachedTargets()
+            => hwndReBar != IntPtr.Zero
+                && hwndTaskSwitcher != IntPtr.Zero
+                && hwndTaskList != IntPtr.Zero
+                && User32.IsWindow(hwndReBar)
+                && User32.IsWindow(hwndTaskSwitcher)
+                && User32.IsWindow(hwndTaskList)
+                && User32.GetAncestor(hwndReBar, GetAncestorFlags.GA_PARENT) == hwndTaskbar
+                && User32.GetAncestor(hwndTaskSwitcher, GetAncestorFlags.GA_PARENT) == hwndReBar
+                && User32.GetAncestor(hwndTaskList, GetAncestorFlags.GA_PARENT) == hwndTaskSwitcher;
+
+        private RECT ObserveBaseline(RECT currentScreenRect, RECT parentScreenRect)
+        {
+            if (taskSwitcherState.LastAppliedScreenRect is not { } applied
+                || !RectsEqual(currentScreenRect, applied))
+            {
+                taskSwitcherState.BaselineClientRect = ToClientRect(currentScreenRect, parentScreenRect);
+                taskSwitcherState.LastAppliedScreenRect = null;
+            }
+
+            taskSwitcherState.BaselineClientRect ??= ToClientRect(currentScreenRect, parentScreenRect);
+            return ToScreenRect(taskSwitcherState.BaselineClientRect.Value, parentScreenRect);
+        }
+
+        private bool TrySetWindowRect(RECT targetScreenRect, RECT parentScreenRect)
+        {
+            if (!IsValid(targetScreenRect))
+                return false;
+
+            if (User32.GetWindowRect(hwndTaskSwitcher, out RECT currentScreenRect)
+                && RectsEqual(currentScreenRect, targetScreenRect))
+            {
+                taskSwitcherState.FailureLogged = false;
+                return true;
+            }
+
+            RECT targetClientRect = ToClientRect(targetScreenRect, parentScreenRect);
+            bool success = User32.SetWindowPos(
+                hwndTaskSwitcher,
+                IntPtr.Zero,
+                targetClientRect.left,
+                targetClientRect.top,
+                targetClientRect.right - targetClientRect.left,
+                targetClientRect.bottom - targetClientRect.top,
+                PositionFlags);
+            if (success)
+            {
+                taskSwitcherState.FailureLogged = false;
+                return true;
+            }
+
+            if (!taskSwitcherState.FailureLogged)
+            {
+                taskSwitcherState.FailureLogged = true;
+                Log.Warning(
+                    new Win32Exception(Marshal.GetLastWin32Error()),
+                    "Could not reserve the classic task switcher area");
+            }
+            return false;
+        }
+
+        private void ResetTargets()
+        {
+            hwndReBar = IntPtr.Zero;
+            hwndTaskSwitcher = IntPtr.Zero;
+            hwndTaskList = IntPtr.Zero;
+            taskSwitcherState.Reset();
+        }
+
+        private static RECT ToClientRect(RECT screenRect, RECT parentScreenRect)
+            => new()
+            {
+                left = screenRect.left - parentScreenRect.left,
+                top = screenRect.top - parentScreenRect.top,
+                right = screenRect.right - parentScreenRect.left,
+                bottom = screenRect.bottom - parentScreenRect.top,
+            };
+
+        private static RECT ToScreenRect(RECT clientRect, RECT parentScreenRect)
+            => new()
+            {
+                left = clientRect.left + parentScreenRect.left,
+                top = clientRect.top + parentScreenRect.top,
+                right = clientRect.right + parentScreenRect.left,
+                bottom = clientRect.bottom + parentScreenRect.top,
+            };
+
+        private static bool IsValid(RECT rect)
+            => rect.right > rect.left && rect.bottom > rect.top;
+
+        private static bool RectsEqual(RECT left, RECT right)
+            => left.left == right.left
+                && left.top == right.top
+                && left.right == right.right
+                && left.bottom == right.bottom;
+
+        public void Dispose()
+        {
+            lock (syncRoot)
+            {
+                if (disposed)
+                    return;
+                RestoreCore();
+                disposed = true;
+                ResetTargets();
+            }
+        }
+
+        private sealed class ReservationState
+        {
+            public RECT? BaselineClientRect { get; set; }
+            public RECT? LastAppliedScreenRect { get; set; }
+            public bool FailureLogged { get; set; }
+
+            public void Reset()
+            {
+                BaselineClientRect = null;
+                LastAppliedScreenRect = null;
+                FailureLogged = false;
+            }
+        }
+    }
+}

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -75,6 +75,7 @@ namespace TaskbarQuota.Taskbar
         private readonly string displayKey;
         private readonly string WidgetClassName = "TaskbarQuotaWidgetWinRT";
         private readonly TaskbarStructureWatcher taskbarWatcher;
+        private readonly ClassicTaskbarSpaceReservation classicTaskbarReservation;
         private readonly string positionPath;
         private readonly CancellationTokenSource positionUpdateCancellation = new();
         private readonly SemaphoreSlim positionUpdateGate = new(1, 1);
@@ -210,6 +211,7 @@ namespace TaskbarQuota.Taskbar
             positionPath = target.GetPositionPath();
 
             taskbarWatcher = new TaskbarStructureWatcher(hwndShell, hwndReBar);
+            classicTaskbarReservation = new ClassicTaskbarSpaceReservation(hwndShell);
             taskbarWatcher.TaskbarChangedNotificationCompleted += (_, e) =>
             {
                 if (initialized)
@@ -318,6 +320,7 @@ namespace TaskbarQuota.Taskbar
             {
                 if (isDragging)
                     EndDragging(revert: true);
+                classicTaskbarReservation.Restore();
                 appWindow.Hide();
             }
         }
@@ -874,6 +877,25 @@ namespace TaskbarQuota.Taskbar
                 }
                 bool useDefault = offsetX == -1;
 
+                // Classic task switchers can ignore a sibling overlay when their uncombined buttons grow.
+                // For the default LTR placement, shorten only the switcher's right edge and put the widget
+                // in the resulting tray-side slot. Native Win11 lacks this hierarchy, so its path is unchanged.
+                int classicOffsetX = 0;
+                bool useClassicRightReservation = CanUseClassicRightReservation(
+                        isVisible,
+                        isPrimaryTaskbar,
+                        useDefault,
+                        hasNotificationArea,
+                        IsRtlUI)
+                    && classicTaskbarReservation.TryApplyRight(
+                        taskbarScreenRect,
+                        notificationScreenRect,
+                        WidgetHostWidth,
+                        TrayClearancePx,
+                        out classicOffsetX);
+                if (!useClassicRightReservation)
+                    classicTaskbarReservation.Restore();
+
                 // The Widgets/weather pill is a XAML element the child-window scan can't see, so fetch its
                 // bounds separately (UIA, with a cached fallback) and treat it as an obstacle like any other.
                 RECT? wbRect = isWidgetsEnabled ? await taskbarWatcher.GetWidgetsButtonRectAsync() : null;
@@ -893,10 +915,6 @@ namespace TaskbarQuota.Taskbar
                     lastTaskButtonClientRects = converted;
                 }
 
-                // Every taskbar button (app icons + system buttons) is an obstacle, so the widget can never rest
-                // on top of the app cluster — same set for resting and dragging (issue #17).
-                var obstacles = CollectObstacleClientRects(taskbarScreenRect, wbClient, lastTaskButtonClientRects);
-
                 var (leftBound, rightBound) = ComputeUsableHorizontalBounds(
                     taskbarRect,
                     hasNotificationArea ? trayNotifyRect : null,
@@ -905,7 +923,9 @@ namespace TaskbarQuota.Taskbar
 
                 // Preferred X: the saved manual position, or the side-appropriate default anchor.
                 int preferredX;
-                if (!useDefault)
+                if (useClassicRightReservation)
+                    preferredX = classicOffsetX;
+                else if (!useDefault)
                     preferredX = offsetX;
                 else if (!hasNotificationArea)
                     preferredX = IsRtlUI ? leftBound : rightBound - WidgetHostWidth;
@@ -914,22 +934,36 @@ namespace TaskbarQuota.Taskbar
                 else
                     preferredX = IsRtlUI ? leftBound : rightBound - WidgetHostWidth;
 
+                // Every taskbar button (app icons + system buttons) is an obstacle, so the widget can never rest
+                // on top of the app cluster — same set for resting and dragging (issue #17).
+                var obstacles = CollectObstacleClientRects(taskbarScreenRect, wbClient, lastTaskButtonClientRects);
+
                 // Only ever rest inside a gap that FULLY fits the widget; if none does, don't move it into an
                 // overlap — keep the last valid spot (issue #17). First run with no fit hugs the tray.
                 var gaps = ComputeFreeGaps(leftBound, rightBound, obstacles);
                 // The widget is not one of its own obstacles, so the gap it sits in measures the full space
                 // it may occupy. That is the budget the tile-fit math trims against.
                 UpdateAvailableWidth(gaps);
-                int? placed = PlaceInFittingGap(preferredX, gaps, WidgetHostWidth);
-                if (placed is not { } fitX)
+
+                if (useClassicRightReservation)
                 {
-                    if (currentOffsetX != int.MinValue)
-                        return;
-                    offsetX = Math.Max(leftBound, rightBound - WidgetHostWidth);
+                    // The shortened classic switcher owns the button layout. Its reserved slot is therefore
+                    // authoritative even if UI Automation briefly reports stale child-button rectangles.
+                    offsetX = preferredX;
                 }
                 else
                 {
-                    offsetX = fitX;
+                    int? placed = PlaceInFittingGap(preferredX, gaps, WidgetHostWidth);
+                    if (placed is not { } fitX)
+                    {
+                        if (currentOffsetX != int.MinValue)
+                            return;
+                        offsetX = Math.Max(leftBound, rightBound - WidgetHostWidth);
+                    }
+                    else
+                    {
+                        offsetX = fitX;
+                    }
                 }
 
                 offsetX = ClampToTaskbarMonitor(
@@ -983,10 +1017,24 @@ namespace TaskbarQuota.Taskbar
             => currentOffsetX == int.MinValue
             || Math.Abs((long)currentOffsetX - offsetX) >= deadbandPx;
 
+        internal static bool CanUseClassicRightReservation(
+            bool isVisible,
+            bool isPrimaryTaskbar,
+            bool useDefault,
+            bool hasNotificationArea,
+            bool isRtlUi)
+            => isVisible
+                && isPrimaryTaskbar
+                && useDefault
+                && hasNotificationArea
+                && !isRtlUi;
+
         public void StartDragging()
         {
             if (isDragging || appWindow is null || hostContent is null || summaryPanel is null) return;
+            isDragging = true;
             SetVisible(true);
+            classicTaskbarReservation.Restore();
             SetTilesHitTestVisible(false);
             User32.GetWindowRect(hwndShell, out var taskbarRect);
             User32.SetCursorPos(
@@ -995,7 +1043,6 @@ namespace TaskbarQuota.Taskbar
             hostContent.KeyUp += Content_KeyUp;
             hostContent.PointerPressed += Content_PointerPressed;
             hostContent.PointerReleased += Content_PointerReleased;
-            isDragging = true;
             PrimeObstacleCacheForDrag();
             if (!host!.HasFocus && hwnd != User32.GetForegroundWindow())
                 User32.SetForegroundWindow(hwnd);
@@ -1016,6 +1063,7 @@ namespace TaskbarQuota.Taskbar
                 dragPreviewX = null;
                 activeDragGap = null;
                 appWindow.Move(new PointInt32(currentOffsetX, currentOffsetY));
+                QueuePositionUpdate(TaskbarChangeReason.None);
                 return;
             }
             _ = SnapToValidPositionAsync(dragPreviewX ?? appWindow.Position.X);
@@ -1072,6 +1120,7 @@ namespace TaskbarQuota.Taskbar
                 if (Math.Abs(point.x - pressCursorPositionX) < Math.Ceiling(4 * dpiScale))
                     return;
                 isDirectDrag = true;
+                classicTaskbarReservation.Restore();
                 SuppressTileClicks();
                 e.Handled = true;
             }
@@ -1095,9 +1144,12 @@ namespace TaskbarQuota.Taskbar
 
         private void WidgetSummary_PointerCanceled(object sender, PointerRoutedEventArgs e)
         {
+            bool wasDirectDrag = isDirectDrag;
             isPointerTracking = false;
             isDirectDrag = false;
             (sender as WidgetSummary)?.ReleasePointerCaptures();
+            if (wasDirectDrag)
+                QueuePositionUpdate(TaskbarChangeReason.None);
         }
 
         private void SetTilesHitTestVisible(bool visible)
@@ -1414,7 +1466,6 @@ namespace TaskbarQuota.Taskbar
                 Log.Warning(ex, "Failed to prime the taskbar obstacle cache for a drag");
             }
         }
-
 
         /// <summary>Keeps a widget of <paramref name="width"/> inside [leftBound, rightBound].</summary>
         internal static int ClampToSpan(int desiredX, int leftBound, int rightBound, int width)
@@ -1965,6 +2016,7 @@ namespace TaskbarQuota.Taskbar
             initialized = false;
             isVisible = false;
             positionUpdateCancellation.Cancel();
+            classicTaskbarReservation.Dispose();
             try { appWindow?.Hide(); } catch { }
             foreach (var tile in tiles)
             {

--- a/tests/TaskbarQuota.Tests/ClassicTaskbarSpaceReservationTests.cs
+++ b/tests/TaskbarQuota.Tests/ClassicTaskbarSpaceReservationTests.cs
@@ -1,0 +1,181 @@
+using TaskbarQuota.Interop;
+using TaskbarQuota.Taskbar;
+
+namespace TaskbarQuota.Tests;
+
+public class ClassicTaskbarSpaceReservationTests
+{
+    [Fact]
+    public void TryApplyRight_AfterDispose_IsAlwaysANoOp()
+    {
+        using var reservation = new ClassicTaskbarSpaceReservation(IntPtr.Zero);
+        reservation.Dispose();
+
+        bool applied = reservation.TryApplyRight(
+            R(0, 0, 1920, 48),
+            R(1600, 0, 1920, 48),
+            widgetWidth: 200,
+            clearance: 6,
+            out _);
+
+        Assert.False(applied);
+    }
+
+    [Theory]
+    [InlineData(172, 3157)]
+    [InlineData(220, 3109)]
+    [InlineData(280, 3049)]
+    public void TryComputeRightPlacement_WidgetModesUseTheirActualWidth(
+        int widgetWidth,
+        int expectedOffset)
+    {
+        bool found = ClassicTaskbarSpaceReservation.TryComputeRightPlacement(
+            R(0, 0, 3840, 90),
+            R(3335, 0, 3840, 90),
+            widgetWidth,
+            clearance: 6,
+            out int offset,
+            out RECT widgetRect);
+
+        Assert.True(found);
+        Assert.Equal(expectedOffset, offset);
+        AssertRect(widgetRect, expectedOffset, 0, 3329, 90);
+    }
+
+    [Fact]
+    public void TryComputeRightPlacement_NegativeTaskbarOrigin_ReturnsClientOffset()
+    {
+        bool found = ClassicTaskbarSpaceReservation.TryComputeRightPlacement(
+            R(-1920, 1000, 0, 1080),
+            R(-400, 1000, 0, 1080),
+            widgetWidth: 300,
+            clearance: 6,
+            out int offset,
+            out RECT widgetRect);
+
+        Assert.True(found);
+        Assert.Equal(1214, offset);
+        AssertRect(widgetRect, -706, 1000, -406, 1080);
+    }
+
+    [Fact]
+    public void TryComputeRightPlacement_NegativeClearance_IsClampedToZero()
+    {
+        bool found = ClassicTaskbarSpaceReservation.TryComputeRightPlacement(
+            R(0, 0, 1920, 48),
+            R(1600, 0, 1920, 48),
+            widgetWidth: 200,
+            clearance: -10,
+            out int offset,
+            out RECT widgetRect);
+
+        Assert.True(found);
+        Assert.Equal(1400, offset);
+        AssertRect(widgetRect, 1400, 0, 1600, 48);
+    }
+
+    [Fact]
+    public void TryComputeRightPlacement_WidgetDoesNotFitBeforeTray_ReturnsFalse()
+    {
+        bool found = ClassicTaskbarSpaceReservation.TryComputeRightPlacement(
+            R(0, 0, 500, 48),
+            R(100, 0, 500, 48),
+            widgetWidth: 200,
+            clearance: 6,
+            out _,
+            out _);
+
+        Assert.False(found);
+    }
+
+    [Fact]
+    public void TryComputeRightPlacement_NoVerticalIntersection_ReturnsFalse()
+    {
+        bool found = ClassicTaskbarSpaceReservation.TryComputeRightPlacement(
+            R(0, 0, 1920, 48),
+            R(1600, 48, 1920, 96),
+            widgetWidth: 200,
+            clearance: 6,
+            out _,
+            out _);
+
+        Assert.False(found);
+    }
+
+    [Fact]
+    public void TryComputeRightPlacement_NotificationAreaOutsideTaskbar_ReturnsFalse()
+    {
+        bool found = ClassicTaskbarSpaceReservation.TryComputeRightPlacement(
+            R(0, 0, 1920, 48),
+            R(1920, 0, 2200, 48),
+            widgetWidth: 200,
+            clearance: 6,
+            out _,
+            out _);
+
+        Assert.False(found);
+    }
+
+    [Fact]
+    public void TryComputeReservedTaskSwitcherRect_OverlappingRightEdge_ShortensOnlyRightEdge()
+    {
+        bool found = ClassicTaskbarSpaceReservation.TryComputeReservedTaskSwitcherRect(
+            R(110, 0, 3335, 90),
+            R(2907, 0, 3321, 90),
+            out RECT result);
+
+        Assert.True(found);
+        AssertRect(result, 110, 0, 2907, 90);
+    }
+
+    [Fact]
+    public void TryComputeReservedTaskSwitcherRect_AlreadyBeforeWidget_RemainsUnchanged()
+    {
+        bool found = ClassicTaskbarSpaceReservation.TryComputeReservedTaskSwitcherRect(
+            R(110, 0, 2800, 90),
+            R(2907, 0, 3321, 90),
+            out RECT result);
+
+        Assert.True(found);
+        AssertRect(result, 110, 0, 2800, 90);
+    }
+
+    [Fact]
+    public void TryComputeReservedTaskSwitcherRect_WidgetConsumesWholeSwitcher_ReturnsFalse()
+    {
+        RECT switcher = R(110, 0, 3335, 90);
+
+        bool found = ClassicTaskbarSpaceReservation.TryComputeReservedTaskSwitcherRect(
+            switcher,
+            R(100, 0, 500, 90),
+            out RECT result);
+
+        Assert.False(found);
+        AssertRect(result, switcher.left, switcher.top, switcher.right, switcher.bottom);
+    }
+
+    [Fact]
+    public void TryComputeReservedTaskSwitcherRect_NoVerticalIntersection_ReturnsFalse()
+    {
+        RECT switcher = R(110, 0, 3335, 90);
+
+        bool found = ClassicTaskbarSpaceReservation.TryComputeReservedTaskSwitcherRect(
+            switcher,
+            R(2907, 90, 3321, 180),
+            out RECT result);
+
+        Assert.False(found);
+        AssertRect(result, switcher.left, switcher.top, switcher.right, switcher.bottom);
+    }
+
+    private static RECT R(int left, int top, int right, int bottom)
+        => new() { left = left, top = top, right = right, bottom = bottom };
+
+    private static void AssertRect(RECT actual, int left, int top, int right, int bottom)
+    {
+        Assert.Equal(left, actual.left);
+        Assert.Equal(top, actual.top);
+        Assert.Equal(right, actual.right);
+        Assert.Equal(bottom, actual.bottom);
+    }
+}

--- a/tests/TaskbarQuota.Tests/TaskBarWidgetGapTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskBarWidgetGapTests.cs
@@ -32,6 +32,31 @@ public class TaskBarWidgetGapTests
         Assert.True(TaskBarWidget.ShouldReposition(1200, 1198, 2));
     }
 
+    [Theory]
+    [InlineData(true, true, true, true, false, true)]
+    [InlineData(false, true, true, true, false, false)]
+    [InlineData(true, false, true, true, false, false)]
+    [InlineData(true, true, false, true, false, false)]
+    [InlineData(true, true, true, false, false, false)]
+    [InlineData(true, true, true, true, true, false)]
+    public void CanUseClassicRightReservation_RequiresEverySupportedCondition(
+        bool isVisible,
+        bool isPrimaryTaskbar,
+        bool useDefault,
+        bool hasNotificationArea,
+        bool isRtlUi,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            TaskBarWidget.CanUseClassicRightReservation(
+                isVisible,
+                isPrimaryTaskbar,
+                useDefault,
+                hasNotificationArea,
+                isRtlUi));
+    }
+
     [Fact]
     public void ComputeFreeGaps_NoObstacles_ReturnsWholeSpan()
     {


### PR DESCRIPTION
## Problem

With a restored/classic Windows 11 taskbar such as StartAllBack, uncombined task buttons can continue growing underneath TaskbarQuota when enough windows are open. The widget itself remains visible, but task-button icons, titles, and hover backgrounds overlap it.

## Cause

TaskbarQuota hosts its widget as a sibling window and avoids known taskbar obstacles when choosing its own position. A classic `MSTaskSwWClass` task switcher does not treat that sibling overlay as reserved layout space, so its uncombined buttons can still use the widget's rectangle.

## Solution

- Detect the generic classic hierarchy `Shell_TrayWnd` → `ReBarWindow32` → `MSTaskSwWClass` → `MSTaskListWClass`.
- For the default left-to-right position on the primary taskbar, shorten only the right edge of `MSTaskSwWClass` and place the widget in the resulting tray-side slot.
- Size the reservation from the widget's current host width, including the different bars/percentages display modes and multi-tile layouts.
- Serialize reservation application, restoration, and disposal so background placement cannot race UI cleanup.
- Restore the original switcher bounds when the widget is hidden, dragged, moved to a custom position, disposed, or cannot safely use the reservation.
- Leave native Windows 11, secondary taskbars, right-to-left layouts, and custom positions on their existing placement path.

This does not detect or reference StartAllBack specifically and adds no dependency on it.

## Tests performed

- Focused geometry and placement tests: 52 passed.
- Full test suite with xUnit collection parallelism disabled: 506 passed.
- Debug x64 build: passed.
- Self-contained Release publish: x64 and ARM64 passed.
- Publish artifact validation: `TaskbarQuota.exe`, `TaskbarQuota.pri`, and all 8 generated XBF files were present for both architectures.
- Manual Windows 11 + StartAllBack validation on current commit `cbc340c`: passed with a crowded taskbar and uncombined buttons. The widget remained immediately before the tray, Start stayed stable, and the tested display-mode, drag, and visibility interactions did not reintroduce overlap or oscillation.

The manual procedure in `docs/manual-testing-classic-taskbar-reservation.md` covers crowded taskbars, every widget display mode, hide/show, drag/cancel/reset, Explorer restart, and a native Windows 11 regression check.

## Known limitations

- The visual result depends on the active shell's task-button layout and cannot be established by unit tests.
- The automatic reservation intentionally applies only to the default position on a left-to-right primary classic taskbar exposing the complete hierarchy.
- Inno Setup is not installed in the development environment, so the installer itself was not compiled.
- Builds still report the existing `NU1903` advisory for `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 (GHSA-2m69-gcr7-jv3q); this dependency is unchanged by this PR and should be handled separately.
- A default parallel test run can expose an unrelated shared-configuration race in `ZaiProviderTests`; the complete sequential run passes 506/506.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Classic taskbar layouts now reserve space for the widget beside the notification area.
  - Taskbar placement updates correctly when the widget is shown, hidden, moved, or dragged.
  - Reservation is restored after dragging, cancellation, or widget repositioning.

- **Bug Fixes**
  - Improved placement handling for crowded taskbars, varying display layouts, and widget sizes.

- **Documentation**
  - Added a manual testing guide covering classic taskbar behavior, regressions, diagnostics, and known limitations.

- **Tests**
  - Added coverage for placement, boundary, scaling, and overlap scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
