### PR TITLE
feat(widget): add configurable global visibility policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <h1 align="center">TaskbarQuota</h1>
 
 <p align="center">
-  A native <b>Windows</b> taskbar companion that <b>automatically detects which AI tool you are using</b> — the focused desktop app <i>or</i> the agent running in your terminal — and shows live usage for <em>that</em> provider only.<br/>
+  A native <b>Windows</b> taskbar companion that <b>automatically detects supported AI tools</b> — desktop apps, terminal agents, or a supported active browser tab — and shows live provider usage.<br/>
   Sessions, rate windows, cost or balance; compact widget beside the tray; full dashboard on demand; no cloud backend.
 </p>
 
@@ -38,20 +38,22 @@ On first launch after upgrading from the internal **WinCheck** codename, setting
 
 ## Automatically follows your active tool
 
-TaskbarQuota answers one question: **“What am I using right now, and how much quota is left?”** It distinguishes two cases:
+TaskbarQuota answers one question: **“What am I using right now, and how much quota is left?”** It distinguishes three cases:
 
 | You are working in… | How TaskbarQuota decides |
 | ------------------- | ------------------------ |
 | **A desktop AI app** (Cursor, Antigravity, Codex, Claude, VS Code with Copilot, …) | The **foreground window** is matched to a provider. |
-| **A terminal** (Windows Terminal, PowerShell, Warp, WezTerm, …) | The focused shell is detected, then running processes are scanned for CLI agents (`claude`, `codex`, `cursor-agent`, `opencode`, `gh copilot`, …). The **most recently started** matching agent wins. |
+| **A terminal** (Windows Terminal, PowerShell, WezTerm, …) | The focused shell is detected, then its process session is scanned for CLI agents (`claude`, `codex`, `cursor-agent`, `opencode`, `gh copilot`, …). The best session match wins. |
+| **A browser** | The foreground browser's active-tab URL is inspected. In the current implementation, `claude.ai` maps to Claude; background tabs and window titles do not count. |
 
-When you alt-tab from Cursor into a PowerShell session running Claude Code, the widget retargets to **Claude** within about half a second. When you leave all supported tools, the widget can fade until you return to one. If the foreground app is unrelated (browser, Slack, …), TaskbarQuota keeps showing the **last active** provider so the taskbar still has context.
+When you alt-tab from Cursor into a PowerShell session running Claude Code, the active provider retargets to **Claude** within about half a second. Visibility is configured independently: the widget can stay visible, follow any open supported tool, or require active use. The last relevant eligible provider is remembered for the next time the widget appears.
 
 **Examples**
 
 - Cursor IDE focused → **Cursor** usage  
 - Windows Terminal + `claude` in the command line → **Claude** usage  
 - VS Code focused → **GitHub Copilot** usage  
+- Foreground browser with `claude.ai` as the active tab → **Claude** usage
 - OpenCode model switch (Zen vs Go) → provider updates without restarting TaskbarQuota  
 - Cline surface switch (Usage-Billing vs ClinePass) → provider updates without restarting TaskbarQuota  
 
@@ -65,7 +67,7 @@ After detection, usage is fetched from **local credentials** or **provider APIs*
 
 ### What's new in 1.1.0
 
-- **Pinned providers** — providers can be pinned so their quota stays on the taskbar no matter which tool is in the foreground. The active provider takes the leftmost slot and pinned ones trail it, up to 3 tiles and only while they fit the measured taskbar space. (#32)
+- **Pinned providers** — providers can be pinned so their quota remains in the widget whenever the widget is visible. The active provider takes the leftmost slot and pinned ones trail it, up to 3 tiles and only while they fit the measured taskbar space. Pinning does not override the global visibility policy. (#32)
 - **Single instance** — launching TaskbarQuota again activates the running app instead of spawning a second widget, with a fallback to a normal launch if the activation redirect fails. (#30)
 - **Drag fixed in both directions** — off-band obstacles (the Widgets flyout, overflow popups, hidden sibling windows) no longer erase the free gap left of the icon cluster, so the widget drags left as well as right. (#33)
 - **Reposition deadband fix** — the deadband no longer overflows before the widget's first placement. (#31)
@@ -101,7 +103,7 @@ After detection, usage is fetched from **local credentials** or **provider APIs*
 
 ### What's new in 1.0.15
 
-- **Browser tab detection** — TaskbarQuota reads the active browser tab to attribute usage to the provider you're actually using (ChatGPT, Claude, Gemini, and more), instead of folding web chats into coding-client providers.
+- **Browser tab detection** — TaskbarQuota can classify supported sites from the foreground browser's active tab. The current visibility path recognizes `claude.ai`; it does not inspect background tabs or infer from window titles.
 - **Login with Claude** — a cookie-free one-click sign-in for Claude usage that survives Chrome's App-Bound Encryption, with an automatic fallback to `claude.ai` browser cookies when no CLI is present.
 - **Detection source in the UI** — the dashboard and widget now show how each provider was detected (browser, desktop app, terminal, or host app), plus a dismissible onboarding panel.
 - **Multi-monitor widget confinement** — on setups where one taskbar spans displays, the widget stays on the monitor hosting the notification area instead of straddling the seam.
@@ -133,19 +135,23 @@ After detection, usage is fetched from **local credentials** or **provider APIs*
 - **Follows taskbar layout** — recenters when the taskbar moves, centers, or when Widgets / tray geometry changes.
 - **Draggable placement** — drag to reposition; offset is saved under `%LOCALAPPDATA%\TaskbarQuota\`.
 - **Click for flyout** — quick provider strip and settings shortcut above the widget.
-- **Fades when idle** — widget can hide when no supported AI tool process is detected; returns when you focus a supported app or terminal session.
+- **Configurable visibility** — choose **Always show**, **Show while any supported AI tool is open** (the default), or **Show only while a supported AI tool is in use**.
+- **Background agent option** — in the in-use mode, a separate setting can keep the widget visible while a supported CLI agent remains associated with a terminal session or Codex Desktop exposes a task as still running.
+- **Stable transitions** — qualifying surfaces show immediately; automatic hides wait two continuous seconds to avoid flicker. Manual tray actions and invalid-provider changes apply immediately.
+- **Tray override** — **Show widget**, **Hide widget**, and **Use automatic visibility** change only the current run; the saved policy is left intact.
 
 ### Active-tool detection (desktop app **or** terminal agent)
 
 This is the core behavior — everything else (widget, flyout, fetch cache) hangs off it.
 
-- **Desktop apps** — process name of the focused window: Cursor, Antigravity, Codex, Claude, Devin, VS Code / Insiders (Copilot), and similar.
-- **Terminal agents** — if a known terminal is focused, WMI/process scan looks at command lines for Claude Code, Codex, `cursor-agent`, OpenCode, `cline`, `gh copilot`, Grok, Devin, Antigravity CLI, and related launchers (Windows Terminal, PowerShell, `pwsh`, WezTerm, Alacritty, …).
+- **Desktop apps** — process name of the focused window: Cursor, Antigravity, Codex, Claude, Devin, VS Code / Insiders (Copilot), and similar. VS Code is intentionally an approximation: a running/focused Code process is treated as Copilot without checking editor-extension state.
+- **Terminal agents** — if a known terminal is focused, a WMI/process scan resolves supported native executables and strict launcher signatures for Claude Code, Codex, `cursor-agent`, OpenCode, `cline`, `gh copilot`, Grok, Devin, Antigravity CLI, and related launchers (Windows Terminal, PowerShell, `pwsh`, WezTerm, Alacritty, …). A generic `gh.exe`, runtime process, or project path containing a provider name is not enough.
 - **Fast switching** — coordinator polls about every **500 ms**, so changing app or shell updates the active provider quickly; usage API calls are cached for **60 seconds** so providers are not spammed.
 - **OpenCode model switch** — watches OpenCode model state to move between OpenCode Zen and OpenCode Go without restarting the app.
 - **Cline surface switch** — watches Cline provider state to move between Cline Usage-Billing and ClinePass without restarting the app.
-- **Sticky last provider** — unrelated foreground apps do not clear the widget; last detected tool stays until you focus a supported app or terminal again.
-- **Idle hide** — optional fade when no supported AI process is running; comes back when you focus a supported app or terminal session.
+- **Browser scope** — only the supported active tab of the foreground browser counts. Background tabs, Firefox session-store state, and title text are deliberately excluded from visibility decisions.
+- **Remembered provider** — the last relevant eligible provider supplies widget content after a hide or restart; it does not make an inactive surface count as active.
+- **Background-agent evidence is local and explicit** — CLI presence still means a matching process with a terminal/shell relationship, not proof that it is generating output. Codex Desktop activity uses its accessible running-task indicator rather than its persistent `codex.exe app-server`; TaskbarQuota does not read thread titles, prompts, responses, or Codex logs. WSL agents that expose no matching Windows process are not guaranteed to be detected.
 
 ### Supported providers
 
@@ -170,14 +176,15 @@ Each provider card on the dashboard shows plan name, reset times, rate windows, 
 ### Dashboard & shell
 
 - **Full dashboard** — all registered providers at once with refresh, error states, and detail cards.
-- **System tray** — Open, show widget, and Exit.
+- **System tray** — Open, visibility override submenu, widget positioning actions, and Quit.
 - **Run at startup** — optional Windows startup registration; can launch widget-only.
-- **Settings** — light / dark / system theme, widget layout (bars, percentages, or both), consumed vs remaining percentage display.
+- **Settings** — light / dark / system theme, widget layout, consumed vs remaining percentages, saved visibility policy, and the conditional background-agent option.
 
 ### Privacy
 
 - **Local-only** — no TaskbarQuota backend; usage calls go directly from your PC to each provider (or localhost for Antigravity).
 - **No telemetry** — diagnostics log to `%TEMP%\taskbarquota.log` only.
+- **Detection data is minimized** — visibility logs contain policy, surface category, reason, and provider transitions; browser URLs, window titles, and command lines are not logged or persisted by the visibility subsystem.
 - **Cookie extraction is in-memory** — browser cookies are read to build a request header for the active fetch; they are not intentionally persisted (manual credentials in `credentials.json` are plain JSON today — keep that file on your PC only).
 
 ## How it works
@@ -185,7 +192,8 @@ Each provider card on the dashboard shows plan name, reset times, rate windows, 
 ```text
 ActiveAppDetector
   ├─ foreground GUI app  → ProviderId
-  └─ focused terminal      → scan CLI processes → ProviderId
+  ├─ focused terminal     → session CLI scan → ProviderId
+  └─ foreground browser  → supported active-tab URL → ProviderId
         ↓
 UsageCoordinator (500 ms tick, picks active provider)
         ↓
@@ -193,13 +201,13 @@ UsageService (provider registry + 60 s success cache, shorter TTL on errors / 42
         ↓
 IUsageProvider implementations (HTTP / local API / SQLite / DPAPI)
         ↓
-TaskBarManager → WidgetSummary (taskbar) + Dashboard + Flyout
+WidgetVisibilityPolicy → TaskBarManager → WidgetSummary (taskbar) + Dashboard + Flyout
 ```
 
-1. **Detection** — `ActiveAppDetector` maps the foreground process (or CLI child of a known terminal) to a `ProviderId`.
+1. **Detection** — `ActiveAppDetector` separates supported surface presence from foreground activity and maps the active desktop app, terminal agent, or supported browser tab to a `ProviderId`.
 2. **Fetch** — the matching `IUsageProvider` loads tokens from CLI config files, environment variables, TaskbarQuota credentials, Cursor's local database, or `CookieExtractor` (Chromium / Firefox profiles, copied to `%TEMP%` for locked DBs).
 3. **Normalize** — results become a `UsageSnapshot` with `RateWindow` rows and optional `CostSnapshot`.
-4. **Display** — `UsageCoordinator` raises `StateChanged`; the taskbar widget and dashboard apply the snapshot. Fetches are cached so providers are not hammered on every tick.
+4. **Display** — `UsageCoordinator` keeps publishing cached/fresh state even while the native widget host is hidden. `WidgetVisibilityPolicy` decides whether the host appears; it does not stop detection, dashboard updates, or quota alerts.
 
 ### Architecture at a glance
 

--- a/src/TaskbarQuota.App/ActiveApp/ActiveAppDetector.cs
+++ b/src/TaskbarQuota.App/ActiveApp/ActiveAppDetector.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Management;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Json;
 using TaskbarQuota.Interop;
 using TaskbarQuota.Usage;
@@ -99,7 +100,6 @@ namespace TaskbarQuota.ActiveApp
             ["cursor-agent"] = ProviderId.Cursor,
             ["opencode"] = ProviderId.OpenCode,
             ["copilot"] = ProviderId.Copilot,
-            ["gh"] = ProviderId.Copilot,
             ["grok"] = ProviderId.Grok,
             ["devin"] = ProviderId.Devin,
             ["cline"] = ProviderId.Cline,
@@ -107,10 +107,11 @@ namespace TaskbarQuota.ActiveApp
         };
 
         // Script-runtime hosts that run a CLI as an argument (e.g. "node ... claude"); only these need
-        // their CommandLine inspected, and only when they sit inside the focused terminal session.
+        // their CommandLine inspected. Activity scans limit that work to the focused terminal session;
+        // the 5-second presence probe expands it only when no qualifying native CLI was found.
         private static readonly HashSet<string> CmdLineHostExes = new(StringComparer.OrdinalIgnoreCase)
         {
-            "node", "bun", "deno", "npm", "npx", "pnpm", "yarn", "cmd",
+            "node", "bun", "deno", "npm", "npx", "pnpm", "yarn", "cmd", "gh",
         };
 
         // Bulk scan covers native CLIs + script hosts + shells/terminals (needed to build the session
@@ -121,7 +122,9 @@ namespace TaskbarQuota.ActiveApp
 
         // Brief cache so tab switches inside one terminal stay responsive without hammering WMI.
         private static readonly TimeSpan CliCacheTtl = TimeSpan.FromMilliseconds(250);
-        private static readonly TimeSpan RunningToolCacheTtl = TimeSpan.FromSeconds(15);
+        private static readonly TimeSpan PresenceCacheTtl = TimeSpan.FromSeconds(5);
+        private static readonly TimeSpan BackgroundAgentRetryInterval = TimeSpan.FromMilliseconds(500);
+        private static readonly TimeSpan BackgroundAgentTransitionWindow = TimeSpan.FromSeconds(2);
         private IntPtr _lastForegroundHwnd;
         private int _lastForegroundPid;
         private string? _lastForegroundProcessName;
@@ -132,8 +135,14 @@ namespace TaskbarQuota.ActiveApp
         private int? _cliCacheSessionRootPid;
         private IntPtr _cliCacheFocusHwnd;
         private readonly Dictionary<IntPtr, ProviderId> _terminalWindowCliCache = new();
-        private bool _runningToolCache;
-        private DateTime _runningToolCacheAt = DateTime.MinValue;
+        private bool _guiPresenceCache;
+        private DateTime _guiPresenceCacheAt = DateTime.MinValue;
+        private bool _cliPresenceCache;
+        private DateTime _cliPresenceCacheAt = DateTime.MinValue;
+        private bool _backgroundAgentCache;
+        private DateTime _backgroundAgentCacheAt = DateTime.MinValue;
+        private DateTime _backgroundAgentRetryUntil = DateTime.MinValue;
+        private bool _codexDesktopWasForeground;
         private volatile bool _openCodeModelStateDirty;
         private volatile bool _clineStateDirty;
         private OpenCodeModelStateWatcher? _modelStateWatcher;
@@ -143,6 +152,7 @@ namespace TaskbarQuota.ActiveApp
         private ProviderSource _activeSource = ProviderSource.Unknown;
         private readonly SynaraUiaReader _synaraUia = new();
         private readonly BrowserActiveTabDetector _browserTabs = new();
+        private readonly CodexDesktopActivityDetector _codexDesktopActivity = new();
 
         /// <summary>Raised when Synara's localStorage changes (provider switch / thread navigation).</summary>
         public event Action? SynaraStateChanged;
@@ -454,7 +464,7 @@ namespace TaskbarQuota.ActiveApp
 
             if (terminalFocused)
             {
-                Diagnostics.Log.Debug($"[detect] terminal focused: fgPid={foregroundPid} proc={procName} rootPid={sessionRootPid} rootName={sessionRootName} title='{windowTitle}'");
+                Diagnostics.Log.Debug($"[detect] terminal focused: fgPid={foregroundPid} proc={procName} rootPid={sessionRootPid} rootName={sessionRootName}");
                 bool hasPreferred = _terminalWindowCliCache.TryGetValue(hwnd, out var preferredProvider);
                 _cliCache = DetectCliFromProcesses(
                     sessionRootPid,
@@ -470,6 +480,8 @@ namespace TaskbarQuota.ActiveApp
                 {
                     _terminalWindowCliCache[hwnd] = detectedCli;
                     _activeSource = ResolveCliSource(sessionRootName ?? procName);
+                    _cliPresenceCache = true;
+                    _cliPresenceCacheAt = DateTime.UtcNow;
                 }
                 return _lastForegroundResult = _cliCache;
             }
@@ -749,7 +761,8 @@ namespace TaskbarQuota.ActiveApp
 
             try
             {
-                DetectCliFromProcesses();
+                _cliPresenceCache = DetectCliFromProcesses() != null;
+                _cliPresenceCacheAt = DateTime.UtcNow;
             }
             catch (Exception ex)
             {
@@ -757,15 +770,58 @@ namespace TaskbarQuota.ActiveApp
             }
         }
 
-        public bool HasAnyKnownToolRunning()
+        public SupportedToolPresence GetSupportedToolPresence(bool codexDesktopForeground = false)
         {
-            if (DateTime.UtcNow - _runningToolCacheAt < RunningToolCacheTtl)
-                return _runningToolCache;
+            var now = DateTime.UtcNow;
+            if (now - _guiPresenceCacheAt >= PresenceCacheTtl)
+            {
+                _guiPresenceCache = HasAnyKnownGuiProcessRunning();
+                _guiPresenceCacheAt = now;
+            }
 
-            _runningToolCache = HasAnyKnownGuiProcessRunning() || DetectCliFromProcesses() != null;
-            _runningToolCacheAt = DateTime.UtcNow;
-            return _runningToolCache;
+            if (now - _cliPresenceCacheAt >= PresenceCacheTtl)
+            {
+                _cliPresenceCache = DetectCliFromProcesses() != null;
+                _cliPresenceCacheAt = now;
+            }
+
+            bool codexDesktopLostForeground = _codexDesktopWasForeground && !codexDesktopForeground;
+            _codexDesktopWasForeground = codexDesktopForeground;
+            if (ShouldRefreshBackgroundAgentPresence(
+                now,
+                _backgroundAgentCacheAt,
+                _backgroundAgentRetryUntil,
+                codexDesktopLostForeground))
+            {
+                bool previouslyRunning = _backgroundAgentCache;
+                _backgroundAgentCache = _codexDesktopActivity.HasRunningTurn();
+                _backgroundAgentCacheAt = now;
+                if (_backgroundAgentCache)
+                {
+                    _backgroundAgentRetryUntil = DateTime.MinValue;
+                }
+                else if (codexDesktopLostForeground || previouslyRunning)
+                {
+                    // UI Automation can briefly rebuild Codex's tree while its window loses focus or
+                    // closes. Retry only during that handoff; steady idle state retains the cheap 5 s
+                    // cache instead of scanning the accessibility tree twice per second forever.
+                    _backgroundAgentRetryUntil = now + BackgroundAgentTransitionWindow;
+                }
+            }
+
+            return new(_guiPresenceCache, _cliPresenceCache, _backgroundAgentCache);
         }
+
+        internal static bool ShouldRefreshBackgroundAgentPresence(
+            DateTime now,
+            DateTime cacheAt,
+            DateTime retryUntil,
+            bool codexDesktopLostForeground)
+            => codexDesktopLostForeground
+                || (now < retryUntil && now - cacheAt >= BackgroundAgentRetryInterval)
+                || now - cacheAt >= PresenceCacheTtl;
+
+        public bool HasAnyKnownToolRunning() => GetSupportedToolPresence().Any;
 
         private static bool HasAnyKnownGuiProcessRunning()
         {
@@ -826,8 +882,8 @@ namespace TaskbarQuota.ActiveApp
             ProviderId? preferredProvider = null)
         {
             // One cheap, name-only scan builds the process tree and resolves native CLI exes. Script-host
-            // CommandLines (node/bun/npm/...) are read separately and only for the focused session, so a
-            // terminal full of unrelated node.exe children no longer stalls detection.
+            // CommandLines (node/bun/npm/...) are read separately for the focused session, or conditionally
+            // by the lower-frequency global presence probe when native evidence is insufficient.
             var candidates = new List<(ProviderId id, DateTime started, int pid, int parentPid)>();
             var processParents = new Dictionary<int, int>();
             var processNames = new Dictionary<int, string>();
@@ -902,15 +958,81 @@ namespace TaskbarQuota.ActiveApp
 
                 return null;
             }
-            else if (candidates.Count == 0)
+            else
             {
-                // Presence probe with no native CLI found: fall back to inspecting every script host.
-                ResolveHostCommandLines(hostPids, processStarts, processParents, candidates);
+                // Presence probes avoid reading runtime command lines when a qualifying native CLI already
+                // exists. Desktop executables that share a CLI name do not suppress this fallback.
+                bool hasNativeCliPresence = candidates.Any(candidate => IsCliPresenceCandidate(
+                    candidate.pid,
+                    candidate.parentPid,
+                    processParents,
+                    processNames));
+                if (!hasNativeCliPresence)
+                    ResolveHostCommandLines(hostPids, processStarts, processParents, candidates);
             }
 
-            if (candidates.Count == 0) return null;
-            return PickForegroundCli(candidates, foregroundTerminalPid ?? -1, processParents);
+            var presenceCandidates = candidates
+                .Where(candidate => IsCliPresenceCandidate(
+                    candidate.pid,
+                    candidate.parentPid,
+                    processParents,
+                    processNames))
+                .ToList();
+
+            if (presenceCandidates.Count == 0) return null;
+            return PickForegroundCli(presenceCandidates, foregroundTerminalPid ?? -1, processParents);
         }
+
+        private static bool IsCliPresenceCandidate(
+            int pid,
+            int parentPid,
+            IReadOnlyDictionary<int, int> parents,
+            IReadOnlyDictionary<int, string> names)
+        {
+            names.TryGetValue(pid, out var processName);
+
+            // Script runtimes and executable names shared by a desktop app are not enough on their own:
+            // require a shell/terminal relationship so unrelated projects and Electron helpers do not
+            // become background CLI agents.
+            if (processName is not null
+                && (CmdLineHostExes.Contains(processName) || IsKnownGuiProcessName(processName)))
+            {
+                return HasTerminalRelationship(pid, parentPid, parents, names);
+            }
+
+            return true;
+        }
+
+        internal static bool HasTerminalRelationship(
+            int pid,
+            int parentPid,
+            IReadOnlyDictionary<int, int> parents,
+            IReadOnlyDictionary<int, string> names)
+        {
+            var seen = new HashSet<int>();
+            var current = pid;
+            var nextParent = parentPid;
+
+            while (current != 0 && seen.Add(current))
+            {
+                if (names.TryGetValue(current, out var name) && IsTerminalHostProcessName(name))
+                    return true;
+
+                if (nextParent == 0)
+                    break;
+
+                current = nextParent;
+                nextParent = parents.TryGetValue(current, out var ancestorParent) ? ancestorParent : 0;
+            }
+
+            return false;
+        }
+
+        private static bool IsTerminalHostProcessName(string? processName)
+            => processName is not null
+            && (Terminals.Contains(processName)
+                || IsConsoleHostName(processName)
+                || IsShellHostName(processName));
 
         internal static ProviderId PickForegroundCli(
             IReadOnlyList<(ProviderId id, DateTime started, int pid, int parentPid)> candidates,
@@ -1318,27 +1440,154 @@ namespace TaskbarQuota.ActiveApp
 
         internal static ProviderId? TryDetectCliProvider(string? processName, string? commandLine)
         {
-            var name = (processName ?? "").ToLowerInvariant();
-            if (name is "antigravity.exe" or "agy.exe") return ProviderId.Antigravity;
-            if (name is "claude.exe") return ProviderId.Claude;
-            if (name is "codex.exe") return ProviderId.Codex;
-            if (name is "cursor.exe") return ProviderId.Cursor;
-            if (name is "cursor-agent.exe") return ProviderId.Cursor;
-            if (name is "opencode.exe") return ProviderId.OpenCode;
-            if (name is "copilot.exe" or "gh.exe") return ProviderId.Copilot;
-            if (name is "grok.exe") return ProviderId.Grok;
-            if (name is "devin.exe") return ProviderId.Devin;
-            if (name is "cline.exe") return ProviderId.Cline;
-            if (name is "kimi.exe") return ProviderId.Kimi;
+            var name = NormalizeProcessName(processName ?? "").ToLowerInvariant();
+            if (name == "gh")
+                return ContainsCommandSequence(commandLine, "gh", "copilot")
+                    ? ProviderId.Copilot
+                    : null;
 
-            var haystack = ((commandLine ?? "") + " " + name).ToLowerInvariant();
-            foreach (var (marker, id) in CliMarkers)
+            if (name is "antigravity" or "agy") return ProviderId.Antigravity;
+            if (name == "claude") return ProviderId.Claude;
+            if (name == "codex") return ProviderId.Codex;
+            if (name == "cursor") return ProviderId.Cursor;
+            if (name == "cursor-agent") return ProviderId.Cursor;
+            if (name == "opencode") return ProviderId.OpenCode;
+            if (name == "copilot") return ProviderId.Copilot;
+            if (name == "grok") return ProviderId.Grok;
+            if (name == "devin") return ProviderId.Devin;
+            if (name == "cline") return ProviderId.Cline;
+            if (name == "kimi") return ProviderId.Kimi;
+
+            if (string.IsNullOrWhiteSpace(commandLine))
+                return null;
+
+            var normalized = commandLine.Replace('\\', '/').ToLowerInvariant();
+            if (normalized.Contains("@anthropic-ai/claude-code", StringComparison.Ordinal))
+                return ProviderId.Claude;
+            if (normalized.Contains("@openai/codex", StringComparison.Ordinal))
+                return ProviderId.Codex;
+            if (normalized.Contains("/cursor/resources/app/out/cli.js", StringComparison.Ordinal))
+                return ProviderId.Cursor;
+            if (normalized.Contains("/node_modules/opencode/", StringComparison.Ordinal))
+                return ProviderId.OpenCode;
+            if (normalized.Contains("@github/copilot", StringComparison.Ordinal))
+                return ProviderId.Copilot;
+            if (normalized.Contains("/.grok/bin/grok", StringComparison.Ordinal))
+                return ProviderId.Grok;
+            if (normalized.Contains("/node_modules/devin/", StringComparison.Ordinal))
+                return ProviderId.Devin;
+            if (normalized.Contains("/node_modules/cline/", StringComparison.Ordinal))
+                return ProviderId.Cline;
+            if (normalized.Contains("@moonshot-ai/kimi", StringComparison.Ordinal)
+                || normalized.Contains("/.kimi-code/bin/kimi", StringComparison.Ordinal))
+                return ProviderId.Kimi;
+            if (normalized.Contains("/agy/bin/agy", StringComparison.Ordinal)
+                || normalized.Contains("/antigravity/bin/antigravity", StringComparison.Ordinal))
+                return ProviderId.Antigravity;
+
+            if (name == "cmd" && TryResolveShellCommand(commandLine) is { } shellProvider)
+                return shellProvider;
+
+            return null;
+        }
+
+        private static ProviderId? TryResolveShellCommand(string commandLine)
+        {
+            var tokens = CommandTokens(commandLine);
+            for (var i = 0; i < tokens.Count - 1; i++)
             {
-                if (ContainsCliMarker(haystack, marker))
-                    return id;
+                if (tokens[i] is not ("/c" or "/k"))
+                    continue;
+
+                return CommandTokenName(tokens[i + 1]) switch
+                {
+                    "antigravity" or "agy" => ProviderId.Antigravity,
+                    "claude" => ProviderId.Claude,
+                    "codex" => ProviderId.Codex,
+                    "cursor" or "cursor-agent" => ProviderId.Cursor,
+                    "opencode" => ProviderId.OpenCode,
+                    "copilot" => ProviderId.Copilot,
+                    "grok" => ProviderId.Grok,
+                    "devin" => ProviderId.Devin,
+                    "cline" => ProviderId.Cline,
+                    "kimi" => ProviderId.Kimi,
+                    _ => null,
+                };
             }
 
             return null;
+        }
+
+        private static bool ContainsCommandSequence(string? commandLine, string command, string subcommand)
+        {
+            if (string.IsNullOrWhiteSpace(commandLine))
+                return false;
+
+            var tokens = CommandTokens(commandLine);
+            for (var i = 0; i < tokens.Count - 1; i++)
+            {
+                if (CommandTokenName(tokens[i]) == command
+                    && CommandTokenName(tokens[i + 1]) == subcommand)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static List<string> CommandTokens(string commandLine)
+        {
+            var tokens = new List<string>();
+            var current = new StringBuilder();
+            char quote = '\0';
+
+            foreach (char character in commandLine)
+            {
+                if (character is '"' or '\'')
+                {
+                    if (quote == '\0')
+                    {
+                        quote = character;
+                        continue;
+                    }
+                    if (quote == character)
+                    {
+                        quote = '\0';
+                        continue;
+                    }
+                }
+
+                if (char.IsWhiteSpace(character) && quote == '\0')
+                {
+                    if (current.Length > 0)
+                    {
+                        tokens.Add(current.ToString().ToLowerInvariant());
+                        current.Clear();
+                    }
+                    continue;
+                }
+
+                current.Append(character);
+            }
+
+            if (current.Length > 0)
+                tokens.Add(current.ToString().ToLowerInvariant());
+            return tokens;
+        }
+
+        private static string CommandTokenName(string token)
+        {
+            var normalized = token.Replace('\\', '/').TrimEnd('/');
+            var slash = normalized.LastIndexOf('/');
+            var name = slash >= 0 ? normalized[(slash + 1)..] : normalized;
+            foreach (var extension in new[] { ".exe", ".cmd", ".bat" })
+            {
+                if (name.EndsWith(extension, StringComparison.Ordinal))
+                    return name[..^extension.Length];
+            }
+
+            return name;
         }
 
         private static bool ContainsCliMarker(string haystack, string marker)
@@ -1655,5 +1904,13 @@ namespace TaskbarQuota.ActiveApp
             }
             catch { return false; }
         }
+    }
+
+    public readonly record struct SupportedToolPresence(
+        bool DesktopAppPresent,
+        bool CliAgentPresent,
+        bool BackgroundAgentRunning = false)
+    {
+        public bool Any => DesktopAppPresent || CliAgentPresent;
     }
 }

--- a/src/TaskbarQuota.App/ActiveApp/ActiveAppDetector.cs
+++ b/src/TaskbarQuota.App/ActiveApp/ActiveAppDetector.cs
@@ -135,13 +135,20 @@ namespace TaskbarQuota.ActiveApp
         private int? _cliCacheSessionRootPid;
         private IntPtr _cliCacheFocusHwnd;
         private readonly Dictionary<IntPtr, ProviderId> _terminalWindowCliCache = new();
+        private readonly object _presenceGate = new();
         private bool _guiPresenceCache;
         private DateTime _guiPresenceCacheAt = DateTime.MinValue;
+        private bool _guiPresenceRefreshInProgress;
         private bool _cliPresenceCache;
         private DateTime _cliPresenceCacheAt = DateTime.MinValue;
+        private bool _cliPresenceRefreshInProgress;
+        private long _cliPresenceProbeVersion;
+        private int _globalCliPresenceProbeInFlight;
+        private int _globalCliPresenceProbeRequested;
         private bool _backgroundAgentCache;
         private DateTime _backgroundAgentCacheAt = DateTime.MinValue;
         private DateTime _backgroundAgentRetryUntil = DateTime.MinValue;
+        private bool _backgroundAgentRefreshInProgress;
         private bool _codexDesktopWasForeground;
         private volatile bool _openCodeModelStateDirty;
         private volatile bool _clineStateDirty;
@@ -446,7 +453,7 @@ namespace TaskbarQuota.ActiveApp
 
             // Normal browser chat surfaces have their own account-level usage semantics and should not be
             // folded into coding-client providers like Codex or Antigravity.
-            if (_browserTabs.Detect(hwnd, procName, windowTitle) is { } browserProvider)
+            if (_browserTabs.Detect(hwnd, procName) is { } browserProvider)
             {
                 _activeSource = browserProvider.Source;
                 return _lastForegroundResult = browserProvider.Provider;
@@ -480,8 +487,7 @@ namespace TaskbarQuota.ActiveApp
                 {
                     _terminalWindowCliCache[hwnd] = detectedCli;
                     _activeSource = ResolveCliSource(sessionRootName ?? procName);
-                    _cliPresenceCache = true;
-                    _cliPresenceCacheAt = DateTime.UtcNow;
+                    RecordCliPresence();
                 }
                 return _lastForegroundResult = _cliCache;
             }
@@ -761,8 +767,8 @@ namespace TaskbarQuota.ActiveApp
 
             try
             {
-                _cliPresenceCache = DetectCliFromProcesses() != null;
-                _cliPresenceCacheAt = DateTime.UtcNow;
+                long version = BeginCliPresenceProbe();
+                CompleteCliPresenceProbe(version, DetectCliFromProcesses() != null);
             }
             catch (Exception ex)
             {
@@ -773,44 +779,166 @@ namespace TaskbarQuota.ActiveApp
         public SupportedToolPresence GetSupportedToolPresence(bool codexDesktopForeground = false)
         {
             var now = DateTime.UtcNow;
-            if (now - _guiPresenceCacheAt >= PresenceCacheTtl)
-            {
-                _guiPresenceCache = HasAnyKnownGuiProcessRunning();
-                _guiPresenceCacheAt = now;
-            }
+            bool refreshGui;
+            bool refreshCli;
+            bool refreshBackgroundAgent;
+            bool codexDesktopLostForeground;
+            bool backgroundAgentWasRunning;
+            long cliProbeVersion = 0;
 
-            if (now - _cliPresenceCacheAt >= PresenceCacheTtl)
+            lock (_presenceGate)
             {
-                _cliPresenceCache = DetectCliFromProcesses() != null;
-                _cliPresenceCacheAt = now;
-            }
+                refreshGui = !_guiPresenceRefreshInProgress
+                    && now - _guiPresenceCacheAt >= PresenceCacheTtl;
+                if (refreshGui)
+                    _guiPresenceRefreshInProgress = true;
 
-            bool codexDesktopLostForeground = _codexDesktopWasForeground && !codexDesktopForeground;
-            _codexDesktopWasForeground = codexDesktopForeground;
-            if (ShouldRefreshBackgroundAgentPresence(
-                now,
-                _backgroundAgentCacheAt,
-                _backgroundAgentRetryUntil,
-                codexDesktopLostForeground))
-            {
-                bool previouslyRunning = _backgroundAgentCache;
-                _backgroundAgentCache = _codexDesktopActivity.HasRunningTurn();
-                _backgroundAgentCacheAt = now;
-                if (_backgroundAgentCache)
+                refreshCli = !_cliPresenceRefreshInProgress
+                    && now - _cliPresenceCacheAt >= PresenceCacheTtl;
+                if (refreshCli)
                 {
-                    _backgroundAgentRetryUntil = DateTime.MinValue;
+                    _cliPresenceRefreshInProgress = true;
+                    cliProbeVersion = ++_cliPresenceProbeVersion;
                 }
-                else if (codexDesktopLostForeground || previouslyRunning)
+
+                codexDesktopLostForeground = _codexDesktopWasForeground && !codexDesktopForeground;
+                _codexDesktopWasForeground = codexDesktopForeground;
+                refreshBackgroundAgent = !_backgroundAgentRefreshInProgress
+                    && ShouldRefreshBackgroundAgentPresence(
+                        now,
+                        _backgroundAgentCacheAt,
+                        _backgroundAgentRetryUntil,
+                        codexDesktopLostForeground);
+                backgroundAgentWasRunning = _backgroundAgentCache;
+                if (refreshBackgroundAgent)
                 {
-                    // UI Automation can briefly rebuild Codex's tree while its window loses focus or
-                    // closes. Retry only during that handoff; steady idle state retains the cheap 5 s
-                    // cache instead of scanning the accessibility tree twice per second forever.
+                    _backgroundAgentRefreshInProgress = true;
+                }
+                else if (codexDesktopLostForeground)
+                {
+                    // Preserve the transition retry even if another tick already owns the current UIA scan.
                     _backgroundAgentRetryUntil = now + BackgroundAgentTransitionWindow;
                 }
             }
 
-            return new(_guiPresenceCache, _cliPresenceCache, _backgroundAgentCache);
+            if (refreshGui)
+            {
+                bool guiPresent = HasAnyKnownGuiProcessRunning();
+                lock (_presenceGate)
+                {
+                    _guiPresenceCache = guiPresent;
+                    _guiPresenceCacheAt = DateTime.UtcNow;
+                    _guiPresenceRefreshInProgress = false;
+                }
+            }
+
+            if (refreshCli)
+            {
+                // Keep the periodic path to one bulk name/process-tree snapshot. Script-host command lines
+                // are resolved by the separately throttled background probe below.
+                bool cliPresent = DetectCliFromProcesses(resolveGlobalHostCommandLines: false) != null;
+                CompleteCliPresenceProbe(cliProbeVersion, cliPresent);
+                lock (_presenceGate)
+                    _cliPresenceRefreshInProgress = false;
+
+                if (!cliPresent)
+                    QueueGlobalCliPresenceProbe();
+            }
+
+            if (refreshBackgroundAgent)
+            {
+                bool backgroundAgentPresent = _codexDesktopActivity.HasRunningTurn();
+                var completedAt = DateTime.UtcNow;
+                lock (_presenceGate)
+                {
+                    _backgroundAgentCache = backgroundAgentPresent;
+                    _backgroundAgentCacheAt = completedAt;
+                    _backgroundAgentRefreshInProgress = false;
+                    if (backgroundAgentPresent)
+                    {
+                        _backgroundAgentRetryUntil = DateTime.MinValue;
+                    }
+                    else if (codexDesktopLostForeground || backgroundAgentWasRunning)
+                    {
+                        // UI Automation can briefly rebuild Codex's tree while its window loses focus or
+                        // closes. Retry only during that handoff; steady idle state retains the cheap 5 s
+                        // cache instead of scanning the accessibility tree twice per second forever.
+                        _backgroundAgentRetryUntil = completedAt + BackgroundAgentTransitionWindow;
+                    }
+                }
+            }
+
+            lock (_presenceGate)
+                return new(_guiPresenceCache, _cliPresenceCache, _backgroundAgentCache);
         }
+
+        private long BeginCliPresenceProbe()
+        {
+            lock (_presenceGate)
+                return ++_cliPresenceProbeVersion;
+        }
+
+        private void CompleteCliPresenceProbe(long version, bool present)
+        {
+            lock (_presenceGate)
+            {
+                if (!IsCurrentCliPresenceProbeResult(_cliPresenceProbeVersion, version))
+                    return;
+
+                _cliPresenceCache = present;
+                _cliPresenceCacheAt = DateTime.UtcNow;
+            }
+        }
+
+        private void RecordCliPresence()
+        {
+            lock (_presenceGate)
+            {
+                _cliPresenceProbeVersion++;
+                _cliPresenceCache = true;
+                _cliPresenceCacheAt = DateTime.UtcNow;
+            }
+        }
+
+        private void QueueGlobalCliPresenceProbe()
+        {
+            System.Threading.Interlocked.Exchange(ref _globalCliPresenceProbeRequested, 1);
+            if (!TryBeginSingleProbe(ref _globalCliPresenceProbeInFlight))
+                return;
+
+            _ = System.Threading.Tasks.Task.Run(() =>
+            {
+                try
+                {
+                    while (System.Threading.Interlocked.Exchange(
+                               ref _globalCliPresenceProbeRequested,
+                               0) != 0)
+                    {
+                        long version = BeginCliPresenceProbe();
+                        CompleteCliPresenceProbe(version, DetectCliFromProcesses() != null);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Diagnostics.Log.Warning(ex, "Background CLI presence probe failed");
+                }
+                finally
+                {
+                    System.Threading.Interlocked.Exchange(ref _globalCliPresenceProbeInFlight, 0);
+                    if (System.Threading.Volatile.Read(ref _globalCliPresenceProbeRequested) != 0)
+                        QueueGlobalCliPresenceProbe();
+                }
+            });
+        }
+
+        internal static bool IsCurrentCliPresenceProbeResult(
+            long currentVersion,
+            long completedVersion)
+            // A completed process snapshot must not overwrite newer native or foreground evidence.
+            => currentVersion == completedVersion;
+
+        internal static bool TryBeginSingleProbe(ref int inFlight)
+            => System.Threading.Interlocked.CompareExchange(ref inFlight, 1, 0) == 0;
 
         internal static bool ShouldRefreshBackgroundAgentPresence(
             DateTime now,
@@ -879,7 +1007,8 @@ namespace TaskbarQuota.ActiveApp
             int? foregroundTerminalPid = null,
             string? foregroundProcName = null,
             string? windowTitleHint = null,
-            ProviderId? preferredProvider = null)
+            ProviderId? preferredProvider = null,
+            bool resolveGlobalHostCommandLines = true)
         {
             // One cheap, name-only scan builds the process tree and resolves native CLI exes. Script-host
             // CommandLines (node/bun/npm/...) are read separately for the focused session, or conditionally
@@ -967,7 +1096,7 @@ namespace TaskbarQuota.ActiveApp
                     candidate.parentPid,
                     processParents,
                     processNames));
-                if (!hasNativeCliPresence)
+                if (!hasNativeCliPresence && resolveGlobalHostCommandLines)
                     ResolveHostCommandLines(hostPids, processStarts, processParents, candidates);
             }
 

--- a/src/TaskbarQuota.App/ActiveApp/BrowserActiveTabDetector.cs
+++ b/src/TaskbarQuota.App/ActiveApp/BrowserActiveTabDetector.cs
@@ -33,6 +33,8 @@ namespace TaskbarQuota.ActiveApp
 
         private static readonly TimeSpan CacheTtl = TimeSpan.FromMilliseconds(350);
 
+        private readonly object _cacheGate = new();
+        private readonly object _automationGate = new();
         private IUIAutomation? _automation;
         private IntPtr _cachedHwnd;
         private ProviderId? _cachedProvider;
@@ -50,7 +52,9 @@ namespace TaskbarQuota.ActiveApp
             if (!IsBrowserProcessName(processName))
                 return null;
 
-            var provider = DetectActiveProvider(hwnd);
+            var provider = DetectActiveProvider(hwnd)
+                ?? TryResolveProviderFromUrl(
+                    FirefoxSessionStoreReader.TryReadSelectedTabUrl(processName));
 
             return provider is { } p
                 ? new BrowserProviderDetection(p, ResolveBrowserSource(processName))
@@ -62,16 +66,22 @@ namespace TaskbarQuota.ActiveApp
             if (hwnd == IntPtr.Zero)
                 return null;
 
-            var now = DateTime.UtcNow;
-            if (hwnd == _cachedHwnd && now - _cachedAtUtc < CacheTtl)
-                return _cachedProvider;
+            lock (_cacheGate)
+            {
+                var now = DateTime.UtcNow;
+                if (hwnd == _cachedHwnd && now - _cachedAtUtc < CacheTtl)
+                    return _cachedProvider;
+            }
 
             // Cache only the provider classification. URLs may contain private paths, conversation IDs,
             // or query text and are not needed after the active-tab decision has been made.
             var provider = TryResolveProviderFromUrl(TryReadActiveTabUrlCore(hwnd));
-            _cachedHwnd = hwnd;
-            _cachedProvider = provider;
-            _cachedAtUtc = now;
+            lock (_cacheGate)
+            {
+                _cachedHwnd = hwnd;
+                _cachedProvider = provider;
+                _cachedAtUtc = DateTime.UtcNow;
+            }
             return provider;
         }
 
@@ -119,22 +129,25 @@ namespace TaskbarQuota.ActiveApp
 
         private string? TryReadActiveTabUrlCore(IntPtr hwnd)
         {
-            try
+            lock (_automationGate)
             {
-                _automation ??= new CUIAutomation();
-                var root = _automation.ElementFromHandle(hwnd);
-                if (root is null)
-                    return null;
+                try
+                {
+                    _automation ??= new CUIAutomation();
+                    var root = _automation.ElementFromHandle(hwnd);
+                    if (root is null)
+                        return null;
 
-                if (TryFindUrlInEdits(root) is { } editUrl)
-                    return editUrl;
-            }
-            catch (Exception ex)
-            {
-                Diagnostics.Log.Debug($"[browser] URL UIA read failed: {ex.Message}");
-            }
+                    if (TryFindUrlInEdits(root) is { } editUrl)
+                        return editUrl;
+                }
+                catch (Exception ex)
+                {
+                    Diagnostics.Log.Debug($"[browser] URL UIA read failed: {ex.Message}");
+                }
 
-            return null;
+                return null;
+            }
         }
 
         private string? TryFindUrlInEdits(IUIAutomationElement root)

--- a/src/TaskbarQuota.App/ActiveApp/BrowserActiveTabDetector.cs
+++ b/src/TaskbarQuota.App/ActiveApp/BrowserActiveTabDetector.cs
@@ -35,7 +35,7 @@ namespace TaskbarQuota.ActiveApp
 
         private IUIAutomation? _automation;
         private IntPtr _cachedHwnd;
-        private string? _cachedUrl;
+        private ProviderId? _cachedProvider;
         private DateTime _cachedAtUtc = DateTime.MinValue;
 
         internal static bool IsBrowserProcessName(string? processName)
@@ -50,30 +50,29 @@ namespace TaskbarQuota.ActiveApp
             if (!IsBrowserProcessName(processName))
                 return null;
 
-            var url = TryReadActiveTabUrl(hwnd);
-            var provider = TryResolveProviderFromUrl(url)
-                ?? TryResolveProviderFromUrl(FirefoxSessionStoreReader.TryReadSelectedTabUrl(processName))
-                ?? TryResolveProviderFromTitle(windowTitle);
+            var provider = DetectActiveProvider(hwnd);
 
             return provider is { } p
                 ? new BrowserProviderDetection(p, ResolveBrowserSource(processName))
                 : null;
         }
 
-        internal string? TryReadActiveTabUrl(IntPtr hwnd)
+        private ProviderId? DetectActiveProvider(IntPtr hwnd)
         {
             if (hwnd == IntPtr.Zero)
                 return null;
 
             var now = DateTime.UtcNow;
             if (hwnd == _cachedHwnd && now - _cachedAtUtc < CacheTtl)
-                return _cachedUrl;
+                return _cachedProvider;
 
-            var url = TryReadActiveTabUrlCore(hwnd);
+            // Cache only the provider classification. URLs may contain private paths, conversation IDs,
+            // or query text and are not needed after the active-tab decision has been made.
+            var provider = TryResolveProviderFromUrl(TryReadActiveTabUrlCore(hwnd));
             _cachedHwnd = hwnd;
-            _cachedUrl = url;
+            _cachedProvider = provider;
             _cachedAtUtc = now;
-            return url;
+            return provider;
         }
 
         internal static ProviderId? TryResolveProviderFromUrl(string? rawUrl)
@@ -96,16 +95,7 @@ namespace TaskbarQuota.ActiveApp
         }
 
         internal static ProviderId? TryResolveProviderFromTitle(string? windowTitle)
-        {
-            if (string.IsNullOrWhiteSpace(windowTitle))
-                return null;
-
-            var title = windowTitle.ToLowerInvariant();
-            if (title.Contains("claude", StringComparison.Ordinal))
-                return ProviderId.Claude;
-
-            return null;
-        }
+            => null;
 
         internal static ProviderSource ResolveBrowserSource(string? processName)
         {

--- a/src/TaskbarQuota.App/ActiveApp/BrowserActiveTabDetector.cs
+++ b/src/TaskbarQuota.App/ActiveApp/BrowserActiveTabDetector.cs
@@ -42,10 +42,10 @@ namespace TaskbarQuota.ActiveApp
             => !string.IsNullOrWhiteSpace(processName)
             && BrowserProcesses.Contains(NormalizeProcessName(processName));
 
-        internal ProviderId? DetectProvider(IntPtr hwnd, string? processName, string? windowTitle = null)
-            => Detect(hwnd, processName, windowTitle)?.Provider;
+        internal ProviderId? DetectProvider(IntPtr hwnd, string? processName)
+            => Detect(hwnd, processName)?.Provider;
 
-        internal BrowserProviderDetection? Detect(IntPtr hwnd, string? processName, string? windowTitle = null)
+        internal BrowserProviderDetection? Detect(IntPtr hwnd, string? processName)
         {
             if (!IsBrowserProcessName(processName))
                 return null;
@@ -94,8 +94,8 @@ namespace TaskbarQuota.ActiveApp
             return null;
         }
 
-        internal static ProviderId? TryResolveProviderFromTitle(string? windowTitle)
-            => null;
+        // Window titles can contain private prompt/project text and are intentionally never used as
+        // provider evidence. Only the foreground browser's active address-bar URL is classified.
 
         internal static ProviderSource ResolveBrowserSource(string? processName)
         {

--- a/src/TaskbarQuota.App/ActiveApp/CodexDesktopActivityDetector.cs
+++ b/src/TaskbarQuota.App/ActiveApp/CodexDesktopActivityDetector.cs
@@ -25,14 +25,19 @@ namespace TaskbarQuota.ActiveApp
         private const string RunningStatusLayoutClassToken = "shrink-0";
         private const string CompletedStatusClassToken = "no-drag";
         private const string ComposerButtonClassToken = "size-token-button-composer";
+        private static readonly TimeSpan FailureLogInterval = TimeSpan.FromMinutes(1);
 
         private IUIAutomation? _automation;
+        private readonly object _failureLogGate = new();
+        private DateTime _lastFailureLogAtUtc = DateTime.MinValue;
 
         internal bool HasRunningTurn()
         {
+            int candidateCount = 0;
             try
             {
                 var processIds = GetCandidateProcessIds();
+                candidateCount = processIds.Count;
                 if (processIds.Count == 0)
                     return false;
 
@@ -52,11 +57,27 @@ namespace TaskbarQuota.ActiveApp
                 }, IntPtr.Zero);
                 return running;
             }
-            catch
+            catch (Exception ex)
             {
+                bool shouldLog;
+                var now = DateTime.UtcNow;
+                lock (_failureLogGate)
+                {
+                    shouldLog = ShouldLogProbeFailure(now, _lastFailureLogAtUtc);
+                    if (shouldLog)
+                        _lastFailureLogAtUtc = now;
+                }
+                if (shouldLog)
+                {
+                    Diagnostics.Log.Debug(
+                        $"[codex-activity] running-turn probe failed candidates={candidateCount}: {ex.Message}");
+                }
                 return false;
             }
         }
+
+        internal static bool ShouldLogProbeFailure(DateTime now, DateTime lastLoggedAt)
+            => now - lastLoggedAt >= FailureLogInterval;
 
         private bool WindowHasRunningTurn(IntPtr hwnd)
         {

--- a/src/TaskbarQuota.App/ActiveApp/CodexDesktopActivityDetector.cs
+++ b/src/TaskbarQuota.App/ActiveApp/CodexDesktopActivityDetector.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using global::Interop.UIAutomationClient;
+using static TaskbarQuota.Interop.User32;
+
+namespace TaskbarQuota.ActiveApp
+{
+    /// <summary>
+    /// Detects a running Codex Desktop turn from the app's accessibility tree. The long-lived
+    /// <c>codex.exe app-server</c> process is deliberately not enough: it remains present while the
+    /// application is idle. Codex exposes a Stop button for the selected running turn and a distinct
+    /// status glyph in every background task row that is still running.
+    ///
+    /// Only control names and CSS class tokens needed to identify those controls are read. Thread
+    /// titles, prompts, responses and command text are never collected.
+    /// </summary>
+    internal sealed class CodexDesktopActivityDetector
+    {
+        private const string CodexDocumentName = "Codex";
+        private const string RootDocumentAutomationId = "RootWebArea";
+        private const string TaskRowClassToken = "cursor-grab";
+        private const string TaskRowDraggingClassToken = "active:cursor-grabbing";
+        private const string RunningStatusSizeClassToken = "icon-xs";
+        private const string RunningStatusLayoutClassToken = "shrink-0";
+        private const string CompletedStatusClassToken = "no-drag";
+        private const string ComposerButtonClassToken = "size-token-button-composer";
+
+        private IUIAutomation? _automation;
+
+        internal bool HasRunningTurn()
+        {
+            try
+            {
+                var processIds = GetCandidateProcessIds();
+                if (processIds.Count == 0)
+                    return false;
+
+                _automation ??= new CUIAutomation();
+                bool running = false;
+                EnumWindows((hwnd, _) =>
+                {
+                    GetWindowThreadProcessId(hwnd, out uint processId);
+                    if (!processIds.Contains(processId))
+                        return true;
+
+                    if (!WindowHasRunningTurn(hwnd))
+                        return true;
+
+                    running = true;
+                    return false;
+                }, IntPtr.Zero);
+                return running;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private bool WindowHasRunningTurn(IntPtr hwnd)
+        {
+            var automation = _automation;
+            if (automation is null)
+                return false;
+
+            IUIAutomationElement root;
+            try { root = automation.ElementFromHandle(hwnd); }
+            catch { return false; }
+            if (root is null)
+                return false;
+
+            IUIAutomationElement? document;
+            try
+            {
+                var rootDocumentCondition = automation.CreatePropertyCondition(
+                    UIA_PropertyIds.UIA_AutomationIdPropertyId,
+                    RootDocumentAutomationId);
+                document = root.FindFirst(TreeScope.TreeScope_Descendants, rootDocumentCondition);
+            }
+            catch
+            {
+                return false;
+            }
+
+            if (document is null)
+                return false;
+
+            try
+            {
+                if (document.CurrentControlType != UIA_ControlTypeIds.UIA_DocumentControlTypeId
+                    || !string.Equals(document.CurrentName, CodexDocumentName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+
+            IUIAutomationElementArray buttons;
+            try
+            {
+                var buttonCondition = automation.CreatePropertyCondition(
+                    UIA_PropertyIds.UIA_ControlTypePropertyId,
+                    UIA_ControlTypeIds.UIA_ButtonControlTypeId);
+                buttons = document.FindAll(TreeScope.TreeScope_Descendants, buttonCondition);
+            }
+            catch
+            {
+                return false;
+            }
+            if (buttons is null)
+                return false;
+
+            int count;
+            try { count = buttons.Length; }
+            catch { return false; }
+
+            for (int index = 0; index < count; index++)
+            {
+                IUIAutomationElement button;
+                try { button = buttons.GetElement(index); }
+                catch { continue; }
+                if (button is null)
+                    continue;
+
+                string? name;
+                string? className;
+                try
+                {
+                    name = button.CurrentName;
+                    className = button.CurrentClassName;
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (IsRunningComposerButton(name, className))
+                    return true;
+
+                if (IsTaskRowClass(className) && TaskRowHasRunningStatus(button, automation))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool TaskRowHasRunningStatus(
+            IUIAutomationElement taskRow,
+            IUIAutomation automation)
+        {
+            IUIAutomationElementArray images;
+            try
+            {
+                var imageCondition = automation.CreatePropertyCondition(
+                    UIA_PropertyIds.UIA_ControlTypePropertyId,
+                    UIA_ControlTypeIds.UIA_ImageControlTypeId);
+                images = taskRow.FindAll(TreeScope.TreeScope_Descendants, imageCondition);
+            }
+            catch
+            {
+                return false;
+            }
+            if (images is null)
+                return false;
+
+            int count;
+            try { count = images.Length; }
+            catch { return false; }
+
+            for (int index = 0; index < count; index++)
+            {
+                try
+                {
+                    var image = images.GetElement(index);
+                    if (image is not null && IsRunningTaskStatusClass(image.CurrentClassName))
+                        return true;
+                }
+                catch
+                {
+                }
+            }
+
+            return false;
+        }
+
+        private static HashSet<uint> GetCandidateProcessIds()
+        {
+            var result = new HashSet<uint>();
+            foreach (var processName in new[] { "ChatGPT", "Codex" })
+            {
+                Process[] processes;
+                try { processes = Process.GetProcessesByName(processName); }
+                catch { continue; }
+
+                foreach (var process in processes)
+                {
+                    using (process)
+                    {
+                        try { result.Add((uint)process.Id); }
+                        catch
+                        {
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        internal static bool IsTaskRowClass(string? className)
+            => HasClassToken(className, TaskRowClassToken)
+                && HasClassToken(className, TaskRowDraggingClassToken);
+
+        internal static bool IsRunningTaskStatusClass(string? className)
+            => HasClassToken(className, RunningStatusSizeClassToken)
+                && HasClassToken(className, RunningStatusLayoutClassToken)
+                && !HasClassToken(className, CompletedStatusClassToken);
+
+        internal static bool IsRunningComposerButton(string? name, string? className)
+        {
+            if (!HasClassToken(className, ComposerButtonClassToken)
+                || string.IsNullOrWhiteSpace(name))
+            {
+                return false;
+            }
+
+            string normalized = name.Trim().ToLowerInvariant();
+            return normalized is "stop" or "detener" or "interrupt" or "interrumpir"
+                || normalized.StartsWith("stop ", StringComparison.Ordinal)
+                || normalized.StartsWith("detener ", StringComparison.Ordinal);
+        }
+
+        private static bool HasClassToken(string? className, string token)
+        {
+            if (string.IsNullOrWhiteSpace(className))
+                return false;
+
+            foreach (string candidate in className.Split(
+                (char[]?)null,
+                StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (candidate.Equals(token, StringComparison.Ordinal))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -75,6 +75,7 @@ namespace TaskbarQuota.Controls
         private ProviderId? _lastAppliedProvider;
         private string? _lastRenderSignature;
         private string? _lastSourceSignature;
+        private Func<ProviderSource, string>? _tooltipBuilder;
         private bool _hasRevealed;
         private bool _isActiveToolVisible = true;
         // Storyboards and their animations are allocated on first use and re-aimed afterwards; all three
@@ -181,6 +182,7 @@ namespace TaskbarQuota.Controls
                 {
                     _lastSourceSignature = sourceSignature;
                     ApplySourceBadge(result);
+                    RefreshTileTooltip(result.Source);
                 }
                 return;
             }
@@ -226,7 +228,9 @@ namespace TaskbarQuota.Controls
                 };
                 RenderRows();
                 AnimateRender(isFirstReveal, providerSwitch: providerChanged);
-                ToolTipService.SetToolTip(this, $"{widgetName}: {result.Error ?? "Loading..."}");
+                SetTileTooltip(
+                    result.Source,
+                    source => $"{WidgetTooltipTitle(widgetName, source)}: {result.Error ?? "Loading..."}");
                 return;
             }
 
@@ -238,8 +242,9 @@ namespace TaskbarQuota.Controls
                     _rows = new() { new WidgetUsageRow("Login", 0, "required", HasBar: false) };
                     RenderRows();
                     AnimateRender(isFirstReveal, providerSwitch: providerChanged);
-                    var loginSourceText = result.Source.IsKnown ? $" {result.Source.ShortViaText}" : "";
-                    ToolTipService.SetToolTip(this, $"{widgetName}{loginSourceText}: Login required — open the app to connect.");
+                    SetTileTooltip(
+                        result.Source,
+                        source => $"{WidgetTooltipTitle(widgetName, source)}: Login required — open the app to connect.");
                     return;
                 }
 
@@ -250,8 +255,9 @@ namespace TaskbarQuota.Controls
                 };
                 RenderRows();
                 AnimateRender(isFirstReveal, providerSwitch: providerChanged);
-                var sourceText = result.Source.IsKnown ? $" {result.Source.ShortViaText}" : "";
-                ToolTipService.SetToolTip(this, $"{widgetName}{sourceText}: {result.Error ?? "Unavailable"}");
+                SetTileTooltip(
+                    result.Source,
+                    source => $"{WidgetTooltipTitle(widgetName, source)}: {result.Error ?? "Unavailable"}");
                 return;
             }
 
@@ -292,10 +298,12 @@ namespace TaskbarQuota.Controls
             var costTooltip = WidgetCostTooltipLine(result.Id, usage.Cost);
             var resetCreditsTooltip = WidgetResetCreditsTooltipLine(usage.ResetCredits);
             var staleTooltip = StaleTooltipLine(result);
-            ToolTipService.SetToolTip(this,
-                string.IsNullOrEmpty(plan)
-                    ? $"{WidgetTooltipTitle(widgetName, result.Source)}\n{string.Join("\n", tooltipLines)}{costTooltip}{resetCreditsTooltip}{staleTooltip}"
-                    : $"{WidgetTooltipTitle(widgetName, result.Source)} · {plan}\n{string.Join("\n", tooltipLines)}{costTooltip}{resetCreditsTooltip}{staleTooltip}");
+            var tooltipBody = string.Join("\n", tooltipLines);
+            SetTileTooltip(
+                result.Source,
+                source => string.IsNullOrEmpty(plan)
+                    ? $"{WidgetTooltipTitle(widgetName, source)}\n{tooltipBody}{costTooltip}{resetCreditsTooltip}{staleTooltip}"
+                    : $"{WidgetTooltipTitle(widgetName, source)} · {plan}\n{tooltipBody}{costTooltip}{resetCreditsTooltip}{staleTooltip}");
         }
 
         /// <summary>
@@ -361,6 +369,25 @@ namespace TaskbarQuota.Controls
 
         private static string WidgetTooltipTitle(string widgetName, ProviderSource source)
             => source.IsKnown ? $"{widgetName} {source.ShortViaText}" : widgetName;
+
+        private void SetTileTooltip(
+            ProviderSource source,
+            Func<ProviderSource, string> builder)
+        {
+            _tooltipBuilder = builder;
+            RefreshTileTooltip(source);
+        }
+
+        private void RefreshTileTooltip(ProviderSource source)
+        {
+            if (_tooltipBuilder is { } builder)
+                ToolTipService.SetToolTip(this, BuildTooltipForSource(builder, source));
+        }
+
+        internal static string BuildTooltipForSource(
+            Func<ProviderSource, string> builder,
+            ProviderSource source)
+            => builder(source);
 
         public void SetActiveToolVisible(bool isVisible)
         {
@@ -625,11 +652,13 @@ namespace TaskbarQuota.Controls
             RenderRows();
             AnimateRender(!_hasRevealed, providerSwitch: providerChanged);
 
-            ToolTipService.SetToolTip(this,
-                $"{WidgetTooltipTitle(result.DisplayName, result.Source)} · {usage.LoginMethod}\n" +
-                $"Usage: {usage.Cost?.Display ?? "--"}\n" +
-                $"Balance: {(balanceText != null ? "$" + balanceText.Split(' ')[0] : "--")}" +
-                StaleTooltipLine(result));
+            SetTileTooltip(
+                result.Source,
+                source =>
+                    $"{WidgetTooltipTitle(result.DisplayName, source)} · {usage.LoginMethod}\n" +
+                    $"Usage: {usage.Cost?.Display ?? "--"}\n" +
+                    $"Balance: {(balanceText != null ? "$" + balanceText.Split(' ')[0] : "--")}" +
+                    StaleTooltipLine(result));
         }
 
         /// <summary>
@@ -648,10 +677,12 @@ namespace TaskbarQuota.Controls
             RenderRows();
             AnimateRender(!_hasRevealed, providerSwitch: providerChanged);
 
-            ToolTipService.SetToolTip(this,
-                $"{WidgetTooltipTitle(result.DisplayName, result.Source)} · {usage.LoginMethod}\n" +
-                $"Credit balance: {usage.Cost?.Display ?? "--"}" +
-                StaleTooltipLine(result));
+            SetTileTooltip(
+                result.Source,
+                source =>
+                    $"{WidgetTooltipTitle(result.DisplayName, source)} · {usage.LoginMethod}\n" +
+                    $"Credit balance: {usage.Cost?.Display ?? "--"}" +
+                    StaleTooltipLine(result));
         }
 
         private void ApplyCreditsDisplay(UsageResult result, UsageSnapshot usage, CostSnapshot credits, bool providerChanged = false)
@@ -697,15 +728,19 @@ namespace TaskbarQuota.Controls
             AnimateRender(!_hasRevealed, providerSwitch: providerChanged);
 
             var plan = FormatPlanLabel(result.Id, widgetName, usage.LoginMethod);
-            var tooltip = string.IsNullOrEmpty(plan)
-                ? $"{WidgetTooltipTitle(widgetName, result.Source)}\nCredits: {value} ({FormatCreditCount(remaining)} remaining)"
-                : $"{WidgetTooltipTitle(widgetName, result.Source)} · {plan}\nCredits: {value} ({FormatCreditCount(remaining)} remaining)";
-            if (usage.AdditionalUsage is { Enabled: true } addl)
-                tooltip += $"\nAdditional usage: {addl.StatusText} ({addl.SpendText})";
-            if (usage.Primary.ResetDescription is { } resetDesc)
-                tooltip += $"\nresets in {resetDesc}";
-            tooltip += StaleTooltipLine(result);
-            ToolTipService.SetToolTip(this, tooltip);
+            SetTileTooltip(
+                result.Source,
+                source =>
+                {
+                    var tooltip = string.IsNullOrEmpty(plan)
+                        ? $"{WidgetTooltipTitle(widgetName, source)}\nCredits: {value} ({FormatCreditCount(remaining)} remaining)"
+                        : $"{WidgetTooltipTitle(widgetName, source)} · {plan}\nCredits: {value} ({FormatCreditCount(remaining)} remaining)";
+                    if (usage.AdditionalUsage is { Enabled: true } addl)
+                        tooltip += $"\nAdditional usage: {addl.StatusText} ({addl.SpendText})";
+                    if (usage.Primary.ResetDescription is { } resetDesc)
+                        tooltip += $"\nresets in {resetDesc}";
+                    return tooltip + StaleTooltipLine(result);
+                });
         }
 
         /// <summary>
@@ -820,16 +855,21 @@ namespace TaskbarQuota.Controls
             AnimateRender(!_hasRevealed, providerSwitch: providerChanged);
 
             var plan = FormatPlanLabel(ProviderId.Antigravity, "Antigravity", usage.LoginMethod);
-            var title = WidgetTooltipTitle("Antigravity", result.Source);
-            // Header and body are built separately because `cond ? a : b + c` binds the concatenation to
-            // the false branch only — inlining these dropped the whole body whenever plan was empty.
-            var header = string.IsNullOrEmpty(plan) ? $"{title}\n" : $"{title} · {plan}\n";
             var body =
                 $"Gemini: {WidgetSettingsService.FormatDisplayPercent(usage.Primary.UsedPercent)}" +
                 (usage.Primary.ResetDescription is { } r1 ? $" (resets {r1})" : "") + "\n" +
                 $"Non-Gemini: {WidgetSettingsService.FormatDisplayPercent(usage.Secondary?.UsedPercent ?? 0)}" +
                 (usage.Secondary?.ResetDescription is { } r2 ? $" (resets {r2})" : "");
-            ToolTipService.SetToolTip(this, header + body + StaleTooltipLine(result));
+            SetTileTooltip(
+                result.Source,
+                source =>
+                {
+                    var title = WidgetTooltipTitle("Antigravity", source);
+                    // Header and body stay separate because `cond ? a : b + c` binds the concatenation to
+                    // the false branch only — inlining these dropped the body whenever plan was empty.
+                    var header = string.IsNullOrEmpty(plan) ? $"{title}\n" : $"{title} · {plan}\n";
+                    return header + body + StaleTooltipLine(result);
+                });
         }
 
         private void OnWidgetSettingsChanged(object? sender, EventArgs e)

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -74,6 +74,7 @@ namespace TaskbarQuota.Controls
         private UsageResult? _lastResult;
         private ProviderId? _lastAppliedProvider;
         private string? _lastRenderSignature;
+        private string? _lastSourceSignature;
         private bool _hasRevealed;
         private bool _isActiveToolVisible = true;
         // Storyboards and their animations are allocated on first use and re-aimed afterwards; all three
@@ -168,13 +169,27 @@ namespace TaskbarQuota.Controls
             }
 
             var signature = BuildRenderSignature(result);
+            var sourceSignature = BuildSourceSignature(result);
             if (!force && _lastRenderSignature == signature)
+            {
+                // Focus changes only alter the small source badge (desktop/browser/terminal). Rebuilding
+                // every row for that cosmetic change clears the Grid and starts the 180 ms refresh pulse,
+                // which makes the whole widget flash whenever focus enters or leaves a supported app.
+                // Keep the usage content in place and update only the badge.
+                _lastResult = result;
+                if (_lastSourceSignature != sourceSignature)
+                {
+                    _lastSourceSignature = sourceSignature;
+                    ApplySourceBadge(result);
+                }
                 return;
+            }
 
             var isFirstReveal = !_hasRevealed;
             var providerChanged = _lastAppliedProvider != result.Id;
             _lastAppliedProvider = result.Id;
             _lastRenderSignature = signature;
+            _lastSourceSignature = sourceSignature;
             _lastResult = result;
             ApplyTaskbarForeground();
             // Values restored from the previous session render dimmed until a live fetch confirms them,
@@ -1421,8 +1436,6 @@ namespace TaskbarQuota.Controls
                 result.Error ?? string.Empty,
                 result.IsPending ? "pending" : "settled",
                 result.IsStale ? "stale" : "live",
-                result.Source.Kind.ToString(),
-                result.Source.DisplayName,
             };
 
             if (result.Fetch is not { } fetch)
@@ -1462,6 +1475,16 @@ namespace TaskbarQuota.Controls
 
             return string.Join("|", parts);
         }
+
+        private static string BuildSourceSignature(UsageResult result)
+            => string.Join(
+                "|",
+                result.Source.Kind,
+                result.Source.DisplayName,
+                result.Source.IconKey);
+
+        internal static bool HasSameRenderedContentForTesting(UsageResult left, UsageResult right)
+            => BuildRenderSignature(left) == BuildRenderSignature(right);
 
         private static void AppendRateWindow(List<string> parts, RateWindow? window)
         {

--- a/src/TaskbarQuota.App/Interop/Native.cs
+++ b/src/TaskbarQuota.App/Interop/Native.cs
@@ -93,9 +93,6 @@ namespace TaskbarQuota.Interop
         [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         public static extern uint GetWindowLong(IntPtr hwnd, int index);
 
-        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        public static extern IntPtr SetWindowLongPtr(IntPtr hwnd, int index, IntPtr newStyle);
-
         [DllImport("user32.dll", SetLastError = true)]
         public static extern bool SetWindowPos(
             IntPtr hwnd,
@@ -112,6 +109,8 @@ namespace TaskbarQuota.Interop
         public const uint SWP_NOZORDER = 0x0004;
         public const uint SWP_NOACTIVATE = 0x0010;
         public const uint SWP_FRAMECHANGED = 0x0020;
+        internal const uint SWP_SHOWWINDOW = 0x0040;
+        internal const uint SWP_HIDEWINDOW = 0x0080;
 
         [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         public static extern IntPtr SendMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);

--- a/src/TaskbarQuota.App/Interop/Native.cs
+++ b/src/TaskbarQuota.App/Interop/Native.cs
@@ -91,7 +91,27 @@ namespace TaskbarQuota.Interop
         public static extern uint SetWindowLong(IntPtr hwnd, int index, uint newStyle);
 
         [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern uint GetWindowLong(IntPtr hwnd, int index);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         public static extern IntPtr SetWindowLongPtr(IntPtr hwnd, int index, IntPtr newStyle);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool SetWindowPos(
+            IntPtr hwnd,
+            IntPtr hwndInsertAfter,
+            int x,
+            int y,
+            int width,
+            int height,
+            uint flags);
+
+        public const int GWL_STYLE = -16;
+        public const uint SWP_NOSIZE = 0x0001;
+        public const uint SWP_NOMOVE = 0x0002;
+        public const uint SWP_NOZORDER = 0x0004;
+        public const uint SWP_NOACTIVATE = 0x0010;
+        public const uint SWP_FRAMECHANGED = 0x0020;
 
         [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         public static extern IntPtr SendMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
@@ -193,6 +213,7 @@ namespace TaskbarQuota.Interop
     public enum WindowStyles : uint
     {
         WS_POPUP = 0x80000000,
+        WS_CHILD = 0x40000000,
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/TaskbarQuota.App/Services/ProviderInstallDetector.cs
+++ b/src/TaskbarQuota.App/Services/ProviderInstallDetector.cs
@@ -65,7 +65,10 @@ internal static class ProviderInstallDetector
         ProviderId.OpenCode or ProviderId.OpenCodeGo => IsCliAvailable("opencode")
             || !string.IsNullOrWhiteSpace(CredentialStore.Instance.For(ProviderId.OpenCode).CookieHeader),
         ProviderId.Cline or ProviderId.ClinePass => IsCliAvailable("cline") || File.Exists(ClineProvidersPath()),
-        _ => true,
+        ProviderId.Zai => IsZaiConfiguredOrInstalled(),
+        ProviderId.Kimi => IsKimiCodeInstalled()
+            || HasKimiCredentials(),
+        _ => false,
     };
 
     /// <summary>Fast path for the UI thread before <see cref="WarmCliCache"/> finishes — never spawns processes.</summary>
@@ -87,7 +90,11 @@ internal static class ProviderInstallDetector
             !string.IsNullOrWhiteSpace(CredentialStore.Instance.For(ProviderId.OpenCode).CookieHeader)
             || HasCachedCli("opencode"),
         ProviderId.Cline or ProviderId.ClinePass => File.Exists(ClineProvidersPath()) || HasCachedCli("cline"),
-        _ => true,
+        ProviderId.Zai => IsZaiConfiguredOrInstalled(),
+        ProviderId.Kimi => IsKimiCodeInstalledWithoutCli()
+            || HasCachedCli("kimi")
+            || HasKimiCredentials(),
+        _ => false,
     };
 
     private static bool HasCachedCli(string name)
@@ -292,12 +299,14 @@ internal static class ProviderInstallDetector
     }
 
     private static bool IsKimiCodeInstalled()
+        => IsKimiCodeInstalledWithoutCli() || IsCliAvailable("kimi");
+
+    private static bool IsKimiCodeInstalledWithoutCli()
     {
         var kimiBin = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             ".kimi-code", "bin", "kimi.exe");
-        return File.Exists(kimiBin)
-            || IsCliAvailable("kimi");
+        return File.Exists(kimiBin);
     }
 
     private static bool IsZCodeInstalled()
@@ -306,6 +315,31 @@ internal static class ProviderInstallDetector
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "Programs", "ZCode");
         return File.Exists(Path.Combine(localPrograms, "ZCode.exe"));
+    }
+
+    private static bool IsZaiConfiguredOrInstalled()
+        => IsZCodeInstalled()
+        || !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("Z_AI_API_KEY"))
+        || !string.IsNullOrWhiteSpace(CredentialStore.Instance.ApiKey(ProviderId.Zai, "Z_AI_API_KEY"))
+        || File.Exists(Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".zcode", "v2", "config.json"));
+
+    private static bool HasKimiCredentials()
+    {
+        if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("KIMI_CODE_API_KEY"))
+            || !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("KIMI_AUTH_TOKEN"))
+            || !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("kimi_auth_token"))
+            || !string.IsNullOrWhiteSpace(CredentialStore.Instance.ApiKey(ProviderId.Kimi, "KIMI_CODE_API_KEY"))
+            || !string.IsNullOrWhiteSpace(CredentialStore.Instance.For(ProviderId.Kimi).Extra))
+        {
+            return true;
+        }
+
+        var home = Environment.GetEnvironmentVariable("KIMI_CODE_HOME")?.Trim();
+        if (string.IsNullOrWhiteSpace(home))
+            home = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".kimi-code");
+        return File.Exists(Path.Combine(home, "credentials", "kimi-code.json"));
     }
 
     private static bool IsDesktopAppInstalled(string appFolderName)

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -101,8 +101,14 @@ public static class WidgetSettingsService
         if (CurrentVisibilityMode == mode)
             return;
 
-        CurrentVisibilityMode = mode;
-        StateStore.SaveVisibilityMode(mode);
+        if (!TryPersistAndApply(
+            () => StateStore.SaveVisibilityMode(mode),
+            () => CurrentVisibilityMode = mode))
+        {
+            Diagnostics.Log.Warning($"Could not save widget visibility mode '{mode}'.");
+            return;
+        }
+
         Changed?.Invoke(null, EventArgs.Empty);
     }
 
@@ -111,8 +117,14 @@ public static class WidgetSettingsService
         if (KeepVisibleWhileBackgroundAgentRunning == enabled)
             return;
 
-        KeepVisibleWhileBackgroundAgentRunning = enabled;
-        StateStore.SaveKeepVisibleWhileBackgroundCliAgentRunning(enabled);
+        if (!TryPersistAndApply(
+            () => StateStore.SaveKeepVisibleWhileBackgroundCliAgentRunning(enabled),
+            () => KeepVisibleWhileBackgroundAgentRunning = enabled))
+        {
+            Diagnostics.Log.Warning("Could not save the background-agent widget visibility setting.");
+            return;
+        }
+
         Changed?.Invoke(null, EventArgs.Empty);
     }
 
@@ -121,8 +133,21 @@ public static class WidgetSettingsService
         if (LastWidgetProvider == provider)
             return;
 
-        LastWidgetProvider = provider;
-        StateStore.SaveLastProvider(provider);
+        if (!TryPersistAndApply(
+            () => StateStore.SaveLastProvider(provider),
+            () => LastWidgetProvider = provider))
+        {
+            Diagnostics.Log.Warning($"Could not save the last widget provider '{provider}'.");
+        }
+    }
+
+    internal static bool TryPersistAndApply(Func<bool> persist, Action apply)
+    {
+        if (!persist())
+            return false;
+
+        apply();
+        return true;
     }
 
     public static double DisplayPercent(double usedPercent)

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using TaskbarQuota.Taskbar;
 using TaskbarQuota.Usage;
 
 namespace TaskbarQuota;
@@ -57,6 +58,7 @@ public static class WidgetSettingsService
     private static readonly string AutoHideUnavailablePath =
         Path.Combine(AppStorage.AppDataDirectory, "auto-hide-unavailable.txt");
 
+    private static readonly WidgetStateStore StateStore = new(AppStorage.AppDataDirectory);
     private static readonly Dictionary<string, bool> RowVisibility = LoadRowVisibility();
     private static readonly Dictionary<string, bool> ProviderVisibility = LoadProviderVisibility();
     private static readonly Dictionary<string, bool> DashboardProviderVisibility = LoadDashboardProviderVisibility();
@@ -65,6 +67,10 @@ public static class WidgetSettingsService
     public static WidgetDisplayMode Current { get; private set; } = LoadWidgetDisplayMode();
     public static PercentageDisplayMode CurrentPercentageMode { get; private set; } = LoadPercentageDisplayMode();
     public static bool AutoHideUnavailable { get; private set; } = LoadAutoHideUnavailable();
+    public static WidgetVisibilityMode CurrentVisibilityMode { get; private set; } = StateStore.LoadVisibilityMode();
+    public static bool KeepVisibleWhileBackgroundAgentRunning { get; private set; } =
+        StateStore.LoadKeepVisibleWhileBackgroundCliAgentRunning();
+    public static ProviderId? LastWidgetProvider { get; private set; } = StateStore.LoadLastProvider();
     public static event EventHandler? Changed;
     public static event EventHandler? DashboardCompositionChanged;
     public static event EventHandler? PercentageModeChanged;
@@ -88,6 +94,35 @@ public static class WidgetSettingsService
         Save(PercentageDisplayModePath, (int)mode);
         PercentageModeChanged?.Invoke(null, EventArgs.Empty);
         Changed?.Invoke(null, EventArgs.Empty);
+    }
+
+    public static void ApplyWidgetVisibilityMode(WidgetVisibilityMode mode)
+    {
+        if (CurrentVisibilityMode == mode)
+            return;
+
+        CurrentVisibilityMode = mode;
+        StateStore.SaveVisibilityMode(mode);
+        Changed?.Invoke(null, EventArgs.Empty);
+    }
+
+    public static void ApplyKeepVisibleWhileBackgroundAgentRunning(bool enabled)
+    {
+        if (KeepVisibleWhileBackgroundAgentRunning == enabled)
+            return;
+
+        KeepVisibleWhileBackgroundAgentRunning = enabled;
+        StateStore.SaveKeepVisibleWhileBackgroundCliAgentRunning(enabled);
+        Changed?.Invoke(null, EventArgs.Empty);
+    }
+
+    public static void RememberLastWidgetProvider(ProviderId provider)
+    {
+        if (LastWidgetProvider == provider)
+            return;
+
+        LastWidgetProvider = provider;
+        StateStore.SaveLastProvider(provider);
     }
 
     public static double DisplayPercent(double usedPercent)

--- a/src/TaskbarQuota.App/Services/WidgetStateStore.cs
+++ b/src/TaskbarQuota.App/Services/WidgetStateStore.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Globalization;
+using System.IO;
+using TaskbarQuota.Taskbar;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota;
+
+internal sealed class WidgetStateStore
+{
+    private const string VisibilityPolicyFileName = "widget-visibility-policy.txt";
+    private const string BackgroundCliFileName = "widget-background-cli.txt";
+    private const string LastProviderFileName = "last-widget-provider.txt";
+
+    private readonly string _directory;
+
+    public WidgetStateStore(string directory)
+    {
+        _directory = directory;
+    }
+
+    public WidgetVisibilityMode LoadVisibilityMode()
+        => LoadEnum(
+            VisibilityPolicyFileName,
+            WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen);
+
+    public bool LoadKeepVisibleWhileBackgroundCliAgentRunning()
+        => LoadInt(BackgroundCliFileName) == 1;
+
+    public ProviderId? LoadLastProvider()
+    {
+        try
+        {
+            string path = Path.Combine(_directory, LastProviderFileName);
+            if (!File.Exists(path))
+                return null;
+
+            string value = File.ReadAllText(path).Trim();
+            return Enum.TryParse(value, ignoreCase: false, out ProviderId provider)
+                && Enum.IsDefined(provider)
+                ? provider
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public bool SaveVisibilityMode(WidgetVisibilityMode mode)
+        => Save(VisibilityPolicyFileName, ((int)mode).ToString(CultureInfo.InvariantCulture));
+
+    public bool SaveKeepVisibleWhileBackgroundCliAgentRunning(bool enabled)
+        => Save(BackgroundCliFileName, enabled ? "1" : "0");
+
+    public bool SaveLastProvider(ProviderId provider)
+        => Save(LastProviderFileName, provider.ToString());
+
+    private TEnum LoadEnum<TEnum>(string fileName, TEnum fallback)
+        where TEnum : struct, Enum
+    {
+        int? value = LoadInt(fileName);
+        return value is int defined && Enum.IsDefined(typeof(TEnum), defined)
+            ? (TEnum)Enum.ToObject(typeof(TEnum), defined)
+            : fallback;
+    }
+
+    private int? LoadInt(string fileName)
+    {
+        try
+        {
+            string path = Path.Combine(_directory, fileName);
+            if (!File.Exists(path))
+                return null;
+
+            return int.TryParse(
+                File.ReadAllText(path),
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out int value)
+                ? value
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private bool Save(string fileName, string value)
+    {
+        try
+        {
+            Directory.CreateDirectory(_directory);
+            File.WriteAllText(Path.Combine(_directory, fileName), value);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -24,14 +24,27 @@ namespace TaskbarQuota.Taskbar
         private static DispatcherQueue? _dispatcher;
         private static Action? _showMainWindow;
         private static DispatcherTimer? _widgetHealthTimer;
+        private static DispatcherTimer? _visibilityTimer;
         private static bool _initialized;
         private static bool _isReconcilingWidgets;
         private static ProviderId? _lastLoggedWidgetApplyProvider;
+        private static PopupMenuItem? _showWidgetMenuItem;
+        private static PopupMenuItem? _hideWidgetMenuItem;
+        private static PopupMenuItem? _automaticWidgetMenuItem;
+        private static PopupMenuItem? _moveWidgetMenuItem;
+        private static WidgetVisibilityOverride _visibilityOverride = WidgetVisibilityOverride.Automatic;
+        private static readonly WidgetVisibilityStabilizer VisibilityStabilizer = new();
+        private static WidgetVisibilityDecision? _lastVisibilityDecision;
+        private static bool _lastWidgetVisible;
+        private static WidgetVisibilityMode? _lastObservedVisibilityMode;
+        private static bool? _lastObservedBackgroundAgent;
 
         public static void Initialize(DispatcherQueue dispatcher, Action showMainWindow)
         {
             _dispatcher = dispatcher;
             _showMainWindow = showMainWindow;
+            _lastObservedVisibilityMode = WidgetSettingsService.CurrentVisibilityMode;
+            _lastObservedBackgroundAgent = WidgetSettingsService.KeepVisibleWhileBackgroundAgentRunning;
 
             CreateTrayIcon();
             EnsureWidgets();
@@ -41,19 +54,30 @@ namespace TaskbarQuota.Taskbar
                 UsageCoordinator.Instance.StateChanged += OnStateChanged;
                 UsageCoordinator.Instance.ActiveProviderChanged += OnActiveProviderChanged;
                 UsageCoordinator.Instance.ActiveToolPresenceChanged += OnActiveToolPresenceChanged;
+                UsageCoordinator.Instance.SupportedSurfacesChanged += OnSupportedSurfacesChanged;
                 WidgetSettingsService.Changed += OnWidgetSettingsChanged;
                 App.Quitting += OnQuitting;
                 _initialized = true;
             }
 
             StartWidgetHealthTimer();
-            OnActiveToolPresenceChanged(UsageCoordinator.Instance.IsActiveToolPresent);
+            SyncWidgetState();
         }
 
         private static void CreateTrayIcon()
         {
             var open = new PopupMenuItem("Open TaskbarQuota", (_, _) => _dispatcher?.TryEnqueue(() => _showMainWindow?.Invoke()));
-            var move = new PopupMenuItem("Move primary taskbar widget", (_, _) => _dispatcher?.TryEnqueue(
+            _showWidgetMenuItem = new PopupMenuItem("Show widget", (_, _) => _dispatcher?.TryEnqueue(
+                () => ApplyVisibilityOverride(WidgetVisibilityOverride.ForceShow)));
+            _hideWidgetMenuItem = new PopupMenuItem("Hide widget", (_, _) => _dispatcher?.TryEnqueue(
+                () => ApplyVisibilityOverride(WidgetVisibilityOverride.ForceHide)));
+            _automaticWidgetMenuItem = new PopupMenuItem("Use automatic visibility", (_, _) => _dispatcher?.TryEnqueue(
+                () => ApplyVisibilityOverride(WidgetVisibilityOverride.Automatic)));
+            var visibility = new PopupSubMenu("Widget visibility")
+            {
+                Items = { _showWidgetMenuItem, _hideWidgetMenuItem, _automaticWidgetMenuItem },
+            };
+            _moveWidgetMenuItem = new PopupMenuItem("Move primary taskbar widget", (_, _) => _dispatcher?.TryEnqueue(
                 () => PrimaryWidget()?.StartDragging()));
             var reset = new PopupMenuItem("Reset widget positions", (_, _) => _dispatcher?.TryEnqueue(
                 () =>
@@ -76,7 +100,19 @@ namespace TaskbarQuota.Taskbar
 
             _trayIcon = new TrayIconWithContextMenu
             {
-                ContextMenu = new PopupMenu { Items = { open, new PopupMenuSeparator(), move, reset, new PopupMenuSeparator(), quit } },
+                ContextMenu = new PopupMenu
+                {
+                    Items =
+                    {
+                        open,
+                        new PopupMenuSeparator(),
+                        visibility,
+                        _moveWidgetMenuItem,
+                        reset,
+                        new PopupMenuSeparator(),
+                        quit,
+                    },
+                },
                 ToolTip = "TaskbarQuota",
             };
             _trayIcon.Create();
@@ -119,6 +155,10 @@ namespace TaskbarQuota.Taskbar
                 }
             };
             _widgetHealthTimer.Start();
+
+            _visibilityTimer ??= new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(250) };
+            _visibilityTimer.Tick -= OnVisibilityTimerTick;
+            _visibilityTimer.Tick += OnVisibilityTimerTick;
         }
 
         private static void EnsureWidgets()
@@ -206,10 +246,55 @@ namespace TaskbarQuota.Taskbar
             => Widgets.Values.FirstOrDefault(widget => widget.IsAlive && widget.IsPrimaryTaskbar)
                 ?? Widgets.Values.FirstOrDefault(widget => widget.IsAlive);
 
-        private static void SyncWidgetState()
+        private static void SyncWidgetState(bool hideImmediately = false, bool hydrate = true)
         {
+            var coordinator = UsageCoordinator.Instance;
+            var providers = coordinator.WidgetDisplayProviders;
+            var decision = EvaluateVisibilityDecision(providers, hideImmediately);
+            bool visible = decision.ShouldShowWidget && providers.Count > 0;
+            bool needsFetch = false;
+
             foreach (var widget in Widgets.Values.ToArray())
-                SyncWidgetState(widget);
+            {
+                if (!widget.IsAlive)
+                    continue;
+
+                if (visible)
+                {
+                    // Bind before exposing the native host so a show never paints one frame of stale or
+                    // collapsed content.
+                    widget.SetDisplayProviders(providers, coordinator.ActiveWidgetProvider);
+                    widget.SetVisible(true);
+                }
+                else
+                {
+                    // Leave the current tiles bound during the short host fade. Collapsing them first makes
+                    // the animation look like a blank flash.
+                    widget.SetVisible(false);
+                }
+
+                if (!visible || !hydrate)
+                    continue;
+
+                foreach (var provider in providers)
+                {
+                    var toApply = HydrateResult(coordinator, provider);
+                    if (toApply is { } result)
+                    {
+                        widget.ApplyResult(result, force: true);
+                        LogWidgetApply(result.Id, "sync");
+                    }
+
+                    // Hydrating from a placeholder/failed snapshot leaves the tile showing a non-value while
+                    // the flyout fetches its own data. Kick a fetch so the widget resolves on its own (#21).
+                    if (toApply is null or { Ok: false })
+                        needsFetch = true;
+                }
+            }
+
+            FinalizeVisibilityDecision(decision, visible);
+            if (needsFetch)
+                _ = coordinator.TickAsync(force: true);
         }
 
         private static void SyncWidgetState(TaskBarWidget widget)
@@ -219,32 +304,138 @@ namespace TaskbarQuota.Taskbar
 
             var coordinator = UsageCoordinator.Instance;
             var providers = coordinator.WidgetDisplayProviders;
-
-            // No provider to show -> hide the native host instead of leaving a transparent taskbar child
-            // window over the notification area (#10).
-            widget.SetVisible(providers.Count > 0);
-            widget.SetDisplayProviders(providers, coordinator.ActiveProvider);
-            if (providers.Count == 0)
-                return;
-
-            bool needsFetch = false;
-            foreach (var provider in providers)
+            var decision = EvaluateVisibilityDecision(providers);
+            bool visible = decision.ShouldShowWidget && providers.Count > 0;
+            if (visible)
             {
-                var toApply = HydrateResult(coordinator, provider);
-                if (toApply is { } result)
-                {
-                    widget.ApplyResult(result, force: true);
-                    LogWidgetApply(result.Id, "sync");
-                }
-
-                // Hydrating from a placeholder/failed snapshot leaves the tile showing a non-value while
-                // the flyout fetches its own data. Kick a fetch so the widget resolves on its own (#21).
-                if (toApply is null or { Ok: false })
-                    needsFetch = true;
+                widget.SetDisplayProviders(providers, coordinator.ActiveWidgetProvider);
+                widget.SetVisible(true);
+            }
+            else
+            {
+                widget.SetVisible(false);
             }
 
+            bool needsFetch = false;
+            if (visible)
+            {
+                foreach (var provider in providers)
+                {
+                    var toApply = HydrateResult(coordinator, provider);
+                    if (toApply is { } result)
+                    {
+                        widget.ApplyResult(result, force: true);
+                        LogWidgetApply(result.Id, "sync");
+                    }
+
+                    if (toApply is null or { Ok: false })
+                        needsFetch = true;
+                }
+            }
+
+            FinalizeVisibilityDecision(decision, visible);
             if (needsFetch)
                 _ = coordinator.TickAsync(force: true);
+        }
+
+        /// <summary>
+        /// Applies only the native host visibility decision. Focus/presence transitions do not change the
+        /// usage snapshot, so routing them through <see cref="SyncWidgetState(bool, bool)"/> needlessly
+        /// re-runs tile layout and render animations throughout the hide debounce.
+        /// </summary>
+        private static void SyncWidgetVisibility()
+        {
+            var coordinator = UsageCoordinator.Instance;
+            var providers = coordinator.WidgetDisplayProviders;
+            var decision = EvaluateVisibilityDecision(providers);
+            bool visible = decision.ShouldShowWidget && providers.Count > 0;
+
+            // A newly visible host may have missed provider updates while hidden. Perform one full bind
+            // before showing it; transitions that keep it visible do no content work at all.
+            if (visible && !_lastWidgetVisible)
+            {
+                SyncWidgetState();
+                return;
+            }
+
+            foreach (var widget in Widgets.Values.ToArray())
+            {
+                if (widget.IsAlive)
+                    widget.SetVisible(visible);
+            }
+
+            FinalizeVisibilityDecision(decision, visible);
+        }
+
+        private static WidgetVisibilityDecision EvaluateVisibilityDecision(
+            IReadOnlyList<ProviderId> providers,
+            bool hideImmediately = false)
+        {
+            var input = new WidgetVisibilityInput(
+                WidgetSettingsService.CurrentVisibilityMode,
+                _visibilityOverride,
+                providers.Count > 0,
+                WidgetSettingsService.KeepVisibleWhileBackgroundAgentRunning,
+                UsageCoordinator.Instance.SupportedSurfaces);
+            var raw = WidgetVisibilityPolicy.Evaluate(input);
+            bool bypassDelay = hideImmediately
+                || raw.Reason is WidgetVisibilityReason.ManualForceHide
+                    or WidgetVisibilityReason.NoValidProvider;
+            return VisibilityStabilizer.Apply(raw, DateTimeOffset.UtcNow, bypassDelay);
+        }
+
+        private static void FinalizeVisibilityDecision(WidgetVisibilityDecision decision, bool visible)
+        {
+            if (_lastWidgetVisible && !visible)
+                CloseFlyout();
+
+            _lastWidgetVisible = visible;
+            UpdateTrayMenuState();
+
+            if (decision.Reason == WidgetVisibilityReason.HideDebounce)
+                _visibilityTimer?.Start();
+            else
+                _visibilityTimer?.Stop();
+
+            if (_lastVisibilityDecision != decision)
+            {
+                _lastVisibilityDecision = decision;
+                var provider = UsageCoordinator.Instance.WidgetDisplayProvider?.ToString() ?? "none";
+                Log.Information(
+                    $"[visibility] visible={visible} reason={decision.Reason} " +
+                    $"policy={WidgetSettingsService.CurrentVisibilityMode} provider={provider}");
+            }
+        }
+
+        private static void OnVisibilityTimerTick(object? sender, object e)
+            => SyncWidgetVisibility();
+
+        private static void ApplyVisibilityOverride(WidgetVisibilityOverride visibilityOverride)
+        {
+            if (_visibilityOverride == visibilityOverride)
+                return;
+
+            _visibilityOverride = visibilityOverride;
+            Log.Information($"[visibility] override={visibilityOverride}");
+            SyncWidgetState(hideImmediately: true);
+        }
+
+        private static void UpdateTrayMenuState()
+        {
+            if (_showWidgetMenuItem is not null)
+                _showWidgetMenuItem.Checked = _visibilityOverride == WidgetVisibilityOverride.ForceShow;
+            if (_hideWidgetMenuItem is not null)
+                _hideWidgetMenuItem.Checked = _visibilityOverride == WidgetVisibilityOverride.ForceHide;
+            if (_automaticWidgetMenuItem is not null)
+                _automaticWidgetMenuItem.Checked = _visibilityOverride == WidgetVisibilityOverride.Automatic;
+            if (_moveWidgetMenuItem is not null)
+                _moveWidgetMenuItem.Enabled = _lastWidgetVisible;
+        }
+
+        private static void CloseFlyout()
+        {
+            try { _flyout?.Close(); } catch { }
+            _flyout = null;
         }
 
         /// <summary>
@@ -319,6 +510,8 @@ namespace TaskbarQuota.Taskbar
             var coordinator = UsageCoordinator.Instance;
             var providers = coordinator.WidgetDisplayProviders;
             bool isDisplayed = providers.Contains(result.Id);
+            var decision = EvaluateVisibilityDecision(providers);
+            bool visible = decision.ShouldShowWidget && providers.Count > 0;
 
             // Reused buffer: this runs on every usage publish, so a fresh array per publish was pure waste.
             SnapshotWidgets();
@@ -329,14 +522,22 @@ namespace TaskbarQuota.Taskbar
 
                 // Reconcile the tile set first, so a provider that just became active already owns a slot
                 // before its result is routed. SetDisplayProviders is a cheap no-op when nothing changed.
-                widget.SetVisible(providers.Count > 0);
-                widget.SetDisplayProviders(providers, coordinator.ActiveProvider);
+                if (!visible)
+                {
+                    widget.SetVisible(false);
+                    continue;
+                }
+
+                widget.SetDisplayProviders(providers, coordinator.ActiveWidgetProvider);
+                widget.SetVisible(true);
                 if (!isDisplayed)
                     continue;
 
                 widget.ApplyResult(result);
                 LogWidgetApply(result.Id, "state");
             }
+
+            FinalizeVisibilityDecision(decision, visible);
         }
 
         /// <summary>
@@ -368,20 +569,29 @@ namespace TaskbarQuota.Taskbar
         private static void OnActiveToolPresenceChanged(bool isPresent)
             => _dispatcher?.TryEnqueue(() => ApplyActiveToolPresenceChanged(isPresent));
 
-        private static void ApplyActiveToolPresenceChanged(bool isPresent)
-        {
-            // Pinned tiles stay on the taskbar even when no AI tool is in the foreground; only the active
-            // tile follows presence. SyncWidgetState recomputes the whole set and hydrates it.
-            foreach (var widget in Widgets.Values.ToArray())
-            {
-                if (widget.IsAlive)
-                    SyncWidgetState(widget);
-            }
-        }
+        private static void ApplyActiveToolPresenceChanged(bool _)
+            // Like SupportedSurfacesChanged, this is a visibility transition rather than new usage data.
+            // SyncWidgetVisibility performs a full bind when the host becomes visible, but avoids forcing a
+            // tile re-render while it remains visible during the hide debounce.
+            => SyncWidgetVisibility();
+
+        private static void OnSupportedSurfacesChanged(SupportedSurfaceState _)
+            => _dispatcher?.TryEnqueue(SyncWidgetVisibility);
 
         private static void OnWidgetSettingsChanged(object? sender, EventArgs e)
         {
-            _dispatcher?.TryEnqueue(SyncWidgetState);
+            _dispatcher?.TryEnqueue(() =>
+            {
+                var mode = WidgetSettingsService.CurrentVisibilityMode;
+                var backgroundAgent = WidgetSettingsService.KeepVisibleWhileBackgroundAgentRunning;
+                bool visibilitySettingChanged = _lastObservedVisibilityMode != mode
+                    || _lastObservedBackgroundAgent != backgroundAgent;
+                _lastObservedVisibilityMode = mode;
+                _lastObservedBackgroundAgent = backgroundAgent;
+                if (visibilitySettingChanged)
+                    Log.Information($"[visibility] policy={mode} backgroundAgent={backgroundAgent}");
+                SyncWidgetState(hideImmediately: visibilitySettingChanged);
+            });
         }
 
         private static void OnQuitting()
@@ -389,18 +599,30 @@ namespace TaskbarQuota.Taskbar
             UsageCoordinator.Instance.StateChanged -= OnStateChanged;
             UsageCoordinator.Instance.ActiveProviderChanged -= OnActiveProviderChanged;
             UsageCoordinator.Instance.ActiveToolPresenceChanged -= OnActiveToolPresenceChanged;
+            UsageCoordinator.Instance.SupportedSurfacesChanged -= OnSupportedSurfacesChanged;
             WidgetSettingsService.Changed -= OnWidgetSettingsChanged;
             _initialized = false;
             _widgetHealthTimer?.Stop();
             _widgetHealthTimer = null;
+            _visibilityTimer?.Stop();
+            _visibilityTimer = null;
             if (_trayIcon != null) { _trayIcon.TryRemove(); _trayIcon.Dispose(); _trayIcon = null; }
-            try { _flyout?.Close(); } catch { }
-            _flyout = null;
+            CloseFlyout();
             foreach (var widget in Widgets.Values.ToArray())
             {
                 try { widget.Dispose(); } catch { }
             }
             Widgets.Clear();
+            _showWidgetMenuItem = null;
+            _hideWidgetMenuItem = null;
+            _automaticWidgetMenuItem = null;
+            _moveWidgetMenuItem = null;
+            _visibilityOverride = WidgetVisibilityOverride.Automatic;
+            _lastVisibilityDecision = null;
+            _lastWidgetVisible = false;
+            _lastObservedVisibilityMode = null;
+            _lastObservedBackgroundAgent = null;
+            VisibilityStabilizer.Reset(isVisible: false);
         }
     }
 }

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -17,9 +17,6 @@ namespace TaskbarQuota.Taskbar
         private static TrayIconWithContextMenu? _trayIcon;
         private static System.Drawing.Icon? _trayIconSource;
         private static readonly Dictionary<IntPtr, TaskBarWidget> Widgets = new();
-        // Reused snapshot of Widgets.Values, so iterating it while a callback may mutate the dictionary
-        // doesn't allocate. Only valid until the next SnapshotWidgets call, and only used on the UI thread.
-        private static readonly List<TaskBarWidget> _widgetBuffer = new();
         private static FlyoutWindow? _flyout;
         private static DispatcherQueue? _dispatcher;
         private static Action? _showMainWindow;
@@ -145,10 +142,7 @@ namespace TaskbarQuota.Taskbar
                 Services.PinBudgetService.EnforceBudget();
                 // Re-run the tile-fit math against the gap the last position pass measured, so tiles that
                 // were trimmed off a crowded taskbar come back once there is room for them again.
-                // Iterated over the reused buffer rather than Widgets.Values.ToArray(), which allocated an
-                // array every five seconds for the life of the process.
-                SnapshotWidgets();
-                foreach (var widget in _widgetBuffer)
+                foreach (var widget in CreateStableSnapshot(Widgets.Values))
                 {
                     if (widget.IsAlive)
                         widget.RefreshLayout();
@@ -252,6 +246,16 @@ namespace TaskbarQuota.Taskbar
             var providers = coordinator.WidgetDisplayProviders;
             var decision = EvaluateVisibilityDecision(providers, hideImmediately);
             bool visible = decision.ShouldShowWidget && providers.Count > 0;
+            SyncWidgetState(providers, decision, visible, hydrate);
+        }
+
+        private static void SyncWidgetState(
+            IReadOnlyList<ProviderId> providers,
+            WidgetVisibilityDecision decision,
+            bool visible,
+            bool hydrate = true)
+        {
+            var coordinator = UsageCoordinator.Instance;
             bool needsFetch = false;
 
             foreach (var widget in Widgets.Values.ToArray())
@@ -354,7 +358,7 @@ namespace TaskbarQuota.Taskbar
             // before showing it; transitions that keep it visible do no content work at all.
             if (visible && !_lastWidgetVisible)
             {
-                SyncWidgetState();
+                SyncWidgetState(providers, decision, visible);
                 return;
             }
 
@@ -513,9 +517,7 @@ namespace TaskbarQuota.Taskbar
             var decision = EvaluateVisibilityDecision(providers);
             bool visible = decision.ShouldShowWidget && providers.Count > 0;
 
-            // Reused buffer: this runs on every usage publish, so a fresh array per publish was pure waste.
-            SnapshotWidgets();
-            foreach (var widget in _widgetBuffer)
+            foreach (var widget in CreateStableSnapshot(Widgets.Values))
             {
                 if (!widget.IsAlive)
                     continue;
@@ -541,17 +543,11 @@ namespace TaskbarQuota.Taskbar
         }
 
         /// <summary>
-        /// Refills <see cref="_widgetBuffer"/> from the live dictionary. Callers iterate the buffer rather
-        /// than the dictionary because a widget callback can remove an entry mid-loop; the buffer replaces
-        /// the defensive copy that the hot paths used to allocate per pass. UI thread only, and the buffer
-        /// stays valid only until the next call.
+        /// Creates storage owned by this iteration. XAML calls inside the loop can pump the dispatcher and
+        /// re-enter another manager callback; a shared reusable list is then cleared while its outer
+        /// enumerator is still active.
         /// </summary>
-        private static void SnapshotWidgets()
-        {
-            _widgetBuffer.Clear();
-            foreach (var widget in Widgets.Values)
-                _widgetBuffer.Add(widget);
-        }
+        internal static T[] CreateStableSnapshot<T>(IEnumerable<T> source) => source.ToArray();
 
         private static void LogWidgetApply(ProviderId provider, string source)
         {
@@ -601,6 +597,7 @@ namespace TaskbarQuota.Taskbar
             UsageCoordinator.Instance.ActiveToolPresenceChanged -= OnActiveToolPresenceChanged;
             UsageCoordinator.Instance.SupportedSurfacesChanged -= OnSupportedSurfacesChanged;
             WidgetSettingsService.Changed -= OnWidgetSettingsChanged;
+            App.Quitting -= OnQuitting;
             _initialized = false;
             _widgetHealthTimer?.Stop();
             _widgetHealthTimer = null;

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -18,6 +18,7 @@ using TaskbarQuota.Controls;
 using TaskbarQuota.Diagnostics;
 using TaskbarQuota.Interop;
 using TaskbarQuota.Usage;
+using Anim = Microsoft.UI.Xaml.Media.Animation;
 
 namespace TaskbarQuota.Taskbar
 {
@@ -121,6 +122,9 @@ namespace TaskbarQuota.Taskbar
         private bool loggedMissingPanel;
         private DesktopWindowXamlSource? host;
         private Microsoft.UI.Xaml.FrameworkElement? hostContent;
+        private const int HostFadeMilliseconds = 100;
+        private Anim.Storyboard? hostFadeStoryboard;
+        private int hostFadeGeneration;
         private int WidgetHostWidth;
         private int currentOffsetX = int.MinValue;
         private int currentOffsetY = 0;
@@ -274,12 +278,28 @@ namespace TaskbarQuota.Taskbar
         private void InjectIntoTaskbar()
         {
             Log.Information("Injecting widget into taskbar");
+            ApplyTaskbarChildStyle();
             int attempts = 0;
             while (attempts++ <= 3)
             {
                 var previousParent = User32.SetParent(hwnd, hwndShell);
                 if (previousParent != IntPtr.Zero || IsParentedToTaskbar())
                 {
+                    // SetWindowLong caches some style-dependent frame state. Notify USER32 after the
+                    // reparent so Explorer composes this as a real child instead of a top-level popup whose
+                    // owner happens to be the taskbar.
+                    User32.SetWindowPos(
+                        hwnd,
+                        IntPtr.Zero,
+                        0,
+                        0,
+                        0,
+                        0,
+                        User32.SWP_NOMOVE
+                            | User32.SWP_NOSIZE
+                            | User32.SWP_NOZORDER
+                            | User32.SWP_NOACTIVATE
+                            | User32.SWP_FRAMECHANGED);
                     Log.Information("Widget injected successfully");
                     return;
                 }
@@ -287,6 +307,23 @@ namespace TaskbarQuota.Taskbar
             Dispose();
             throw new InvalidOperationException("Could not inject the widget into the taskbar.");
         }
+
+        private void ApplyTaskbarChildStyle()
+        {
+            uint current = User32.GetWindowLong(hwnd, User32.GWL_STYLE);
+            uint childStyle = ConvertToTaskbarChildStyle(current);
+            if (childStyle == current)
+                return;
+
+            Marshal.SetLastPInvokeError(0);
+            uint previous = User32.SetWindowLong(hwnd, User32.GWL_STYLE, childStyle);
+            int error = Marshal.GetLastPInvokeError();
+            if (previous == 0 && error != 0)
+                throw new Win32Exception(error, "Could not convert the taskbar widget host to WS_CHILD.");
+        }
+
+        internal static uint ConvertToTaskbarChildStyle(uint style)
+            => (style & ~(uint)WindowStyles.WS_POPUP) | (uint)WindowStyles.WS_CHILD;
 
         private bool IsParentedToTaskbar()
             => User32.GetAncestor(hwnd, GetAncestorFlags.GA_PARENT) == hwndShell;
@@ -309,17 +346,81 @@ namespace TaskbarQuota.Taskbar
                 return;
 
             isVisible = visible;
+            hostFadeGeneration++;
             if (visible)
             {
                 QueuePositionUpdate(TaskbarChangeReason.None);
-                appWindow.Show(false);
+                if (!appWindow.IsVisible)
+                {
+                    if (hostContent is { } hiddenContent)
+                        hiddenContent.Opacity = 0;
+                    appWindow.Show(false);
+                }
+
+                AnimateHostOpacity(1);
+                return;
             }
-            else
+
+            if (isDragging)
+                EndDragging(revert: true);
+
+            if (hostContent is null)
             {
-                if (isDragging)
-                    EndDragging(revert: true);
                 appWindow.Hide();
+                return;
             }
+
+            int generation = hostFadeGeneration;
+            AnimateHostOpacity(0, () =>
+            {
+                if (generation != hostFadeGeneration || destroyed || appWindow is null)
+                    return;
+
+                appWindow.Hide();
+            });
+        }
+
+        private void AnimateHostOpacity(double to, Action? completed = null)
+        {
+            if (hostContent is not { } content)
+            {
+                completed?.Invoke();
+                return;
+            }
+
+            // Read the animated value before stopping. If a show interrupts a hide, the new fade resumes
+            // from the frame currently on screen instead of jumping through fully transparent.
+            double from = content.Opacity;
+            hostFadeStoryboard?.Stop();
+            hostFadeStoryboard = null;
+            content.Opacity = to;
+
+            if (Math.Abs(from - to) < 0.01)
+            {
+                completed?.Invoke();
+                return;
+            }
+
+            var animation = new Anim.DoubleAnimation
+            {
+                From = from,
+                To = to,
+                Duration = new Microsoft.UI.Xaml.Duration(TimeSpan.FromMilliseconds(HostFadeMilliseconds)),
+                EasingFunction = new Anim.CubicEase { EasingMode = Anim.EasingMode.EaseOut },
+            };
+            Anim.Storyboard.SetTarget(animation, content);
+            Anim.Storyboard.SetTargetProperty(animation, "Opacity");
+
+            var storyboard = new Anim.Storyboard();
+            storyboard.Children.Add(animation);
+            storyboard.Completed += (_, _) =>
+            {
+                if (ReferenceEquals(hostFadeStoryboard, storyboard))
+                    hostFadeStoryboard = null;
+                completed?.Invoke();
+            };
+            hostFadeStoryboard = storyboard;
+            storyboard.Begin();
         }
 
         public void Destroy() => appWindow?.Destroy();
@@ -1964,6 +2065,9 @@ namespace TaskbarQuota.Taskbar
             disposedValue = true;
             initialized = false;
             isVisible = false;
+            hostFadeGeneration++;
+            try { hostFadeStoryboard?.Stop(); } catch { }
+            hostFadeStoryboard = null;
             positionUpdateCancellation.Cancel();
             try { appWindow?.Hide(); } catch { }
             foreach (var tile in tiles)

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -310,7 +310,12 @@ namespace TaskbarQuota.Taskbar
 
         private void ApplyTaskbarChildStyle()
         {
+            Marshal.SetLastPInvokeError(0);
             uint current = User32.GetWindowLong(hwnd, User32.GWL_STYLE);
+            int readError = Marshal.GetLastPInvokeError();
+            if (IsGetWindowLongFailure(current, readError))
+                throw new Win32Exception(readError, "Could not read the taskbar widget host style.");
+
             uint childStyle = ConvertToTaskbarChildStyle(current);
             if (childStyle == current)
                 return;
@@ -324,6 +329,9 @@ namespace TaskbarQuota.Taskbar
 
         internal static uint ConvertToTaskbarChildStyle(uint style)
             => (style & ~(uint)WindowStyles.WS_POPUP) | (uint)WindowStyles.WS_CHILD;
+
+        internal static bool IsGetWindowLongFailure(uint style, int error)
+            => style == 0 && error != 0;
 
         private bool IsParentedToTaskbar()
             => User32.GetAncestor(hwnd, GetAncestorFlags.GA_PARENT) == hwndShell;
@@ -350,11 +358,15 @@ namespace TaskbarQuota.Taskbar
             if (visible)
             {
                 QueuePositionUpdate(TaskbarChangeReason.None);
-                if (!appWindow.IsVisible)
+                if (!User32.IsWindowVisible(hwnd))
                 {
                     if (hostContent is { } hiddenContent)
                         hiddenContent.Opacity = 0;
-                    appWindow.Show(false);
+                    if (!TrySetNativeVisibility(true))
+                    {
+                        isVisible = User32.IsWindowVisible(hwnd);
+                        return;
+                    }
                 }
 
                 AnimateHostOpacity(1);
@@ -366,7 +378,8 @@ namespace TaskbarQuota.Taskbar
 
             if (hostContent is null)
             {
-                appWindow.Hide();
+                if (!TrySetNativeVisibility(false))
+                    isVisible = User32.IsWindowVisible(hwnd);
                 return;
             }
 
@@ -376,9 +389,42 @@ namespace TaskbarQuota.Taskbar
                 if (generation != hostFadeGeneration || destroyed || appWindow is null)
                     return;
 
-                appWindow.Hide();
+                if (!TrySetNativeVisibility(false))
+                    isVisible = User32.IsWindowVisible(hwnd);
             });
         }
+
+        private bool TrySetNativeVisibility(bool visible)
+        {
+            // AppWindow represents a top-level HWND, but this host becomes a WS_CHILD before visibility
+            // starts changing. Keep show/hide on USER32 once reparented so WinAppSDK does not queue a
+            // top-level AppWindow operation for the taskbar child.
+            Marshal.SetLastPInvokeError(0);
+            bool succeeded = User32.SetWindowPos(
+                hwnd,
+                IntPtr.Zero,
+                0,
+                0,
+                0,
+                0,
+                NativeVisibilityFlags(visible));
+            if (!succeeded)
+            {
+                int error = Marshal.GetLastPInvokeError();
+                Log.Warning(
+                    $"Failed to {(visible ? "show" : "hide")} taskbar child window " +
+                    $"taskbar=0x{hwndShell.ToInt64():X}, win32Error={error}");
+            }
+
+            return succeeded;
+        }
+
+        internal static uint NativeVisibilityFlags(bool visible)
+            => User32.SWP_NOMOVE
+                | User32.SWP_NOSIZE
+                | User32.SWP_NOZORDER
+                | User32.SWP_NOACTIVATE
+                | (visible ? User32.SWP_SHOWWINDOW : User32.SWP_HIDEWINDOW);
 
         private void AnimateHostOpacity(double to, Action? completed = null)
         {
@@ -2069,7 +2115,7 @@ namespace TaskbarQuota.Taskbar
             try { hostFadeStoryboard?.Stop(); } catch { }
             hostFadeStoryboard = null;
             positionUpdateCancellation.Cancel();
-            try { appWindow?.Hide(); } catch { }
+            try { TrySetNativeVisibility(false); } catch { }
             foreach (var tile in tiles)
             {
                 if (tile is null)

--- a/src/TaskbarQuota.App/Taskbar/WidgetVisibilityPolicy.cs
+++ b/src/TaskbarQuota.App/Taskbar/WidgetVisibilityPolicy.cs
@@ -1,0 +1,153 @@
+using System;
+
+namespace TaskbarQuota.Taskbar;
+
+public enum WidgetVisibilityMode
+{
+    AlwaysShow = 0,
+    ShowWhileAnySupportedAiToolIsOpen = 1,
+    ShowOnlyWhileSupportedAiToolIsInUse = 2,
+}
+
+internal enum WidgetVisibilityOverride
+{
+    Automatic = 0,
+    ForceShow = 1,
+    ForceHide = 2,
+}
+
+internal enum WidgetVisibilityReason
+{
+    ManualForceShow,
+    ManualForceHide,
+    NoValidProvider,
+    AlwaysShow,
+    OpenDesktopApp,
+    OpenCliAgent,
+    ActiveDesktopApp,
+    ActiveCliAgent,
+    ActiveBrowserTab,
+    BackgroundCliAgent,
+    BackgroundDesktopAgent,
+    NoQualifyingSurface,
+    HideDebounce,
+}
+
+internal readonly record struct SupportedSurfaceState(
+    bool DesktopAppPresent,
+    bool DesktopAppActive,
+    bool CliAgentPresent,
+    bool CliAgentActive,
+    bool BrowserTabActive,
+    bool BackgroundAgentRunning = false)
+{
+    public static SupportedSurfaceState None => new(false, false, false, false, false);
+}
+
+internal readonly record struct WidgetVisibilityInput(
+    WidgetVisibilityMode Mode,
+    WidgetVisibilityOverride Override,
+    bool HasValidProvider,
+    bool KeepVisibleWhileBackgroundAgentRunning,
+    SupportedSurfaceState Surfaces);
+
+internal readonly record struct WidgetVisibilityDecision(
+    bool ShouldShowWidget,
+    WidgetVisibilityReason Reason);
+
+internal static class WidgetVisibilityPolicy
+{
+    public static WidgetVisibilityDecision Evaluate(WidgetVisibilityInput input)
+    {
+        if (input.Override == WidgetVisibilityOverride.ForceHide)
+            return new(false, WidgetVisibilityReason.ManualForceHide);
+
+        if (!input.HasValidProvider)
+            return new(false, WidgetVisibilityReason.NoValidProvider);
+
+        if (input.Override == WidgetVisibilityOverride.ForceShow)
+            return new(true, WidgetVisibilityReason.ManualForceShow);
+
+        if (input.Mode == WidgetVisibilityMode.AlwaysShow)
+            return new(true, WidgetVisibilityReason.AlwaysShow);
+
+        var surfaces = input.Surfaces;
+        if (input.Mode == WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen)
+        {
+            if (surfaces.DesktopAppPresent)
+                return new(true, WidgetVisibilityReason.OpenDesktopApp);
+            if (surfaces.CliAgentPresent)
+                return new(true, WidgetVisibilityReason.OpenCliAgent);
+            if (surfaces.BrowserTabActive)
+                return new(true, WidgetVisibilityReason.ActiveBrowserTab);
+
+            return new(false, WidgetVisibilityReason.NoQualifyingSurface);
+        }
+
+        if (surfaces.DesktopAppActive)
+            return new(true, WidgetVisibilityReason.ActiveDesktopApp);
+        if (surfaces.CliAgentActive)
+            return new(true, WidgetVisibilityReason.ActiveCliAgent);
+        if (surfaces.BrowserTabActive)
+            return new(true, WidgetVisibilityReason.ActiveBrowserTab);
+        if (input.KeepVisibleWhileBackgroundAgentRunning)
+        {
+            if (surfaces.BackgroundAgentRunning)
+                return new(true, WidgetVisibilityReason.BackgroundDesktopAgent);
+            if (surfaces.CliAgentPresent)
+                return new(true, WidgetVisibilityReason.BackgroundCliAgent);
+        }
+
+        return new(false, WidgetVisibilityReason.NoQualifyingSurface);
+    }
+}
+
+/// <summary>
+/// Keeps automatic surface transitions from flickering the native host. Showing is immediate; hiding
+/// waits until the same non-qualifying state has been continuous for the configured delay.
+/// </summary>
+internal sealed class WidgetVisibilityStabilizer
+{
+    private readonly TimeSpan _hideDelay;
+    private DateTimeOffset? _hideCandidateSince;
+    private bool _isVisible;
+
+    public WidgetVisibilityStabilizer(TimeSpan? hideDelay = null)
+    {
+        _hideDelay = hideDelay ?? TimeSpan.FromSeconds(2);
+    }
+
+    public WidgetVisibilityDecision Apply(
+        WidgetVisibilityDecision rawDecision,
+        DateTimeOffset now,
+        bool hideImmediately = false)
+    {
+        if (rawDecision.ShouldShowWidget)
+        {
+            _hideCandidateSince = null;
+            _isVisible = true;
+            return rawDecision;
+        }
+
+        if (hideImmediately || !_isVisible)
+        {
+            _hideCandidateSince = null;
+            _isVisible = false;
+            return rawDecision;
+        }
+
+        _hideCandidateSince ??= now;
+        if (now - _hideCandidateSince.Value < _hideDelay)
+            return new(true, WidgetVisibilityReason.HideDebounce);
+
+        _hideCandidateSince = null;
+        _isVisible = false;
+        return rawDecision;
+    }
+
+    public void Reset(bool isVisible)
+    {
+        _hideCandidateSince = null;
+        _isVisible = isVisible;
+    }
+}

--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using TaskbarQuota.ActiveApp;
+using TaskbarQuota.Taskbar;
 using TaskbarQuota.Usage;
 
 namespace TaskbarQuota
@@ -65,7 +66,7 @@ namespace TaskbarQuota
         private DateTime _uiaHoldUntilUtc = DateTime.MinValue;
         private static readonly TimeSpan UiaReconcileWindow = TimeSpan.FromSeconds(10);
         private bool? _lastHasDetectedTool;
-        private DateTime _lastPresenceProbeAt = DateTime.MinValue;
+        private SupportedSurfaceState _supportedSurfaces = SupportedSurfaceState.None;
         private ProviderSource _activeProviderSource = ProviderSource.Unknown;
 
         public UsageService Service => _service;
@@ -80,19 +81,39 @@ namespace TaskbarQuota
         /// (the old code hard-coded <see cref="ProviderId.Codex"/> as the fallback). See issue #7.
         /// </summary>
         public ProviderId? WidgetDisplayProvider
+            => SelectWidgetDisplayProvider(
+                _lastActive,
+                RecentProviders,
+                WidgetSettingsService.LastWidgetProvider,
+                Enum.GetValues<ProviderId>(),
+                WidgetSettingsService.IsProviderVisible,
+                IsProviderAvailable);
+
+        internal static ProviderId? SelectWidgetDisplayProvider(
+            ProviderId? active,
+            IReadOnlyList<ProviderId> recent,
+            ProviderId? persisted,
+            IReadOnlyList<ProviderId> ordered,
+            Func<ProviderId, bool> isVisible,
+            Func<ProviderId, bool> isAvailable)
         {
-            get
-            {
-                if (_lastActive is { } active && WidgetSettingsService.IsProviderVisible(active))
-                    return active;
-                foreach (var p in RecentProviders)
-                    if (WidgetSettingsService.IsProviderVisible(p) && IsProviderAvailable(p))
-                        return p;
-                foreach (ProviderId p in Enum.GetValues<ProviderId>())
-                    if (WidgetSettingsService.IsProviderVisible(p) && IsProviderAvailable(p))
-                        return p;
-                return null;
-            }
+            static bool Eligible(
+                ProviderId provider,
+                Func<ProviderId, bool> visible,
+                Func<ProviderId, bool> available)
+                => visible(provider) && available(provider);
+
+            if (active is { } activeProvider && Eligible(activeProvider, isVisible, isAvailable))
+                return activeProvider;
+            foreach (var provider in recent)
+                if (Eligible(provider, isVisible, isAvailable))
+                    return provider;
+            if (persisted is { } persistedProvider && Eligible(persistedProvider, isVisible, isAvailable))
+                return persistedProvider;
+            foreach (var provider in ordered)
+                if (Eligible(provider, isVisible, isAvailable))
+                    return provider;
+            return null;
         }
 
         /// <summary>
@@ -113,8 +134,8 @@ namespace TaskbarQuota
         /// </summary>
         public IReadOnlyList<ProviderId> WidgetDisplayProviders
             => ComputeWidgetDisplayProviders(
-                _lastActive,
-                IsActiveToolPresent,
+                ActiveWidgetProvider ?? WidgetDisplayProvider,
+                present: true,
                 RecentProviders,
                 Enum.GetValues<ProviderId>(),
                 WidgetSettingsService.IsProviderPinned,
@@ -137,7 +158,7 @@ namespace TaskbarQuota
 
             // The active provider leads even when it is itself pinned — it is the one the user is looking
             // at right now, so it gets the stable leftmost slot and the pinned tiles trail it.
-            if (present && active is { } a && isVisible(a))
+            if (present && active is { } a && isVisible(a) && isAvailable(a))
                 result.Add(a);
 
             var recentIndex = new Dictionary<ProviderId, int>();
@@ -172,7 +193,14 @@ namespace TaskbarQuota
         public ActiveApp.SynaraStateReader.SynaraSelection? ActiveSynaraHost { get; private set; }
         /// <summary>Last usage snapshot pushed to listeners; used to hydrate the taskbar widget if it was created late.</summary>
         public UsageResult? LastState { get; private set; }
-        public bool IsActiveToolPresent => _lastHasDetectedTool ?? _detector.HasAnyKnownToolRunning();
+        public bool IsActiveToolPresent => _lastHasDetectedTool ?? false;
+        internal SupportedSurfaceState SupportedSurfaces => _supportedSurfaces;
+        internal ProviderId? ActiveWidgetProvider =>
+            _supportedSurfaces.DesktopAppActive
+            || _supportedSurfaces.CliAgentActive
+            || _supportedSurfaces.BrowserTabActive
+                ? _lastActive
+                : null;
         public IReadOnlyList<ProviderId> RecentProviders
         {
             get
@@ -185,6 +213,7 @@ namespace TaskbarQuota
         public event Action<UsageResult>? StateChanged;
         public event Action<bool>? ActiveToolPresenceChanged;
         public event Action<ProviderId?>? ActiveProviderChanged;
+        internal event Action<SupportedSurfaceState>? SupportedSurfacesChanged;
 
         public void Start()
         {
@@ -348,7 +377,10 @@ namespace TaskbarQuota
                 var hostChanged = !SameSynaraSelection(previousHost, host);
                 _lastActive = provider;
                 if (providerChanged)
+                {
                     PromoteRecentProvider(provider);
+                    WidgetSettingsService.RememberLastWidgetProvider(provider);
+                }
 
                 if (_lastHasDetectedTool != true)
                 {
@@ -500,6 +532,7 @@ namespace TaskbarQuota
                 _lastActive = target;
                 _activeProviderSource = foregroundSource;
                 PromoteRecentProvider(target);
+                WidgetSettingsService.RememberLastWidgetProvider(target);
 
                 if (previous != target)
                     ActiveProviderChanged?.Invoke(target);
@@ -600,6 +633,7 @@ namespace TaskbarQuota
                 _lastActive = target;
                 _activeProviderSource = _detector.ActiveSource;
                 PromoteRecentProvider(target);
+                WidgetSettingsService.RememberLastWidgetProvider(target);
 
                 if (previous != target)
                     ActiveProviderChanged?.Invoke(target);
@@ -767,11 +801,15 @@ namespace TaskbarQuota
             ProviderId? detected;
             ProviderSource detectedSource;
             SynaraStateReader.SynaraSelection? detectedSynaraHost;
+            SupportedToolPresence detectedPresence;
             try
             {
                 detected = _detector.Detect();
                 detectedSource = _detector.ActiveSource;
                 detectedSynaraHost = _detector.ActiveSynaraHost;
+                bool codexDesktopForeground = detected == ProviderId.Codex
+                    && detectedSource.Kind == ProviderSourceKind.DesktopApp;
+                detectedPresence = _detector.GetSupportedToolPresence(codexDesktopForeground);
             }
             catch (Exception ex)
             {
@@ -817,7 +855,12 @@ namespace TaskbarQuota
                     ClearSynaraHold();
                 }
 
-                var hasDetectedTool = detected != null || ShouldAssumeToolStillRunning() || ProbeToolPresence();
+                var surfaces = ComputeSupportedSurfaces(detectedPresence, detected, detectedSource);
+                UpdateSupportedSurfaces(surfaces);
+
+                var hasDetectedTool = surfaces.DesktopAppPresent
+                    || surfaces.CliAgentPresent
+                    || surfaces.BrowserTabActive;
                 if (!hasDetectedTool)
                 {
                     if (_lastHasDetectedTool != false)
@@ -830,30 +873,32 @@ namespace TaskbarQuota
                         ClearSynaraHold(force: true);
                         ActiveToolPresenceChanged?.Invoke(false);
                     }
-                    return;
                 }
-
-                ProviderId? previousActive = _lastActive;
-                if (detected is ProviderId p)
+                else
                 {
-                    _lastActive = p;
-                    _activeProviderSource = detectedSource;
-                    PromoteRecentProvider(p);
-                    if (previousActive != p)
+                    ProviderId? previousActive = _lastActive;
+                    if (detected is ProviderId p)
                     {
-                        ActiveProviderChanged?.Invoke(p);
-                        PublishImmediateState(p);
+                        _lastActive = p;
+                        _activeProviderSource = detectedSource;
+                        PromoteRecentProvider(p);
+                        WidgetSettingsService.RememberLastWidgetProvider(p);
+                        if (previousActive != p)
+                        {
+                            ActiveProviderChanged?.Invoke(p);
+                            PublishImmediateState(p);
+                        }
+                    }
+
+                    if (_lastHasDetectedTool != true)
+                    {
+                        _lastHasDetectedTool = true;
+                        ActiveToolPresenceChanged?.Invoke(true);
                     }
                 }
 
-                if (detected is null && _lastActive is null)
+                if (detected is null && _lastActive is null && WidgetDisplayProvider is null)
                     return;
-
-                if (_lastHasDetectedTool != true)
-                {
-                    _lastHasDetectedTool = true;
-                    ActiveToolPresenceChanged?.Invoke(true);
-                }
 
                 // Last-active fallback: nothing detected and never had one -> show the first enabled
                 // provider (never a hidden default), but do not make the fallback sticky as the active one.
@@ -931,7 +976,7 @@ namespace TaskbarQuota
         }
 
         private ProviderSource SourceFor(ProviderId provider)
-            => _lastActive == provider ? _activeProviderSource : ProviderSource.Unknown;
+            => ActiveWidgetProvider == provider ? _activeProviderSource : ProviderSource.Unknown;
 
         private static ProviderSource SynaraSource(HostApp host)
             => new(
@@ -984,13 +1029,31 @@ namespace TaskbarQuota
             _synaraHoldUntilUtc = DateTime.MinValue;
         }
 
-        private bool ShouldAssumeToolStillRunning()
-            => _lastHasDetectedTool == true && DateTime.UtcNow - _lastPresenceProbeAt < TimeSpan.FromSeconds(15);
-
-        private bool ProbeToolPresence()
+        private void UpdateSupportedSurfaces(SupportedSurfaceState surfaces)
         {
-            _lastPresenceProbeAt = DateTime.UtcNow;
-            return _detector.HasAnyKnownToolRunning();
+            if (_supportedSurfaces == surfaces)
+                return;
+
+            _supportedSurfaces = surfaces;
+            SupportedSurfacesChanged?.Invoke(surfaces);
+        }
+
+        internal static SupportedSurfaceState ComputeSupportedSurfaces(
+            SupportedToolPresence presence,
+            ProviderId? detected,
+            ProviderSource source)
+        {
+            bool desktopActive = detected is not null
+                && source.Kind is ProviderSourceKind.DesktopApp or ProviderSourceKind.HostApp;
+            bool cliActive = detected is not null && source.Kind == ProviderSourceKind.Cli;
+            bool browserActive = detected is not null && source.Kind == ProviderSourceKind.Browser;
+            return new(
+                presence.DesktopAppPresent || desktopActive,
+                desktopActive,
+                presence.CliAgentPresent || cliActive,
+                cliActive,
+                browserActive,
+                presence.BackgroundAgentRunning);
         }
 
         internal static IReadOnlyList<UsageResult> SortByRecentActivity(

--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -897,12 +897,13 @@ namespace TaskbarQuota
                     }
                 }
 
-                if (detected is null && _lastActive is null && WidgetDisplayProvider is null)
+                var widgetDisplayProvider = WidgetDisplayProvider;
+                if (detected is null && _lastActive is null && widgetDisplayProvider is null)
                     return;
 
                 // Last-active fallback: nothing detected and never had one -> show the first enabled
                 // provider (never a hidden default), but do not make the fallback sticky as the active one.
-                target = _lastActive ?? WidgetDisplayProvider ?? ProviderId.Codex;
+                target = _lastActive ?? widgetDisplayProvider ?? ProviderId.Codex;
             }
             catch (Exception ex)
             {

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml
@@ -82,6 +82,38 @@
             <StackPanel x:Name="ProviderSettingsPanel" Spacing="4"/>
 
             <TextBlock Text="Behavior" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,16,0,2"/>
+            <tk:SettingsCard Header="Widget visibility"
+                             Description="Choose when the taskbar widget appears. TaskbarQuota keeps running while the widget is hidden.">
+                <tk:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE8A7;"/>
+                </tk:SettingsCard.HeaderIcon>
+                <StackPanel MinWidth="300" MaxWidth="420" Spacing="6">
+                    <ComboBox x:Name="WidgetVisibilityCombo"
+                              HorizontalAlignment="Stretch"
+                              SelectionChanged="OnWidgetVisibilityModeChanged">
+                        <ComboBoxItem Content="Always show" Tag="AlwaysShow"/>
+                        <ComboBoxItem Content="Show while any supported AI tool is open" Tag="ShowWhileOpen"/>
+                        <ComboBoxItem Content="Show only while a supported AI tool is in use" Tag="ShowWhileInUse"/>
+                    </ComboBox>
+                    <TextBlock x:Name="WidgetVisibilityDescription"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Opacity="0.75"
+                               TextWrapping="Wrap"/>
+                </StackPanel>
+            </tk:SettingsCard>
+
+            <tk:SettingsCard x:Name="BackgroundAgentVisibilityCard"
+                             Header="Keep visible while an agent is running in the background"
+                             Description="Keep the widget visible while a supported CLI agent is still running or Codex Desktop reports a task in progress, even when its window or terminal is not focused."
+                             Visibility="Collapsed">
+                <tk:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE756;"/>
+                </tk:SettingsCard.HeaderIcon>
+                <ToggleSwitch x:Name="BackgroundAgentVisibilityToggle"
+                              AutomationProperties.Name="Keep visible while an agent is running in the background"
+                              Toggled="OnBackgroundAgentVisibilityToggled"/>
+            </tk:SettingsCard>
+
             <tk:SettingsCard Header="Open at startup" Description="Start TaskbarQuota with Windows and show only the taskbar widget.">
                 <tk:SettingsCard.HeaderIcon>
                     <FontIcon Glyph="&#xE7F4;"/>

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
@@ -44,7 +44,7 @@ namespace TaskbarQuota.Views
                 _ => 0,
             };
             PercentageModeCombo.SelectedIndex = WidgetSettingsService.CurrentPercentageMode == PercentageDisplayMode.Remaining ? 1 : 0;
-            WidgetVisibilityCombo.SelectedIndex = (int)WidgetSettingsService.CurrentVisibilityMode;
+            SelectWidgetVisibilityMode(WidgetSettingsService.CurrentVisibilityMode);
             BackgroundAgentVisibilityToggle.IsOn = WidgetSettingsService.KeepVisibleWhileBackgroundAgentRunning;
             UpdateWidgetVisibilityControls();
             StartupToggle.IsOn = StartupSettingsService.IsEnabled;
@@ -263,13 +263,9 @@ namespace TaskbarQuota.Views
             if (_isInitializing)
                 return;
 
-            var mode = WidgetVisibilityCombo.SelectedIndex switch
-            {
-                0 => WidgetVisibilityMode.AlwaysShow,
-                2 => WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse,
-                _ => WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen,
-            };
+            var mode = SelectedWidgetVisibilityMode();
             WidgetSettingsService.ApplyWidgetVisibilityMode(mode);
+            SelectWidgetVisibilityMode(WidgetSettingsService.CurrentVisibilityMode);
             UpdateWidgetVisibilityControls();
         }
 
@@ -280,16 +276,12 @@ namespace TaskbarQuota.Views
 
             WidgetSettingsService.ApplyKeepVisibleWhileBackgroundAgentRunning(
                 BackgroundAgentVisibilityToggle.IsOn);
+            SyncBackgroundAgentVisibilityToggle();
         }
 
         private void UpdateWidgetVisibilityControls()
         {
-            var mode = WidgetVisibilityCombo.SelectedIndex switch
-            {
-                0 => WidgetVisibilityMode.AlwaysShow,
-                2 => WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse,
-                _ => WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen,
-            };
+            var mode = SelectedWidgetVisibilityMode();
             WidgetVisibilityDescription.Text = mode switch
             {
                 WidgetVisibilityMode.AlwaysShow =>
@@ -306,6 +298,65 @@ namespace TaskbarQuota.Views
                     ? Visibility.Visible
                     : Visibility.Collapsed;
         }
+
+        private WidgetVisibilityMode SelectedWidgetVisibilityMode()
+            => WidgetVisibilityCombo.SelectedItem is ComboBoxItem item
+                ? ParseWidgetVisibilityModeTag(item.Tag as string)
+                : WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen;
+
+        private void SelectWidgetVisibilityMode(WidgetVisibilityMode mode)
+        {
+            string expectedTag = WidgetVisibilityModeTag(mode);
+            bool wasInitializing = _isInitializing;
+            _isInitializing = true;
+            try
+            {
+                foreach (var option in WidgetVisibilityCombo.Items)
+                {
+                    if (option is ComboBoxItem item
+                        && string.Equals(item.Tag as string, expectedTag, System.StringComparison.Ordinal))
+                    {
+                        WidgetVisibilityCombo.SelectedItem = item;
+                        return;
+                    }
+                }
+            }
+            finally
+            {
+                _isInitializing = wasInitializing;
+            }
+        }
+
+        private void SyncBackgroundAgentVisibilityToggle()
+        {
+            bool wasInitializing = _isInitializing;
+            _isInitializing = true;
+            try
+            {
+                BackgroundAgentVisibilityToggle.IsOn =
+                    WidgetSettingsService.KeepVisibleWhileBackgroundAgentRunning;
+            }
+            finally
+            {
+                _isInitializing = wasInitializing;
+            }
+        }
+
+        internal static string WidgetVisibilityModeTag(WidgetVisibilityMode mode)
+            => mode switch
+            {
+                WidgetVisibilityMode.AlwaysShow => "AlwaysShow",
+                WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse => "ShowWhileInUse",
+                _ => "ShowWhileOpen",
+            };
+
+        internal static WidgetVisibilityMode ParseWidgetVisibilityModeTag(string? tag)
+            => tag switch
+            {
+                "AlwaysShow" => WidgetVisibilityMode.AlwaysShow,
+                "ShowWhileInUse" => WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse,
+                _ => WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen,
+            };
 
         private void OnPercentageModeChanged(object sender, SelectionChangedEventArgs e)
         {

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
 using TaskbarQuota.Helpers;
 using TaskbarQuota.Services;
+using TaskbarQuota.Taskbar;
 using TaskbarQuota.Usage;
 using TaskbarQuota.ViewModels;
 
@@ -43,6 +44,9 @@ namespace TaskbarQuota.Views
                 _ => 0,
             };
             PercentageModeCombo.SelectedIndex = WidgetSettingsService.CurrentPercentageMode == PercentageDisplayMode.Remaining ? 1 : 0;
+            WidgetVisibilityCombo.SelectedIndex = (int)WidgetSettingsService.CurrentVisibilityMode;
+            BackgroundAgentVisibilityToggle.IsOn = WidgetSettingsService.KeepVisibleWhileBackgroundAgentRunning;
+            UpdateWidgetVisibilityControls();
             StartupToggle.IsOn = StartupSettingsService.IsEnabled;
             ApplyQuotaAlertSettingsToControls();
             AutoHideUnavailableToggle.IsOn = WidgetSettingsService.AutoHideUnavailable;
@@ -252,6 +256,55 @@ namespace TaskbarQuota.Views
                 return;
 
             StartupSettingsService.Apply(StartupToggle.IsOn);
+        }
+
+        private void OnWidgetVisibilityModeChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isInitializing)
+                return;
+
+            var mode = WidgetVisibilityCombo.SelectedIndex switch
+            {
+                0 => WidgetVisibilityMode.AlwaysShow,
+                2 => WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse,
+                _ => WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen,
+            };
+            WidgetSettingsService.ApplyWidgetVisibilityMode(mode);
+            UpdateWidgetVisibilityControls();
+        }
+
+        private void OnBackgroundAgentVisibilityToggled(object sender, RoutedEventArgs e)
+        {
+            if (_isInitializing)
+                return;
+
+            WidgetSettingsService.ApplyKeepVisibleWhileBackgroundAgentRunning(
+                BackgroundAgentVisibilityToggle.IsOn);
+        }
+
+        private void UpdateWidgetVisibilityControls()
+        {
+            var mode = WidgetVisibilityCombo.SelectedIndex switch
+            {
+                0 => WidgetVisibilityMode.AlwaysShow,
+                2 => WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse,
+                _ => WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen,
+            };
+            WidgetVisibilityDescription.Text = mode switch
+            {
+                WidgetVisibilityMode.AlwaysShow =>
+                    "Show the widget whenever an enabled provider is available.",
+                WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse =>
+                    "Show while a supported app, CLI terminal, or website tab is active. " +
+                    "A background agent counts only when the option below is on.",
+                _ =>
+                    "Show while a supported desktop app or CLI is running. " +
+                    "Websites count only while a supported site is the active browser tab.",
+            };
+            BackgroundAgentVisibilityCard.Visibility =
+                mode == WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
         }
 
         private void OnPercentageModeChanged(object sender, SelectionChangedEventArgs e)

--- a/tests/TaskbarQuota.Tests/ActiveAppDetectorTests.cs
+++ b/tests/TaskbarQuota.Tests/ActiveAppDetectorTests.cs
@@ -142,17 +142,10 @@ public class ActiveAppDetectorTests : IDisposable
     [InlineData("https://grok.com/chat/123", null)]
     [InlineData("https://aistudio.google.com/usage", null)]
     [InlineData("https://gemini.google.com/app", null)]
+    [InlineData("https://example.com/projects/codex-private-prompt", null)]
     [InlineData("https://example.com/", null)]
     public void BrowserActiveTabDetector_TryResolveProviderFromUrl_MapsChatSurfaces(string url, ProviderId? expected)
         => Assert.Equal(expected, BrowserActiveTabDetector.TryResolveProviderFromUrl(url));
-
-    [Theory]
-    [InlineData("ChatGPT — Zen Browser", null)]
-    [InlineData("Claude — Zen Browser", null)]
-    [InlineData("Grok — Zen Browser", null)]
-    [InlineData("Git clone checkout error — Zen Browser", null)]
-    public void BrowserActiveTabDetector_TryResolveProviderFromTitle_DoesNotInferFromPrivateTitleText(string title, ProviderId? expected)
-        => Assert.Equal(expected, BrowserActiveTabDetector.TryResolveProviderFromTitle(title));
 
     [Theory]
     [InlineData("chrome", "Chrome")]
@@ -239,17 +232,41 @@ public class ActiveAppDetectorTests : IDisposable
     }
 
     [Theory]
-    [InlineData("gh.exe", "gh copilot suggest")]
-    [InlineData("gh.exe", @"C:\Tools\gh.exe copilot explain")]
-    [InlineData("gh.exe", "\"C:\\Program Files\\GitHub CLI\\gh.exe\" copilot suggest")]
-    [InlineData("cmd.exe", @"cmd.exe /c C:\Tools\codex.cmd")]
-    public void TryDetectCliProvider_ExplicitCommandSignatures_ReturnProvider(string processName, string commandLine)
+    [InlineData("gh.exe", "gh copilot suggest", ProviderId.Copilot)]
+    [InlineData("gh.exe", @"C:\Tools\gh.exe copilot explain", ProviderId.Copilot)]
+    [InlineData("gh.exe", "\"C:\\Program Files\\GitHub CLI\\gh.exe\" copilot suggest", ProviderId.Copilot)]
+    [InlineData("cmd.exe", @"cmd.exe /c C:\Tools\codex.cmd", ProviderId.Codex)]
+    public void TryDetectCliProvider_ExplicitCommandSignatures_ReturnProvider(
+        string processName,
+        string commandLine,
+        ProviderId expected)
     {
-        var expected = processName.StartsWith("gh", StringComparison.OrdinalIgnoreCase)
-            ? ProviderId.Copilot
-            : ProviderId.Codex;
-
         Assert.Equal(expected, ActiveAppDetector.TryDetectCliProvider(processName, commandLine));
+    }
+
+    [Theory]
+    [InlineData(4L, 4L, true)]
+    [InlineData(5L, 4L, false)]
+    public void IsCurrentCliPresenceProbeResult_RejectsStaleSnapshots(
+        long currentVersion,
+        long completedVersion,
+        bool expected)
+        => Assert.Equal(
+            expected,
+            ActiveAppDetector.IsCurrentCliPresenceProbeResult(
+                currentVersion,
+                completedVersion));
+
+    [Fact]
+    public void TryBeginSingleProbe_AllowsOnlyOneProbeUntilReleased()
+    {
+        int inFlight = 0;
+
+        Assert.True(ActiveAppDetector.TryBeginSingleProbe(ref inFlight));
+        Assert.False(ActiveAppDetector.TryBeginSingleProbe(ref inFlight));
+
+        System.Threading.Interlocked.Exchange(ref inFlight, 0);
+        Assert.True(ActiveAppDetector.TryBeginSingleProbe(ref inFlight));
     }
 
     [Fact]

--- a/tests/TaskbarQuota.Tests/ActiveAppDetectorTests.cs
+++ b/tests/TaskbarQuota.Tests/ActiveAppDetectorTests.cs
@@ -148,10 +148,10 @@ public class ActiveAppDetectorTests : IDisposable
 
     [Theory]
     [InlineData("ChatGPT — Zen Browser", null)]
-    [InlineData("Claude — Zen Browser", ProviderId.Claude)]
+    [InlineData("Claude — Zen Browser", null)]
     [InlineData("Grok — Zen Browser", null)]
     [InlineData("Git clone checkout error — Zen Browser", null)]
-    public void BrowserActiveTabDetector_TryResolveProviderFromTitle_MapsKnownChatTitles(string title, ProviderId? expected)
+    public void BrowserActiveTabDetector_TryResolveProviderFromTitle_DoesNotInferFromPrivateTitleText(string title, ProviderId? expected)
         => Assert.Equal(expected, BrowserActiveTabDetector.TryResolveProviderFromTitle(title));
 
     [Theory]
@@ -222,6 +222,99 @@ public class ActiveAppDetectorTests : IDisposable
     {
         var result = ActiveAppDetector.TryDetectCliProvider(processName, commandLine);
         Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("gh.exe", "gh auth status")]
+    [InlineData("gh.exe", "gh pr view 123")]
+    [InlineData("node.exe", @"node C:\src\codex\scripts\status.js")]
+    [InlineData("node.exe", @"node C:\src\claude\index.js")]
+    [InlineData("node.exe", @"node C:\src\opencode\tools\build.js")]
+    [InlineData("node.exe", @"node C:\src\cursor-agent\index.js")]
+    [InlineData("node.exe", @"node C:\src\github-copilot\index.js")]
+    [InlineData("cmd.exe", "cmd.exe /c echo codex")]
+    public void TryDetectCliProvider_GenericCommandsAndProjectPaths_ReturnNull(string processName, string commandLine)
+    {
+        Assert.Null(ActiveAppDetector.TryDetectCliProvider(processName, commandLine));
+    }
+
+    [Theory]
+    [InlineData("gh.exe", "gh copilot suggest")]
+    [InlineData("gh.exe", @"C:\Tools\gh.exe copilot explain")]
+    [InlineData("gh.exe", "\"C:\\Program Files\\GitHub CLI\\gh.exe\" copilot suggest")]
+    [InlineData("cmd.exe", @"cmd.exe /c C:\Tools\codex.cmd")]
+    public void TryDetectCliProvider_ExplicitCommandSignatures_ReturnProvider(string processName, string commandLine)
+    {
+        var expected = processName.StartsWith("gh", StringComparison.OrdinalIgnoreCase)
+            ? ProviderId.Copilot
+            : ProviderId.Codex;
+
+        Assert.Equal(expected, ActiveAppDetector.TryDetectCliProvider(processName, commandLine));
+    }
+
+    [Fact]
+    public void HasTerminalRelationship_RequiresShellOrTerminalAncestry()
+    {
+        var parents = new Dictionary<int, int>
+        {
+            [30] = 20,
+            [20] = 10,
+            [10] = 0,
+            [40] = 1,
+        };
+        var names = new Dictionary<int, string>
+        {
+            [30] = "node",
+            [20] = "pwsh",
+            [10] = "windowsterminal",
+            [40] = "node",
+            [1] = "explorer",
+        };
+
+        Assert.True(ActiveAppDetector.HasTerminalRelationship(30, 20, parents, names));
+        Assert.False(ActiveAppDetector.HasTerminalRelationship(40, 1, parents, names));
+    }
+
+    [Fact]
+    public void HasTerminalRelationship_DoesNotTreatCodexDesktopHelperAsItsOwnTerminal()
+    {
+        var parents = new Dictionary<int, int>
+        {
+            [30] = 20,
+            [20] = 10,
+            [10] = 1,
+            [1] = 0,
+        };
+        var names = new Dictionary<int, string>
+        {
+            [30] = "node",
+            [20] = "codex",
+            [10] = "chatgpt",
+            [1] = "explorer",
+        };
+
+        Assert.False(ActiveAppDetector.HasTerminalRelationship(20, 10, parents, names));
+        Assert.False(ActiveAppDetector.HasTerminalRelationship(30, 20, parents, names));
+    }
+
+    [Fact]
+    public void HasTerminalRelationship_AllowsCodexCliUnderAShell()
+    {
+        var parents = new Dictionary<int, int>
+        {
+            [30] = 20,
+            [20] = 10,
+            [10] = 0,
+        };
+        var names = new Dictionary<int, string>
+        {
+            [30] = "node",
+            [20] = "codex",
+            [10] = "pwsh",
+        };
+
+        Assert.True(ActiveAppDetector.HasTerminalRelationship(20, 10, parents, names));
+        Assert.True(ActiveAppDetector.HasTerminalRelationship(30, 20, parents, names));
     }
 
     [Fact]
@@ -1069,5 +1162,44 @@ public class ActiveAppDetectorTests : IDisposable
             allCandidates, foregroundTree, foregroundIsWindowsTerminal: true,
             sessionRootPid: 148228, parents, "? Replace mistake detector with FastConformer streaming model");
         Assert.Equal(ProviderId.Claude, unrelatedTitle);
+    }
+
+    [Fact]
+    public void BackgroundAgentPresenceRefreshesImmediatelyWhenCodexLosesForeground()
+    {
+        var now = new DateTime(2026, 7, 28, 12, 0, 0, DateTimeKind.Utc);
+
+        Assert.True(ActiveAppDetector.ShouldRefreshBackgroundAgentPresence(
+            now,
+            cacheAt: now.AddMilliseconds(-100),
+            retryUntil: DateTime.MinValue,
+            codexDesktopLostForeground: true));
+    }
+
+    [Fact]
+    public void BackgroundAgentPresenceRetriesTransitionMissesWithoutPollingSteadyIdleState()
+    {
+        var now = new DateTime(2026, 7, 28, 12, 0, 0, DateTimeKind.Utc);
+
+        Assert.False(ActiveAppDetector.ShouldRefreshBackgroundAgentPresence(
+            now,
+            cacheAt: now.AddMilliseconds(-499),
+            retryUntil: now.AddSeconds(2),
+            codexDesktopLostForeground: false));
+        Assert.True(ActiveAppDetector.ShouldRefreshBackgroundAgentPresence(
+            now,
+            cacheAt: now.AddMilliseconds(-500),
+            retryUntil: now.AddSeconds(2),
+            codexDesktopLostForeground: false));
+        Assert.False(ActiveAppDetector.ShouldRefreshBackgroundAgentPresence(
+            now,
+            cacheAt: now.AddSeconds(-2),
+            retryUntil: DateTime.MinValue,
+            codexDesktopLostForeground: false));
+        Assert.True(ActiveAppDetector.ShouldRefreshBackgroundAgentPresence(
+            now,
+            cacheAt: now.AddSeconds(-5),
+            retryUntil: DateTime.MinValue,
+            codexDesktopLostForeground: false));
     }
 }

--- a/tests/TaskbarQuota.Tests/CodexDesktopActivityDetectorTests.cs
+++ b/tests/TaskbarQuota.Tests/CodexDesktopActivityDetectorTests.cs
@@ -30,6 +30,10 @@ public sealed class CodexDesktopActivityDetectorTests
     [InlineData("Stop generating", "size-token-button-composer", true)]
     [InlineData("Detener", "size-token-button-composer bg-token-foreground", true)]
     [InlineData("Detener generación", "size-token-button-composer", true)]
+    [InlineData("Interrupt", "size-token-button-composer", true)]
+    [InlineData("Interrumpir", "size-token-button-composer", true)]
+    [InlineData("Detener la tarea", "size-token-button-composer", true)]
+    [InlineData("Stopped", "size-token-button-composer", false)]
     [InlineData("Stop", "sidebar-item", false)]
     [InlineData("Send", "size-token-button-composer", false)]
     [InlineData(null, "size-token-button-composer", false)]
@@ -40,4 +44,18 @@ public sealed class CodexDesktopActivityDetectorTests
         => Assert.Equal(
             expected,
             CodexDesktopActivityDetector.IsRunningComposerButton(name, className));
+
+    [Fact]
+    public void ShouldLogProbeFailure_RateLimitsRepeatedErrors()
+    {
+        var first = new DateTime(2026, 7, 29, 12, 0, 0, DateTimeKind.Utc);
+
+        Assert.True(CodexDesktopActivityDetector.ShouldLogProbeFailure(first, DateTime.MinValue));
+        Assert.False(CodexDesktopActivityDetector.ShouldLogProbeFailure(
+            first.AddSeconds(30),
+            first));
+        Assert.True(CodexDesktopActivityDetector.ShouldLogProbeFailure(
+            first.AddMinutes(1),
+            first));
+    }
 }

--- a/tests/TaskbarQuota.Tests/CodexDesktopActivityDetectorTests.cs
+++ b/tests/TaskbarQuota.Tests/CodexDesktopActivityDetectorTests.cs
@@ -1,0 +1,43 @@
+using TaskbarQuota.ActiveApp;
+
+namespace TaskbarQuota.Tests;
+
+public sealed class CodexDesktopActivityDetectorTests
+{
+    [Theory]
+    [InlineData("cursor-grab active:cursor-grabbing", true)]
+    [InlineData("active:cursor-grabbing cursor-grab other", true)]
+    [InlineData("cursor-grab", false)]
+    [InlineData("active:cursor-grabbing", false)]
+    [InlineData(null, false)]
+    public void IsTaskRowClass_RequiresBothStructuralTokens(string? className, bool expected)
+        => Assert.Equal(expected, CodexDesktopActivityDetector.IsTaskRowClass(className));
+
+    [Theory]
+    [InlineData("icon-xs shrink-0", true)]
+    [InlineData("shrink-0 icon-xs", true)]
+    [InlineData("icon-2xs text-token-description-foreground no-drag shrink-0", false)]
+    [InlineData("icon-xs no-drag shrink-0", false)]
+    [InlineData("icon-xs", false)]
+    [InlineData(null, false)]
+    public void IsRunningTaskStatusClass_SeparatesRunningFromIdleRows(
+        string? className,
+        bool expected)
+        => Assert.Equal(expected, CodexDesktopActivityDetector.IsRunningTaskStatusClass(className));
+
+    [Theory]
+    [InlineData("Stop", "size-token-button-composer bg-token-foreground", true)]
+    [InlineData("Stop generating", "size-token-button-composer", true)]
+    [InlineData("Detener", "size-token-button-composer bg-token-foreground", true)]
+    [InlineData("Detener generación", "size-token-button-composer", true)]
+    [InlineData("Stop", "sidebar-item", false)]
+    [InlineData("Send", "size-token-button-composer", false)]
+    [InlineData(null, "size-token-button-composer", false)]
+    public void IsRunningComposerButton_RequiresStopLabelAndComposerControl(
+        string? name,
+        string? className,
+        bool expected)
+        => Assert.Equal(
+            expected,
+            CodexDesktopActivityDetector.IsRunningComposerButton(name, className));
+}

--- a/tests/TaskbarQuota.Tests/ProviderDiscoveryServiceTests.cs
+++ b/tests/TaskbarQuota.Tests/ProviderDiscoveryServiceTests.cs
@@ -3,7 +3,8 @@ using TaskbarQuota.Usage;
 
 namespace TaskbarQuota.Tests;
 
-public class ProviderDiscoveryServiceTests
+[Collection(ProviderInstallDetectorTestCollection.Name)]
+public class ProviderDiscoveryServiceTests : IDisposable
 {
     public ProviderDiscoveryServiceTests()
     {
@@ -12,6 +13,12 @@ public class ProviderDiscoveryServiceTests
         WidgetSettingsService.ResetDashboardProviderVisibilityForTesting();
         WidgetSettingsService.ApplyAutoHideUnavailable(true);
         ProviderInstallDetector.IsInstalledOverrideForTesting = _ => false;
+        ProviderInstallDetector.ResetCliCacheForTesting();
+    }
+
+    public void Dispose()
+    {
+        ProviderInstallDetector.IsInstalledOverrideForTesting = null;
         ProviderInstallDetector.ResetCliCacheForTesting();
     }
 

--- a/tests/TaskbarQuota.Tests/ProviderInstallDetectorEligibilityTests.cs
+++ b/tests/TaskbarQuota.Tests/ProviderInstallDetectorEligibilityTests.cs
@@ -1,0 +1,57 @@
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.Tests;
+
+[Collection(ProviderInstallDetectorTestCollection.Name)]
+public sealed class ProviderInstallDetectorEligibilityTests
+{
+    [Fact]
+    public void ZaiApiKeyMakesProviderEligibleBeforeCliWarmup()
+        => WithEnvironmentVariable(
+            "Z_AI_API_KEY",
+            "test-key",
+            () => Assert.True(ProviderInstallDetector.IsInstalled(ProviderId.Zai)));
+
+    [Fact]
+    public void KimiApiKeyMakesProviderEligibleBeforeCliWarmup()
+        => WithEnvironmentVariable(
+            "KIMI_CODE_API_KEY",
+            "test-key",
+            () => Assert.True(ProviderInstallDetector.IsInstalled(ProviderId.Kimi)));
+
+    [Fact]
+    public void UnknownProviderValueIsNotAssumedInstalled()
+    {
+        var originalOverride = ProviderInstallDetector.IsInstalledOverrideForTesting;
+        try
+        {
+            ProviderInstallDetector.IsInstalledOverrideForTesting = null;
+            ProviderInstallDetector.ResetCliCacheForTesting();
+            Assert.False(ProviderInstallDetector.IsInstalled((ProviderId)999));
+        }
+        finally
+        {
+            ProviderInstallDetector.IsInstalledOverrideForTesting = originalOverride;
+            ProviderInstallDetector.ResetCliCacheForTesting();
+        }
+    }
+
+    private static void WithEnvironmentVariable(string name, string value, Action assertion)
+    {
+        string? original = Environment.GetEnvironmentVariable(name);
+        var originalOverride = ProviderInstallDetector.IsInstalledOverrideForTesting;
+        try
+        {
+            Environment.SetEnvironmentVariable(name, value);
+            ProviderInstallDetector.IsInstalledOverrideForTesting = null;
+            ProviderInstallDetector.ResetCliCacheForTesting();
+            assertion();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(name, original);
+            ProviderInstallDetector.IsInstalledOverrideForTesting = originalOverride;
+            ProviderInstallDetector.ResetCliCacheForTesting();
+        }
+    }
+}

--- a/tests/TaskbarQuota.Tests/ProviderInstallDetectorTestCollection.cs
+++ b/tests/TaskbarQuota.Tests/ProviderInstallDetectorTestCollection.cs
@@ -1,0 +1,7 @@
+namespace TaskbarQuota.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class ProviderInstallDetectorTestCollection
+{
+    public const string Name = "Provider install detector";
+}

--- a/tests/TaskbarQuota.Tests/TaskBarManagerTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskBarManagerTests.cs
@@ -1,0 +1,21 @@
+using TaskbarQuota.Taskbar;
+
+namespace TaskbarQuota.Tests;
+
+public class TaskBarManagerTests
+{
+    [Fact]
+    public void CreateStableSnapshot_ReentrantCallDoesNotMutateEarlierSnapshot()
+    {
+        var source = new List<int> { 1, 2 };
+        var outerSnapshot = TaskBarManager.CreateStableSnapshot(source);
+
+        source.Clear();
+        source.Add(3);
+        var nestedSnapshot = TaskBarManager.CreateStableSnapshot(source);
+
+        Assert.Equal([1, 2], outerSnapshot);
+        Assert.Equal([3], nestedSnapshot);
+        Assert.NotSame(outerSnapshot, nestedSnapshot);
+    }
+}

--- a/tests/TaskbarQuota.Tests/TaskBarWidgetGapTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskBarWidgetGapTests.cs
@@ -20,6 +20,34 @@ public class TaskBarWidgetGapTests
         Assert.NotEqual(0u, result & (uint)WindowStyles.WS_CHILD);
     }
 
+    [Theory]
+    [InlineData(0u, 5, true)]
+    [InlineData(0u, 0, false)]
+    [InlineData(0x94000000u, 5, false)]
+    public void IsGetWindowLongFailure_RequiresZeroStyleAndWin32Error(
+        uint style,
+        int error,
+        bool expected)
+        => Assert.Equal(expected, TaskBarWidget.IsGetWindowLongFailure(style, error));
+
+    [Theory]
+    [InlineData(true, User32.SWP_SHOWWINDOW, User32.SWP_HIDEWINDOW)]
+    [InlineData(false, User32.SWP_HIDEWINDOW, User32.SWP_SHOWWINDOW)]
+    public void NativeVisibilityFlags_ChangesOnlyTheChildWindowShowState(
+        bool visible,
+        uint expectedVisibilityFlag,
+        uint oppositeVisibilityFlag)
+    {
+        uint result = TaskBarWidget.NativeVisibilityFlags(visible);
+
+        Assert.NotEqual(0u, result & expectedVisibilityFlag);
+        Assert.Equal(0u, result & oppositeVisibilityFlag);
+        Assert.NotEqual(0u, result & User32.SWP_NOMOVE);
+        Assert.NotEqual(0u, result & User32.SWP_NOSIZE);
+        Assert.NotEqual(0u, result & User32.SWP_NOZORDER);
+        Assert.NotEqual(0u, result & User32.SWP_NOACTIVATE);
+    }
+
     [Fact]
     public void ShouldReposition_BeforeFirstPlacement_IsTrueWithoutOverflowing()
     {

--- a/tests/TaskbarQuota.Tests/TaskBarWidgetGapTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskBarWidgetGapTests.cs
@@ -9,6 +9,18 @@ public class TaskBarWidgetGapTests
     private static RECT R(int left, int right) => new() { left = left, top = 0, right = right, bottom = 40 };
 
     [Fact]
+    public void ConvertToTaskbarChildStyle_ReplacesPopupAndPreservesOtherBits()
+    {
+        const uint visibleClipSiblingsPopup = 0x94000000;
+
+        uint result = TaskBarWidget.ConvertToTaskbarChildStyle(visibleClipSiblingsPopup);
+
+        Assert.Equal(0x54000000u, result);
+        Assert.Equal(0u, result & (uint)WindowStyles.WS_POPUP);
+        Assert.NotEqual(0u, result & (uint)WindowStyles.WS_CHILD);
+    }
+
+    [Fact]
     public void ShouldReposition_BeforeFirstPlacement_IsTrueWithoutOverflowing()
     {
         // offsetX == 0 used to make `Math.Abs(int.MinValue - 0)` throw OverflowException,

--- a/tests/TaskbarQuota.Tests/WidgetDisplayProvidersTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetDisplayProvidersTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using TaskbarQuota.ActiveApp;
+using TaskbarQuota.Taskbar;
 using TaskbarQuota.Usage;
 
 namespace TaskbarQuota.Tests;
@@ -122,5 +124,93 @@ public class WidgetDisplayProvidersTests
             fallback: ProviderId.Codex);
 
         Assert.Empty(result);
+    }
+
+    [Fact]
+    public void DisplayProviderSelectionUsesEligibleRecentThenPersistedProvider()
+    {
+        var fromRecent = UsageCoordinator.SelectWidgetDisplayProvider(
+            active: ProviderId.Codex,
+            recent: new[] { ProviderId.Claude },
+            persisted: ProviderId.Cursor,
+            ordered: Enum.GetValues<ProviderId>(),
+            isVisible: _ => true,
+            isAvailable: provider => provider is ProviderId.Claude or ProviderId.Cursor);
+        var fromPersisted = UsageCoordinator.SelectWidgetDisplayProvider(
+            active: ProviderId.Codex,
+            recent: Array.Empty<ProviderId>(),
+            persisted: ProviderId.Cursor,
+            ordered: Enum.GetValues<ProviderId>(),
+            isVisible: _ => true,
+            isAvailable: provider => provider == ProviderId.Cursor);
+
+        Assert.Equal(ProviderId.Claude, fromRecent);
+        Assert.Equal(ProviderId.Cursor, fromPersisted);
+    }
+
+    [Fact]
+    public void DisplayProviderSelectionReturnsNullWhenNoProviderIsEligible()
+    {
+        var result = UsageCoordinator.SelectWidgetDisplayProvider(
+            active: ProviderId.Codex,
+            recent: new[] { ProviderId.Claude },
+            persisted: ProviderId.Cursor,
+            ordered: Enum.GetValues<ProviderId>(),
+            isVisible: _ => true,
+            isAvailable: _ => false);
+
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData(ProviderSourceKind.DesktopApp, true, false, false)]
+    [InlineData(ProviderSourceKind.HostApp, true, false, false)]
+    [InlineData(ProviderSourceKind.Cli, false, true, false)]
+    [InlineData(ProviderSourceKind.Browser, false, false, true)]
+    public void SupportedSurfaceStateSeparatesForegroundCategory(
+        ProviderSourceKind sourceKind,
+        bool desktopActive,
+        bool cliActive,
+        bool browserActive)
+    {
+        var state = UsageCoordinator.ComputeSupportedSurfaces(
+            new SupportedToolPresence(false, false),
+            ProviderId.Claude,
+            new ProviderSource(sourceKind));
+
+        Assert.Equal(desktopActive, state.DesktopAppActive);
+        Assert.Equal(cliActive, state.CliAgentActive);
+        Assert.Equal(browserActive, state.BrowserTabActive);
+    }
+
+    [Fact]
+    public void SupportedSurfaceStateKeepsBackgroundCliSeparateFromForeground()
+    {
+        var state = UsageCoordinator.ComputeSupportedSurfaces(
+            new SupportedToolPresence(false, true),
+            detected: null,
+            ProviderSource.Unknown);
+
+        Assert.True(state.CliAgentPresent);
+        Assert.False(state.CliAgentActive);
+        Assert.False(state.BrowserTabActive);
+    }
+
+    [Fact]
+    public void SupportedSurfaceStateCarriesBackgroundDesktopAgentSeparately()
+    {
+        var state = UsageCoordinator.ComputeSupportedSurfaces(
+            new SupportedToolPresence(
+                DesktopAppPresent: true,
+                CliAgentPresent: false,
+                BackgroundAgentRunning: true),
+            detected: null,
+            ProviderSource.Unknown);
+
+        Assert.True(state.DesktopAppPresent);
+        Assert.True(state.BackgroundAgentRunning);
+        Assert.False(state.DesktopAppActive);
+        Assert.False(state.CliAgentPresent);
+        Assert.False(state.CliAgentActive);
     }
 }

--- a/tests/TaskbarQuota.Tests/WidgetStateStoreTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetStateStoreTests.cs
@@ -1,0 +1,89 @@
+using TaskbarQuota.Taskbar;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.Tests;
+
+public sealed class WidgetStateStoreTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        "TaskbarQuota.Tests",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void MissingFilesUseSafeDefaults()
+    {
+        var store = new WidgetStateStore(_directory);
+
+        Assert.Equal(WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen, store.LoadVisibilityMode());
+        Assert.False(store.LoadKeepVisibleWhileBackgroundCliAgentRunning());
+        Assert.Null(store.LoadLastProvider());
+    }
+
+    [Fact]
+    public void ValuesRoundTrip()
+    {
+        var store = new WidgetStateStore(_directory);
+
+        Assert.True(store.SaveVisibilityMode(WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse));
+        Assert.True(store.SaveKeepVisibleWhileBackgroundCliAgentRunning(true));
+        Assert.True(store.SaveLastProvider(ProviderId.Claude));
+
+        var reloaded = new WidgetStateStore(_directory);
+        Assert.Equal(WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse, reloaded.LoadVisibilityMode());
+        Assert.True(reloaded.LoadKeepVisibleWhileBackgroundCliAgentRunning());
+        Assert.Equal(ProviderId.Claude, reloaded.LoadLastProvider());
+        Assert.DoesNotContain(
+            Directory.EnumerateFiles(_directory),
+            path => Path.GetFileName(path).Contains("override", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("999")]
+    public void InvalidVisibilityModeFallsBack(string value)
+    {
+        Directory.CreateDirectory(_directory);
+        File.WriteAllText(Path.Combine(_directory, "widget-visibility-policy.txt"), value);
+
+        var store = new WidgetStateStore(_directory);
+
+        Assert.Equal(WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen, store.LoadVisibilityMode());
+    }
+
+    [Fact]
+    public void InvalidProviderIsIgnored()
+    {
+        Directory.CreateDirectory(_directory);
+        File.WriteAllText(Path.Combine(_directory, "last-widget-provider.txt"), "UnknownProvider");
+
+        Assert.Null(new WidgetStateStore(_directory).LoadLastProvider());
+    }
+
+    [Fact]
+    public void WriteFailureIsReportedWithoutThrowing()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_directory)!);
+        File.WriteAllText(_directory, "This path is intentionally a file.");
+        var store = new WidgetStateStore(_directory);
+
+        Assert.False(store.SaveVisibilityMode(WidgetVisibilityMode.AlwaysShow));
+        Assert.False(store.SaveKeepVisibleWhileBackgroundCliAgentRunning(true));
+        Assert.False(store.SaveLastProvider(ProviderId.Codex));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_directory))
+                Directory.Delete(_directory, recursive: true);
+            else if (File.Exists(_directory))
+                File.Delete(_directory);
+        }
+        catch
+        {
+            // Test cleanup is best effort.
+        }
+    }
+}

--- a/tests/TaskbarQuota.Tests/WidgetSummaryRevealTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetSummaryRevealTests.cs
@@ -34,4 +34,21 @@ public class WidgetSummaryRevealTests
 
         Assert.True(WidgetSummary.HasSameRenderedContentForTesting(result, foreground));
     }
+
+    [Fact]
+    public void SourceAwareTooltipBuilderUsesTheCurrentSource()
+    {
+        static string Build(ProviderSource source)
+            => source.IsKnown ? $"Codex {source.ShortViaText}: unavailable" : "Codex: unavailable";
+
+        var desktop = new ProviderSource(ProviderSourceKind.DesktopApp, "Codex", "desktop");
+        var terminal = new ProviderSource(ProviderSourceKind.Cli, "PowerShell", "terminal");
+
+        Assert.Equal(
+            "Codex via Codex: unavailable",
+            WidgetSummary.BuildTooltipForSource(Build, desktop));
+        Assert.Equal(
+            "Codex via PowerShell: unavailable",
+            WidgetSummary.BuildTooltipForSource(Build, terminal));
+    }
 }

--- a/tests/TaskbarQuota.Tests/WidgetSummaryRevealTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetSummaryRevealTests.cs
@@ -1,4 +1,5 @@
 using TaskbarQuota.Controls;
+using TaskbarQuota.Usage;
 
 namespace TaskbarQuota.Tests;
 
@@ -23,4 +24,14 @@ public class WidgetSummaryRevealTests
     [Fact]
     public void LeavesLaterRendersAlone()
         => Assert.False(WidgetSummary.ShouldRevealWithoutTransition(isFirstReveal: false, isActiveToolVisible: true));
+
+    [Fact]
+    public void SourceBadgeChangeDoesNotInvalidateRenderedUsageContent()
+    {
+        var result = UsageResult.Failure(ProviderId.Codex, "Unavailable");
+        var foreground = result.WithSource(
+            new ProviderSource(ProviderSourceKind.DesktopApp, "Codex", "desktop"));
+
+        Assert.True(WidgetSummary.HasSameRenderedContentForTesting(result, foreground));
+    }
 }

--- a/tests/TaskbarQuota.Tests/WidgetVisibilityPolicyTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetVisibilityPolicyTests.cs
@@ -1,0 +1,204 @@
+using TaskbarQuota.Taskbar;
+
+namespace TaskbarQuota.Tests;
+
+public sealed class WidgetVisibilityPolicyTests
+{
+    public static IEnumerable<object[]> AutomaticCases =>
+        new[]
+        {
+            new object[] { WidgetVisibilityMode.AlwaysShow, SupportedSurfaceState.None, true, WidgetVisibilityReason.AlwaysShow },
+            new object[]
+            {
+                WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen,
+                new SupportedSurfaceState(true, false, false, false, false),
+                true,
+                WidgetVisibilityReason.OpenDesktopApp
+            },
+            new object[]
+            {
+                WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen,
+                new SupportedSurfaceState(false, false, true, false, false),
+                true,
+                WidgetVisibilityReason.OpenCliAgent
+            },
+            new object[]
+            {
+                WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen,
+                new SupportedSurfaceState(false, false, false, false, true),
+                true,
+                WidgetVisibilityReason.ActiveBrowserTab
+            },
+            new object[]
+            {
+                WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse,
+                new SupportedSurfaceState(true, false, false, false, false),
+                false,
+                WidgetVisibilityReason.NoQualifyingSurface
+            },
+            new object[]
+            {
+                WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse,
+                new SupportedSurfaceState(false, true, false, false, false),
+                true,
+                WidgetVisibilityReason.ActiveDesktopApp
+            },
+            new object[]
+            {
+                WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse,
+                new SupportedSurfaceState(false, false, true, true, false),
+                true,
+                WidgetVisibilityReason.ActiveCliAgent
+            },
+            new object[]
+            {
+                WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse,
+                new SupportedSurfaceState(false, false, false, false, true),
+                true,
+                WidgetVisibilityReason.ActiveBrowserTab
+            },
+        };
+
+    [Theory]
+    [MemberData(nameof(AutomaticCases))]
+    public void AutomaticPolicyUsesExpectedSurface(
+        object modeValue,
+        object surfacesValue,
+        bool expectedVisible,
+        object expectedReasonValue)
+    {
+        var mode = Assert.IsType<WidgetVisibilityMode>(modeValue);
+        var surfaces = Assert.IsType<SupportedSurfaceState>(surfacesValue);
+        var expectedReason = Assert.IsType<WidgetVisibilityReason>(expectedReasonValue);
+        var result = Evaluate(mode, WidgetVisibilityOverride.Automatic, surfaces);
+
+        Assert.Equal(expectedVisible, result.ShouldShowWidget);
+        Assert.Equal(expectedReason, result.Reason);
+    }
+
+    [Fact]
+    public void ForceHideWinsEvenWithoutAProvider()
+    {
+        var result = Evaluate(
+            WidgetVisibilityMode.AlwaysShow,
+            WidgetVisibilityOverride.ForceHide,
+            SupportedSurfaceState.None,
+            hasValidProvider: false);
+
+        Assert.False(result.ShouldShowWidget);
+        Assert.Equal(WidgetVisibilityReason.ManualForceHide, result.Reason);
+    }
+
+    [Fact]
+    public void ForceShowIsRetainedButCannotShowWithoutAValidProvider()
+    {
+        var unavailable = Evaluate(
+            WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse,
+            WidgetVisibilityOverride.ForceShow,
+            SupportedSurfaceState.None,
+            hasValidProvider: false);
+        var available = Evaluate(
+            WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse,
+            WidgetVisibilityOverride.ForceShow,
+            SupportedSurfaceState.None);
+
+        Assert.Equal(new(false, WidgetVisibilityReason.NoValidProvider), unavailable);
+        Assert.Equal(new(true, WidgetVisibilityReason.ManualForceShow), available);
+    }
+
+    [Fact]
+    public void BackgroundCliOptionOnlyAffectsInUseMode()
+    {
+        var surfaces = new SupportedSurfaceState(false, false, true, false, false);
+
+        var disabled = Evaluate(
+            WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse,
+            WidgetVisibilityOverride.Automatic,
+            surfaces);
+        var enabled = Evaluate(
+            WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse,
+            WidgetVisibilityOverride.Automatic,
+            surfaces,
+            backgroundAgent: true);
+
+        Assert.False(disabled.ShouldShowWidget);
+        Assert.Equal(new(true, WidgetVisibilityReason.BackgroundCliAgent), enabled);
+    }
+
+    [Fact]
+    public void BackgroundAgentOptionIncludesRunningCodexDesktopTurn()
+    {
+        var surfaces = new SupportedSurfaceState(
+            DesktopAppPresent: true,
+            DesktopAppActive: false,
+            CliAgentPresent: false,
+            CliAgentActive: false,
+            BrowserTabActive: false,
+            BackgroundAgentRunning: true);
+
+        var disabled = Evaluate(
+            WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse,
+            WidgetVisibilityOverride.Automatic,
+            surfaces);
+        var enabled = Evaluate(
+            WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse,
+            WidgetVisibilityOverride.Automatic,
+            surfaces,
+            backgroundAgent: true);
+
+        Assert.Equal(new(false, WidgetVisibilityReason.NoQualifyingSurface), disabled);
+        Assert.Equal(new(true, WidgetVisibilityReason.BackgroundDesktopAgent), enabled);
+    }
+
+    [Fact]
+    public void StabilizerShowsImmediatelyAndHidesAfterContinuousDelay()
+    {
+        var stabilizer = new WidgetVisibilityStabilizer(TimeSpan.FromSeconds(2));
+        var now = new DateTimeOffset(2026, 7, 28, 12, 0, 0, TimeSpan.Zero);
+        var show = new WidgetVisibilityDecision(true, WidgetVisibilityReason.OpenDesktopApp);
+        var hide = new WidgetVisibilityDecision(false, WidgetVisibilityReason.NoQualifyingSurface);
+
+        Assert.True(stabilizer.Apply(show, now).ShouldShowWidget);
+        Assert.Equal(WidgetVisibilityReason.HideDebounce, stabilizer.Apply(hide, now).Reason);
+        Assert.Equal(WidgetVisibilityReason.HideDebounce, stabilizer.Apply(hide, now.AddMilliseconds(1999)).Reason);
+        Assert.Equal(hide, stabilizer.Apply(hide, now.AddSeconds(2)));
+    }
+
+    [Fact]
+    public void StabilizerCancelsPendingHideWhenSurfaceReturns()
+    {
+        var stabilizer = new WidgetVisibilityStabilizer(TimeSpan.FromSeconds(2));
+        var now = DateTimeOffset.UtcNow;
+        var show = new WidgetVisibilityDecision(true, WidgetVisibilityReason.ActiveCliAgent);
+        var hide = new WidgetVisibilityDecision(false, WidgetVisibilityReason.NoQualifyingSurface);
+
+        stabilizer.Apply(show, now);
+        stabilizer.Apply(hide, now);
+        Assert.Equal(show, stabilizer.Apply(show, now.AddSeconds(1)));
+        Assert.Equal(WidgetVisibilityReason.HideDebounce, stabilizer.Apply(hide, now.AddSeconds(2)).Reason);
+    }
+
+    [Fact]
+    public void StabilizerCanBypassDelayForSettingsAndProviderChanges()
+    {
+        var stabilizer = new WidgetVisibilityStabilizer(TimeSpan.FromSeconds(2));
+        var now = DateTimeOffset.UtcNow;
+        stabilizer.Apply(new(true, WidgetVisibilityReason.AlwaysShow), now);
+
+        var result = stabilizer.Apply(
+            new(false, WidgetVisibilityReason.NoValidProvider),
+            now,
+            hideImmediately: true);
+
+        Assert.Equal(new(false, WidgetVisibilityReason.NoValidProvider), result);
+    }
+
+    private static WidgetVisibilityDecision Evaluate(
+        WidgetVisibilityMode mode,
+        WidgetVisibilityOverride visibilityOverride,
+        SupportedSurfaceState surfaces,
+        bool hasValidProvider = true,
+        bool backgroundAgent = false)
+        => WidgetVisibilityPolicy.Evaluate(
+            new(mode, visibilityOverride, hasValidProvider, backgroundAgent, surfaces));
+}

--- a/tests/TaskbarQuota.Tests/WidgetVisibilitySettingsTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetVisibilitySettingsTests.cs
@@ -1,0 +1,62 @@
+using TaskbarQuota.Taskbar;
+using TaskbarQuota.Views;
+
+namespace TaskbarQuota.Tests;
+
+public class WidgetVisibilitySettingsTests
+{
+    [Theory]
+    [InlineData("AlwaysShow", WidgetVisibilityMode.AlwaysShow)]
+    [InlineData("ShowWhileOpen", WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen)]
+    [InlineData("ShowWhileInUse", WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse)]
+    [InlineData("unknown", WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen)]
+    [InlineData(null, WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen)]
+    public void ParseWidgetVisibilityModeTag_UsesStableXamlTags(
+        string? tag,
+        WidgetVisibilityMode expected)
+        => Assert.Equal(expected, SettingsPage.ParseWidgetVisibilityModeTag(tag));
+
+    [Theory]
+    [InlineData(WidgetVisibilityMode.AlwaysShow, "AlwaysShow")]
+    [InlineData(WidgetVisibilityMode.ShowWhileAnySupportedAiToolIsOpen, "ShowWhileOpen")]
+    [InlineData(WidgetVisibilityMode.ShowOnlyWhileSupportedAiToolIsInUse, "ShowWhileInUse")]
+    public void WidgetVisibilityModeTag_RoundTripsKnownModes(
+        WidgetVisibilityMode mode,
+        string expected)
+        => Assert.Equal(expected, SettingsPage.WidgetVisibilityModeTag(mode));
+
+    [Fact]
+    public void TryPersistAndApply_DoesNotCommitWhenPersistenceFails()
+    {
+        bool applied = false;
+
+        bool result = WidgetSettingsService.TryPersistAndApply(
+            () => false,
+            () => applied = true);
+
+        Assert.False(result);
+        Assert.False(applied);
+    }
+
+    [Fact]
+    public void TryPersistAndApply_CommitsAfterPersistenceSucceeds()
+    {
+        bool persisted = false;
+        bool applied = false;
+
+        bool result = WidgetSettingsService.TryPersistAndApply(
+            () =>
+            {
+                persisted = true;
+                return true;
+            },
+            () =>
+            {
+                Assert.True(persisted);
+                applied = true;
+            });
+
+        Assert.True(result);
+        Assert.True(applied);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a configurable, widget-wide visibility policy with three saved modes:

- **Always show** — show whenever at least one eligible provider is available.
- **Show while any supported AI tool is open** — the default; desktop apps and CLI agents count by presence, while websites count only when a supported active tab is in the foreground.
- **Show only while a supported AI tool is in use** — require an active desktop app, focused CLI terminal, or supported active browser tab.

The in-use mode also has a separate option to keep the widget visible while a supported background agent is still running. Tray actions can temporarily force show, force hide, or return to the saved automatic policy without overwriting it.

## Why

A single focus toggle cannot cover all the useful behaviors consistently. Some users want the quota visible at all times, some want it while their tooling is open, and others want it only while actively working in a supported surface. This separates those policies from provider pinning and from provider selection: TaskbarQuota keeps detecting and refreshing usage even while the native widget host is hidden.

## Relation to #36

This draft overlaps with #36, but explores a broader policy model rather than a replacement implementation of the same toggle.

PR #36 provides an opt-in **hide when provider unfocused** behavior. It keeps pinned providers on the taskbar and uses a foreground WinEvent hook plus a short 120 ms grace period for very fast focus-following behavior.

This draft instead:

- applies visibility to the **whole widget host**, so pinned providers follow the same global policy;
- distinguishes **present/open** surfaces from **foreground/active** surfaces;
- includes explicit background-agent continuity for CLI sessions and running Codex Desktop tasks;
- persists the selected policy and last eligible widget provider;
- adds per-run tray overrides that do not change the saved setting;
- uses a 2-second continuous hide debounce and a 100 ms host fade, favoring stability over the near-instant hide behavior in #36.

That difference is intentional, but it is also a trade-off: #36 is smaller and more responsive when the desired behavior is simply “follow focus”; this draft is larger because it models several visibility policies and tightens the evidence used by those policies.

## Detection and transition details

- Browser activity is based only on the foreground browser's supported active-tab URL; titles, background tabs, and persisted session state do not count.
- CLI presence requires strict command signatures and terminal/shell relationships, avoiding false positives from generic runtimes, project paths, `gh.exe`, or the persistent `codex.exe app-server` process.
- Codex Desktop background work is detected from its accessible running-task indicators without reading thread titles, prompts, responses, or Codex logs.
- Source-badge changes update only the badge instead of rebuilding and fading the whole quota tile.
- The taskbar host is converted from `WS_POPUP` to a real `WS_CHILD` after injection so Explorer composes it as a child window.

## User impact

- Users can choose the visibility behavior that matches their workflow.
- Pinning controls which providers appear, not whether the widget overrides the global policy.
- Hidden widgets keep refreshing data, alerts, dashboard state, and remembered provider context.
- Automatic focus/close transitions remain stable while manual tray actions apply immediately.

## Validation

- `dotnet test tests/TaskbarQuota.Tests/TaskbarQuota.Tests.csproj --no-restore` — **556 passed**.
- `git diff --check` — clean.
- Manual validation with Codex Desktop on Windows: foreground/background task transitions, focus loss, window close, and no visible widget flicker.
- Runtime HWND verification: parent is `Shell_TrayWnd`, `WS_CHILD` is set, and `WS_POPUP` is cleared.

## Known limits

- The two-second hide debounce is intentionally slower than #36's focus hook/grace path.
- Codex Desktop background detection depends on its accessibility structure and may need adjustment if that UI changes.
- WSL agents that expose no matching Windows process are not guaranteed to be detected.

Opening as a draft because the policy overlaps with #36 and would benefit from maintainer direction on whether the broader model, the focused implementation, or selected pieces of both should move forward.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable widget visibility modes: always show, show while a supported tool is open, or show only while it is in use.
  - Added an option to keep the widget visible during background agent activity.
  - Expanded detection for supported desktop apps, terminal agents, and the active browser tab.
  - Added support for detecting Zai and Kimi installations.
  - Added smoother visibility transitions to reduce flicker.

- **Bug Fixes**
  - Browser detection now uses only the foreground browser’s active tab and no longer infers providers from window titles.
  - Improved provider selection and preserved the most recently eligible provider.
  - Source badge updates no longer rebuild unchanged usage content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->