### PR TITLE
fix(widget): recover startup visibility after provider hydration

### DIFF
--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -860,13 +860,13 @@ namespace TaskbarQuota.Controls
         /// <summary>
         /// Whether a render that skips the cross-fade still has to put the tile on screen outright.
         ///
-        /// True exactly when this is the tile's first render and it is meant to be showing: the root ships
-        /// at Opacity 0, and the reveal is the only thing that raises it. A suppressed transition that
-        /// returned early here left the tile permanently invisible even though it measured, laid out and
-        /// reported itself Visible.
+        /// True exactly when this is the tile's first render: the root ships at Opacity 0, and the reveal is
+        /// the only thing that raises it. Provider seeding happens before the layout pass marks the slot
+        /// visible, so consulting the pre-layout visibility flag here can leave the tile permanently
+        /// transparent. The synchronous layout pass still collapses any slot that should not be shown.
         /// </summary>
-        internal static bool ShouldRevealWithoutTransition(bool isFirstReveal, bool isActiveToolVisible)
-            => isFirstReveal && isActiveToolVisible;
+        internal static bool ShouldRevealWithoutTransition(bool isFirstReveal)
+            => isFirstReveal;
 
         private void AnimateRender(bool isFirstReveal, bool providerSwitch = false)
         {
@@ -880,7 +880,7 @@ namespace TaskbarQuota.Controls
                 // transition) used to stay fully transparent for the life of the process: measured, laid
                 // out, Visible, and painting nothing. Show it outright instead — skipping the fade is the
                 // whole point of the suppression, showing it is not.
-                if (ShouldRevealWithoutTransition(isFirstReveal, _isActiveToolVisible))
+                if (ShouldRevealWithoutTransition(isFirstReveal))
                 {
                     Root.Opacity = 1;
                     RootTranslate.Y = 0;

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -305,7 +305,13 @@ namespace TaskbarQuota.Taskbar
 
         public void SetVisible(bool visible)
         {
-            if (appWindow is null || isVisible == visible)
+            if (appWindow is null)
+                return;
+
+            // The cached flag is only our requested state. During Explorer/XAML-island startup the native
+            // window can remain hidden even after an earlier Show request, so an equal cached value must not
+            // suppress recovery when AppWindow reports a different actual state.
+            if (isVisible == visible && appWindow.IsVisible == visible)
                 return;
 
             isVisible = visible;

--- a/tests/TaskbarQuota.Tests/WidgetSummaryRevealTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetSummaryRevealTests.cs
@@ -12,15 +12,18 @@ public class WidgetSummaryRevealTests
 {
     [Fact]
     public void RevealsOutrightWhenTheFirstRenderSkipsTheTransition()
-        => Assert.True(WidgetSummary.ShouldRevealWithoutTransition(isFirstReveal: true, isActiveToolVisible: true));
+        => Assert.True(WidgetSummary.ShouldRevealWithoutTransition(isFirstReveal: true));
 
+    // Slot seeding happens before the layout pass marks the new tile active. The first render must establish
+    // a visible resting value regardless; the synchronous layout pass remains responsible for collapsing a
+    // tile that ultimately does not fit.
     [Fact]
-    public void StaysHiddenWhenTheTileIsNotMeantToShow()
-        => Assert.False(WidgetSummary.ShouldRevealWithoutTransition(isFirstReveal: true, isActiveToolVisible: false));
+    public void FirstSuppressedRenderDoesNotDependOnPreLayoutVisibilityState()
+        => Assert.True(WidgetSummary.ShouldRevealWithoutTransition(isFirstReveal: true));
 
     // Later renders are cross-fades over an already visible tile; forcing the root back to 1 there would
     // undo a hide that SetActiveToolVisible had just animated.
     [Fact]
     public void LeavesLaterRendersAlone()
-        => Assert.False(WidgetSummary.ShouldRevealWithoutTransition(isFirstReveal: false, isActiveToolVisible: true));
+        => Assert.False(WidgetSummary.ShouldRevealWithoutTransition(isFirstReveal: false));
 }


### PR DESCRIPTION
## Summary

- reveal the first seeded tile even when provider hydration occurs before the layout pass marks its slot visible
- retry the native host visibility transition when the cached requested state disagrees with AppWindow.IsVisible
- update reveal regression coverage for the pre-layout startup ordering

## Context

A v1.1.1 report showed two consecutive launches where the taskbar host initialized and injected successfully and Codex was applied, but the widget remained absent. The notification registration warning is unrelated. The existing reveal guard still depended on the pre-layout visibility flag, even though startup snapshot seeding runs before layout establishes that flag.

## Validation

- targeted AppStartupTests and WidgetSummaryRevealTests: 10 passed
- full suite: 488 passed, 1 shared-settings Z.ai test failed; that test passed when rerun alone

Related: #21