### PR TITLE
feat: show live agent activity in the taskbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ After detection, usage is fetched from **local credentials** or **provider APIs*
 - **Click for flyout** — quick provider strip and settings shortcut above the widget.
 - **Fades when idle** — widget can hide when no supported AI tool process is detected; returns when you focus a supported app or terminal session.
 
+### Local agent activity
+
+- **Live task visualization** — a separate taskbar island shows working, waiting, idle, completed, and failed agent sessions. Selecting an agent opens the matching entry in the flyout.
+- **Supported local stores** — activity can be derived from Codex, Claude, OpenCode, Cline, Kimi, Grok, Antigravity, GitHub Copilot, and ZCode process/session data when those tools are running.
+- **Bounded retention** — completed activity is temporary, acknowledged after the activity flyout is viewed, and removed when it expires or disappears from the next successful scan.
+- **User controls** — the activity flyout can stop local activity monitoring completely or hide only the taskbar activity island.
+
 ### Active-tool detection (desktop app **or** terminal agent)
 
 This is the core behavior — everything else (widget, flyout, fetch cache) hangs off it.
@@ -191,6 +198,8 @@ Cookie headers are session credentials. Keep them private and do not paste them 
 ### Privacy
 
 - **Local-only** — no TaskbarQuota backend; usage calls go directly from your PC to each provider (or localhost for Antigravity).
+- **Agent activity stays on your PC** — TaskbarQuota reads local process metadata and supported transcript/session stores only to visualize your activity. Prompt-derived titles and steps are not uploaded to TaskbarQuota, sent to a training service, or used for model training.
+- **Monitoring can be disabled** — turn off **Monitoring** in the Agent activity flyout to stop process/session inspection and immediately clear retained activity from TaskbarQuota memory. Hiding **Activity Widget** alone only removes the taskbar island.
 - **No telemetry** — diagnostics log to `%TEMP%\taskbarquota.log` only.
 - **Cookie extraction is in-memory** — browser cookies are read to build a request header for the active fetch; they are not intentionally persisted (manual credentials in `credentials.json` are plain JSON today — keep that file on your PC only).
 
@@ -220,6 +229,7 @@ TaskBarManager → WidgetSummary (taskbar) + Dashboard + Flyout
 | Path | Role |
 | ---- | ---- |
 | `src/TaskbarQuota.App/ActiveApp/` | Foreground and CLI provider detection |
+| `src/TaskbarQuota.App/AgentActivity/` | Local process/session activity scanning and bounded in-memory state |
 | `src/TaskbarQuota.App/Browser/` | Browser cookie discovery and Chromium decryption |
 | `src/TaskbarQuota.App/Taskbar/` | Widget host, tray icon, taskbar layout watcher |
 | `src/TaskbarQuota.App/Usage/Providers/` | Per-provider fetch logic |

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityModels.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityModels.cs
@@ -67,6 +67,17 @@ public sealed record AgentActivitySnapshot(IReadOnlyList<AgentActivityItem> Item
     public bool HasLiveItems => Items.Any(item => item.IsLive);
     public bool HasUnreadCompletions => Items.Any(item => item.Status is AgentActivityStatus.Completed or AgentActivityStatus.Failed);
 
+    public IReadOnlyList<AgentActivityItem> ItemsForDisplay(string? selectedId)
+    {
+        if (string.IsNullOrWhiteSpace(selectedId))
+            return Items;
+
+        var selected = Items.FirstOrDefault(item => item.Id == selectedId);
+        return selected is null
+            ? Items
+            : new[] { selected }.Concat(Items.Where(item => item.Id != selectedId)).ToArray();
+    }
+
     private static AgentActivityItem? ToCompactItem(AgentActivityItem item)
     {
         if (item.Status is AgentActivityStatus.Working or AgentActivityStatus.Waiting)

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityModels.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityModels.cs
@@ -9,6 +9,7 @@ public enum AgentActivityStatus
 {
     Working,
     Waiting,
+    Idle,
     Completed,
     Failed,
 }
@@ -28,11 +29,12 @@ public sealed record AgentActivityItem(
     string? ParentThreadId = null,
     string? Host = null)
 {
-    public bool IsLive => Status is AgentActivityStatus.Working or AgentActivityStatus.Waiting;
+    public bool IsLive => Status is AgentActivityStatus.Working or AgentActivityStatus.Waiting or AgentActivityStatus.Idle;
     public string StatusText => Status switch
     {
         AgentActivityStatus.Working => "Working",
         AgentActivityStatus.Waiting => "Waiting",
+        AgentActivityStatus.Idle => "Idle",
         AgentActivityStatus.Completed => "Completed",
         AgentActivityStatus.Failed => "Failed",
         _ => "Unknown",

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityModels.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityModels.cs
@@ -25,7 +25,8 @@ public sealed record AgentActivityItem(
     string? Detail = null,
     string? Model = null,
     string? ThreadId = null,
-    string? ParentThreadId = null)
+    string? ParentThreadId = null,
+    string? Host = null)
 {
     public bool IsLive => Status is AgentActivityStatus.Working or AgentActivityStatus.Waiting;
     public string StatusText => Status switch

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityModels.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityModels.cs
@@ -43,13 +43,50 @@ public sealed record AgentActivityItem(
 
 public sealed record AgentActivitySnapshot(IReadOnlyList<AgentActivityItem> Items, IReadOnlyList<AgentActivityItem>? RunItems = null)
 {
-    public IReadOnlyList<AgentActivityItem> TrackedItems => RunItems is { Count: > 0 } ? RunItems : Items;
-    public AgentActivityItem? Primary => Items
-        .Where(item => item.IsLive)
+    public static readonly TimeSpan CompletedRetention = TimeSpan.FromMinutes(1);
+    public static readonly TimeSpan IdleWaitingRetention = TimeSpan.FromSeconds(90);
+    public static readonly TimeSpan IdleCompletedRetention = TimeSpan.FromSeconds(120);
+    public static readonly TimeSpan FailedRetention = TimeSpan.FromMinutes(5);
+
+    private IReadOnlyList<AgentActivityItem> SourceItems => RunItems is { Count: > 0 } ? RunItems : Items;
+
+    /// <summary>Items appropriate for the compact taskbar surface; full history remains in <see cref="Items"/>.</summary>
+    public IReadOnlyList<AgentActivityItem> CompactItems => SourceItems
+        .Select(ToCompactItem)
+        .Where(item => item is not null)
+        .Select(item => item!)
+        .ToArray();
+
+    public IReadOnlyList<AgentActivityItem> TrackedItems => CompactItems;
+    public AgentActivityItem? Primary => CompactItems
+        .Where(item => item.Status is AgentActivityStatus.Working or AgentActivityStatus.Waiting)
         .OrderByDescending(item => item.UpdatedAt)
         .FirstOrDefault()
-        ?? Items.OrderByDescending(item => item.UpdatedAt).FirstOrDefault();
+        ?? CompactItems.OrderByDescending(item => item.UpdatedAt).FirstOrDefault();
 
     public bool HasLiveItems => Items.Any(item => item.IsLive);
     public bool HasUnreadCompletions => Items.Any(item => item.Status is AgentActivityStatus.Completed or AgentActivityStatus.Failed);
+
+    private static AgentActivityItem? ToCompactItem(AgentActivityItem item)
+    {
+        if (item.Status is AgentActivityStatus.Working or AgentActivityStatus.Waiting)
+            return item;
+
+        var age = DateTimeOffset.UtcNow - item.UpdatedAt.ToUniversalTime();
+        if (item.Status == AgentActivityStatus.Idle)
+        {
+            if (age <= IdleWaitingRetention)
+                return item;
+            if (age <= IdleCompletedRetention)
+                return item with { Status = AgentActivityStatus.Completed, Step = "Completed" };
+            return null;
+        }
+
+        var retention = item.Status switch
+        {
+            AgentActivityStatus.Failed => FailedRetention,
+            _ => CompletedRetention,
+        };
+        return age <= retention ? item : null;
+    }
 }

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityModels.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityModels.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.AgentActivity;
+
+public enum AgentActivityStatus
+{
+    Working,
+    Waiting,
+    Completed,
+    Failed,
+}
+
+public sealed record AgentActivityItem(
+    string Id,
+    ProviderId Provider,
+    string Title,
+    string Step,
+    AgentActivityStatus Status,
+    DateTimeOffset StartedAt,
+    DateTimeOffset UpdatedAt,
+    int SubagentCount = 0,
+    string? Detail = null,
+    string? Model = null,
+    string? ThreadId = null,
+    string? ParentThreadId = null)
+{
+    public bool IsLive => Status is AgentActivityStatus.Working or AgentActivityStatus.Waiting;
+    public string StatusText => Status switch
+    {
+        AgentActivityStatus.Working => "Working",
+        AgentActivityStatus.Waiting => "Waiting",
+        AgentActivityStatus.Completed => "Completed",
+        AgentActivityStatus.Failed => "Failed",
+        _ => "Unknown",
+    };
+}
+
+public sealed record AgentActivitySnapshot(IReadOnlyList<AgentActivityItem> Items, IReadOnlyList<AgentActivityItem>? RunItems = null)
+{
+    public IReadOnlyList<AgentActivityItem> TrackedItems => RunItems is { Count: > 0 } ? RunItems : Items;
+    public AgentActivityItem? Primary => Items
+        .Where(item => item.IsLive)
+        .OrderByDescending(item => item.UpdatedAt)
+        .FirstOrDefault()
+        ?? Items.OrderByDescending(item => item.UpdatedAt).FirstOrDefault();
+
+    public bool HasLiveItems => Items.Any(item => item.IsLive);
+    public bool HasUnreadCompletions => Items.Any(item => item.Status is AgentActivityStatus.Completed or AgentActivityStatus.Failed);
+}

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -2778,7 +2778,8 @@ internal sealed class AgentActivityScanner
                     && timestamp.ValueKind == JsonValueKind.String
                     && DateTimeOffset.TryParse(timestamp.GetString(), out var parsedTime))
                 {
-                    started ??= parsedTime;
+                    if (started is null || parsedTime < started.Value)
+                        started = parsedTime;
                     if (activity is null && IsConversationEvent(root, provider)) activity = parsedTime;
                 }
 

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -35,14 +35,46 @@ internal sealed class AgentActivityScanner
         var liveProviders = MergeLiveProviders(desktopApps, terminalAgents);
         Log.Information($"[activity] agent discovery: desktop={desktopApps.Values.Sum()}, terminal={terminalAgents.Values.Sum()}");
         var files = new List<(ProviderId Provider, string Path, DateTimeOffset Modified)>();
-        AddRecent(files, Path.Combine(_home, ".codex", "sessions"), ProviderId.Codex, cancellationToken);
-        AddRecent(files, Path.Combine(_home, ".claude", "projects"), ProviderId.Claude, cancellationToken);
-        AddGrokSessions(files, cancellationToken);
-        AddAntigravityDatabases(files, cancellationToken);
-        AddAntigravityGuiTranscripts(files, cancellationToken);
-        AddOpenCodeDatabases(files, cancellationToken);
-        AddClineSessions(files, cancellationToken);
-        AddKimiSessions(files, cancellationToken);
+        // Process discovery is intentionally the gate for transcript/database work. Most agent
+        // stores are SQLite or recursive file trees, so reopening them every tick when the app is
+        // closed wastes the bulk of the activity refresh time.
+        if (IsDetected(ProviderId.Codex))
+            AddRecent(files, Path.Combine(_home, ".codex", "sessions"), ProviderId.Codex, cancellationToken);
+        if (IsDetected(ProviderId.Claude))
+            AddRecent(files, Path.Combine(_home, ".claude", "projects"), ProviderId.Claude, cancellationToken);
+        if (IsDetected(ProviderId.Grok))
+            AddGrokSessions(files, cancellationToken);
+        if (IsDetected(ProviderId.Antigravity))
+        {
+            AddAntigravityDatabases(files, cancellationToken);
+            AddAntigravityGuiTranscripts(files, cancellationToken);
+        }
+        if (IsDetected(ProviderId.OpenCode))
+            AddOpenCodeDatabases(files, cancellationToken);
+        if (IsDetected(ProviderId.Cline))
+            AddClineSessions(files, cancellationToken);
+        if (IsDetected(ProviderId.Kimi))
+            AddKimiSessions(files, cancellationToken);
+        if (IsDetected(ProviderId.Copilot))
+            AddCopilotSessions(files, cancellationToken);
+        if (IsDetected(ProviderId.Zai))
+            AddZcodeDatabase(files, cancellationToken);
+
+        bool IsDetected(ProviderId provider) => liveProviders.ContainsKey(provider);
+
+        // VS Code persists the same Copilot thread twice: the canonical session snapshot under
+        // chatSessions (with customTitle/modelState) and an extension transcript under transcripts.
+        // Keep one source per session so the prompt-only transcript cannot replace the titled state.
+        var copilotFiles = files
+            .Where(file => file.Provider == ProviderId.Copilot)
+            .GroupBy(file => Path.GetFileNameWithoutExtension(file.Path), StringComparer.OrdinalIgnoreCase)
+            .Select(group => group
+                .OrderBy(file => file.Path.Contains("\\chatSessions\\", StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+                .ThenByDescending(file => file.Modified)
+                .First())
+            .ToArray();
+        files.RemoveAll(file => file.Provider == ProviderId.Copilot);
+        files.AddRange(copilotFiles);
 
         var parsed = new List<AgentActivityItem>();
         var liveClaims = new Dictionary<ProviderId, int>();
@@ -78,6 +110,15 @@ internal sealed class AgentActivityScanner
             {
                 if (TryReadKimiSession(file.Path, file.Modified, claimLive, out var kimiItem))
                     parsed.Add(kimiItem);
+            }
+            else if (file.Provider == ProviderId.Copilot)
+            {
+                if (TryReadCopilotSession(file.Path, file.Modified, claimLive, out var copilotItem))
+                    parsed.Add(copilotItem);
+            }
+            else if (file.Provider == ProviderId.Zai)
+            {
+                parsed.AddRange(ReadZcodeSessions(file.Path, file.Modified, claimLive));
             }
             else if (TryRead(file.Provider, file.Path, file.Modified, claimLive, out var item))
             {
@@ -214,6 +255,340 @@ internal sealed class AgentActivityScanner
 
         yield return Path.Combine(_home, ".kimi-code");
         yield return Path.Combine(_home, ".kimi");
+    }
+
+    private void AddCopilotSessions(List<(ProviderId, string, DateTimeOffset)> output,
+        CancellationToken cancellationToken)
+    {
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var configuredUserData = Environment.GetEnvironmentVariable("VSCODE_USER_DATA_DIR");
+        var userRoots = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            Path.Combine(appData, "Code", "User"),
+            Path.Combine(appData, "Code - Insiders", "User"),
+            Path.Combine(appData, "VSCodium", "User"),
+        };
+        if (!string.IsNullOrWhiteSpace(configuredUserData))
+        {
+            var configured = configuredUserData.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            userRoots.Add(Path.GetFileName(configured).Equals("User", StringComparison.OrdinalIgnoreCase)
+                ? configured
+                : Path.Combine(configured, "User"));
+        }
+
+        try
+        {
+            foreach (var userRoot in userRoots)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!Directory.Exists(userRoot))
+                    continue;
+
+                var transcriptDirectories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var workspaceStorage = Path.Combine(userRoot, "workspaceStorage");
+                if (Directory.Exists(workspaceStorage))
+                {
+                    foreach (var workspace in Directory.EnumerateDirectories(workspaceStorage, "*", SearchOption.TopDirectoryOnly))
+                    {
+                        transcriptDirectories.Add(Path.Combine(workspace, "chatSessions"));
+                        transcriptDirectories.Add(Path.Combine(workspace, "GitHub.copilot-chat", "transcripts"));
+                    }
+                }
+                transcriptDirectories.Add(Path.Combine(userRoot, "globalStorage", "emptyWindowChatSessions"));
+
+                foreach (var directory in transcriptDirectories)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (!Directory.Exists(directory))
+                        continue;
+                    foreach (var path in Directory.EnumerateFiles(directory, "*.*", SearchOption.TopDirectoryOnly))
+                    {
+                        var extension = Path.GetExtension(path);
+                        if (!extension.Equals(".json", StringComparison.OrdinalIgnoreCase)
+                            && !extension.Equals(".jsonl", StringComparison.OrdinalIgnoreCase))
+                            continue;
+
+                        var modified = File.GetLastWriteTimeUtc(path);
+                        if (DateTime.UtcNow - modified <= RecentWindow)
+                        {
+                            output.Add((ProviderId.Copilot, path,
+                                new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
+                        }
+                    }
+                }
+            }
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    internal static bool TryReadCopilotSession(string path, DateTimeOffset modified, bool claimLive,
+        out AgentActivityItem item)
+    {
+        item = default!;
+        if (!File.Exists(path))
+            return false;
+
+        try
+        {
+            var transcript = new CopilotTranscript(Path.GetFileNameWithoutExtension(path));
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete);
+            if (stream.Length == 0)
+                return false;
+
+            if (Path.GetExtension(path).Equals(".json", StringComparison.OrdinalIgnoreCase))
+            {
+                using var document = JsonDocument.Parse(stream);
+                ParseCopilotDocument(document.RootElement, transcript);
+            }
+            else
+            {
+                using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+                string? line;
+                while ((line = reader.ReadLine()) is not null)
+                {
+                    if (string.IsNullOrWhiteSpace(line))
+                        continue;
+                    try
+                    {
+                        using var document = JsonDocument.Parse(line);
+                        ParseCopilotEvent(document.RootElement, transcript);
+                    }
+                    catch (JsonException) { }
+                }
+            }
+
+            transcript.LastActivity ??= modified;
+            transcript.StartedAt ??= transcript.LastActivity;
+            var live = claimLive;
+            var status = !live
+                ? transcript.Failed ? AgentActivityStatus.Failed : AgentActivityStatus.Completed
+                : transcript.Failed ? AgentActivityStatus.Failed
+                : transcript.Waiting ? AgentActivityStatus.Waiting
+                : transcript.Pending ? AgentActivityStatus.Working
+                : AgentActivityStatus.Idle;
+            var step = status switch
+            {
+                AgentActivityStatus.Completed => "Completed",
+                AgentActivityStatus.Failed => "Failed",
+                AgentActivityStatus.Waiting => FirstNonEmpty(transcript.Step, "Waiting for input"),
+                AgentActivityStatus.Idle => "Waiting for the next prompt",
+                _ => FirstNonEmpty(transcript.Step, "Working"),
+            };
+            var host = path.Contains("Code - Insiders", StringComparison.OrdinalIgnoreCase)
+                ? "VS Code Insiders"
+                : path.Contains("VSCodium", StringComparison.OrdinalIgnoreCase) ? "VSCodium" : "VS Code";
+            item = new AgentActivityItem(
+                $"copilot:{transcript.SessionId}", ProviderId.Copilot,
+                Trim(Clean(FirstNonEmpty(transcript.Title, "GitHub Copilot Session")), 72),
+                Trim(Clean(step), 96), status, transcript.StartedAt.Value, transcript.LastActivity.Value,
+                Detail: transcript.Prompt, Model: FirstNonEmpty(transcript.Model, "GitHub Copilot"),
+                ThreadId: transcript.SessionId, Host: host);
+            return true;
+        }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+        catch (JsonException) { return false; }
+    }
+
+    private static void ParseCopilotDocument(JsonElement root, CopilotTranscript transcript)
+    {
+        var value = root.TryGetProperty("v", out var versioned) && versioned.ValueKind == JsonValueKind.Object
+            ? versioned : root;
+        transcript.SessionId = FirstNonEmpty(FirstString(value, "sessionId", "session_id"), transcript.SessionId);
+        transcript.Title = FirstNonEmpty(FirstString(value, "customTitle", "title"), transcript.Title);
+        transcript.StartedAt = FirstTimestampAny(value, "creationDate", "createdAt", "created_at") ?? transcript.StartedAt;
+        transcript.LastActivity = FirstTimestampAny(value, "lastMessageDate", "updatedAt", "updated_at") ?? transcript.LastActivity;
+        transcript.Model = FirstNonEmpty(ParseCopilotModel(value), transcript.Model);
+        if (value.TryGetProperty("requests", out var requests) && requests.ValueKind == JsonValueKind.Array)
+        {
+            var requestIndex = 0;
+            foreach (var request in requests.EnumerateArray())
+                ParseCopilotRequest(request, transcript, requestIndex++);
+        }
+        else
+        {
+            ParseCopilotEvent(value, transcript);
+        }
+    }
+
+    private static void ParseCopilotRequest(JsonElement request, CopilotTranscript transcript, int requestIndex = -1)
+    {
+        if (requestIndex >= 0)
+            transcript.LatestRequestIndex = Math.Max(transcript.LatestRequestIndex, requestIndex);
+        var prompt = FirstStringDeep(request, "text", "prompt", "message", "content");
+        if (prompt.Length > 0)
+        {
+            transcript.Prompt = prompt;
+            transcript.Title = FirstNonEmpty(transcript.Title, SummarizeTitle(prompt) ?? prompt);
+            transcript.HasUser = true;
+        }
+        transcript.Model = FirstNonEmpty(ParseCopilotModel(request), transcript.Model);
+        var requestActivity = FirstTimestampAny(request, "timestamp", "createdAt", "created_at", "completedAt");
+        if (requestActivity is { } requestTime)
+            transcript.LastActivity = transcript.LastActivity is { } previous ? Max(previous, requestTime) : requestTime;
+        var status = FirstString(request, "status", "state", "finishReason", "finish_reason").ToLowerInvariant();
+        if (status is "error" or "failed" or "cancelled")
+            transcript.Failed = true;
+        if (status is "running" or "pending" or "in_progress")
+            transcript.Pending = true;
+        if (status is "waiting" or "awaiting_approval" or "needs_input")
+            transcript.Waiting = true;
+        if (request.TryGetProperty("toolRequests", out var tools) && tools.ValueKind == JsonValueKind.Array && tools.GetArrayLength() > 0)
+        {
+            transcript.Pending = true;
+            transcript.Step = $"Running {FirstStringDeep(tools[tools.GetArrayLength() - 1], "name", "tool", "id")}";
+        }
+        var hasResponse = request.TryGetProperty("response", out var response)
+            && response.ValueKind is JsonValueKind.Array or JsonValueKind.Object
+            && (response.ValueKind != JsonValueKind.Array || response.GetArrayLength() > 0);
+        if (hasResponse)
+        {
+            transcript.HasAssistant = true;
+            var completed = CopilotRequestCompleted(request);
+            transcript.Pending = completed is false;
+            transcript.Waiting = false;
+            transcript.Step = FirstNonEmpty(
+                response.ValueKind == JsonValueKind.Array ? ExtractContentText(response) : FirstStringDeep(response, "text", "value", "content"),
+                transcript.Step);
+        }
+        else if (transcript.HasUser)
+        {
+            transcript.Pending = true;
+        }
+    }
+
+    private static void ParseCopilotEvent(JsonElement root, CopilotTranscript transcript)
+    {
+        if (root.TryGetProperty("kind", out var kindNode) && kindNode.ValueKind == JsonValueKind.Number
+            && kindNode.TryGetInt32(out var kind))
+        {
+            if (kind == 0 && root.TryGetProperty("v", out var snapshot) && snapshot.ValueKind == JsonValueKind.Object)
+            {
+                ParseCopilotDocument(root, transcript);
+                return;
+            }
+            if (root.TryGetProperty("k", out var key) && key.ValueKind == JsonValueKind.Array)
+            {
+                ParseCopilotDelta(root, key, transcript);
+                return;
+            }
+        }
+
+        transcript.SessionId = FirstNonEmpty(FirstString(root, "sessionId", "session_id"), transcript.SessionId);
+        var eventActivity = FirstTimestampAny(root, "timestamp", "time", "createdAt", "created_at", "ts");
+        if (eventActivity is { } eventTime)
+            transcript.LastActivity = transcript.LastActivity is { } previous ? Max(previous, eventTime) : eventTime;
+        transcript.Model = FirstNonEmpty(FirstStringDeep(root, "model", "modelId", "model_id", "selectedModel"), transcript.Model);
+        var type = FirstString(root, "type", "event", "kind").ToLowerInvariant();
+        var payload = root.TryGetProperty("data", out var data) ? data : root;
+        if (type is "session.start" or "session_started")
+        {
+            transcript.SessionId = FirstNonEmpty(FirstString(payload, "sessionId", "session_id"), transcript.SessionId);
+            transcript.StartedAt = FirstTimestampAny(payload, "startTime", "startedAt", "createdAt") ?? transcript.StartedAt;
+            return;
+        }
+
+        var role = FirstString(root, "role").ToLowerInvariant();
+        if (type is "user.message" or "user_message" or "user" or "request" || role == "user")
+        {
+            var prompt = FirstStringDeep(payload, "text", "prompt", "content", "message");
+            if (prompt.Length > 0)
+            {
+                transcript.Prompt = prompt;
+                transcript.Title = FirstNonEmpty(transcript.Title, SummarizeTitle(prompt) ?? prompt);
+                transcript.HasUser = true;
+            }
+            transcript.Pending = true;
+            return;
+        }
+
+        if (type is "assistant.message" or "assistant_message" or "assistant" or "response" || role == "assistant")
+        {
+            transcript.HasAssistant = true;
+            var tool = payload.TryGetProperty("toolRequests", out var tools) && tools.ValueKind == JsonValueKind.Array
+                ? tools : default;
+            if (tool.ValueKind == JsonValueKind.Array && tool.GetArrayLength() > 0)
+            {
+                transcript.Pending = true;
+                var name = FirstStringDeep(tool[tool.GetArrayLength() - 1], "name", "tool", "id");
+                transcript.Step = string.IsNullOrWhiteSpace(name) ? "Running tool" : $"Running {name}";
+            }
+            else
+            {
+                transcript.Pending = false;
+                transcript.Waiting = false;
+                transcript.Step = FirstNonEmpty(
+                    FirstStringDeep(payload, "reasoningText", "reasoning", "text", "content"), transcript.Step);
+            }
+            var status = FirstString(payload, "status", "state", "finishReason", "finish_reason").ToLowerInvariant();
+            if (status is "error" or "failed") transcript.Failed = true;
+            if (status is "running" or "pending" or "in_progress") transcript.Pending = true;
+            if (status is "waiting" or "awaiting_approval" or "needs_input") transcript.Waiting = true;
+        }
+    }
+
+    private static void ParseCopilotDelta(JsonElement root, JsonElement key, CopilotTranscript transcript)
+    {
+        if (key.GetArrayLength() < 3
+            || !string.Equals(key[0].GetString(), "requests", StringComparison.OrdinalIgnoreCase)
+            || !key[1].TryGetInt32(out var requestIndex))
+            return;
+
+        // Deltas can arrive for an earlier request after a newer request has
+        // already been persisted. They must not overwrite the live status of
+        // the newest request.
+        if (requestIndex < transcript.LatestRequestIndex)
+            return;
+        transcript.LatestRequestIndex = requestIndex;
+        var field = key[2].GetString() ?? "";
+        var value = root.TryGetProperty("v", out var valueNode) ? valueNode : default;
+        if (field.Equals("modelState", StringComparison.OrdinalIgnoreCase))
+        {
+            if (value.ValueKind == JsonValueKind.Object && value.TryGetProperty("completedAt", out _))
+            {
+                transcript.Pending = false;
+                transcript.Waiting = false;
+            }
+            else if (value.ValueKind == JsonValueKind.Object && value.TryGetProperty("value", out var state)
+                && state.ValueKind == JsonValueKind.Number && state.TryGetInt32(out var stateValue))
+            {
+                transcript.Pending = stateValue != 1;
+            }
+        }
+        else if (field.Equals("response", StringComparison.OrdinalIgnoreCase))
+        {
+            transcript.HasAssistant = true;
+            if (value.ValueKind == JsonValueKind.Array)
+                transcript.Step = FirstNonEmpty(ExtractContentText(value), transcript.Step);
+        }
+        else if (field.Equals("result", StringComparison.OrdinalIgnoreCase))
+        {
+            transcript.Pending = false;
+            transcript.Waiting = false;
+        }
+    }
+
+    private static bool? CopilotRequestCompleted(JsonElement request)
+    {
+        if (!request.TryGetProperty("modelState", out var state) || state.ValueKind != JsonValueKind.Object)
+            return null;
+        if (state.TryGetProperty("completedAt", out _))
+            return true;
+        if (state.TryGetProperty("value", out var value) && value.ValueKind == JsonValueKind.Number
+            && value.TryGetInt32(out var numeric))
+            return numeric == 1;
+        return null;
+    }
+
+    private static string ParseCopilotModel(JsonElement value)
+    {
+        if (!value.TryGetProperty("selectedModel", out var model))
+            return FirstString(value, "model", "modelId", "model_id");
+        return model.ValueKind == JsonValueKind.Object
+            ? FirstString(model, "family", "identifier", "id")
+            : model.ValueKind == JsonValueKind.String ? Clean(model.GetString()) : "";
     }
 
     private void AddGrokSessions(List<(ProviderId, string, DateTimeOffset)> output,
@@ -929,6 +1304,198 @@ internal sealed class AgentActivityScanner
             catch (UnauthorizedAccessException) { }
         }
     }
+
+    private void AddZcodeDatabase(List<(ProviderId, string, DateTimeOffset)> output,
+        CancellationToken cancellationToken)
+    {
+        var configured = Environment.GetEnvironmentVariable("ZCODE_DB_PATH");
+        var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            string.IsNullOrWhiteSpace(configured)
+                ? Path.Combine(_home, ".zcode", "cli", "db", "db.sqlite")
+                : configured,
+        };
+
+        foreach (var path in candidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                if (!File.Exists(path))
+                    continue;
+                var modified = File.GetLastWriteTimeUtc(path);
+                foreach (var companion in new[] { path + "-wal", path + "-shm" })
+                {
+                    if (File.Exists(companion))
+                    {
+                        var companionModified = File.GetLastWriteTimeUtc(companion);
+                        if (companionModified > modified)
+                            modified = companionModified;
+                    }
+                }
+                if (DateTime.UtcNow - modified <= RecentWindow)
+                    output.Add((ProviderId.Zai, path, new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+
+    private static IReadOnlyList<AgentActivityItem> ReadZcodeSessions(
+        string path, DateTimeOffset modified, bool claimLive)
+    {
+        var items = new List<AgentActivityItem>();
+        try
+        {
+            var connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = path,
+                Mode = SqliteOpenMode.ReadOnly,
+                Cache = SqliteCacheMode.Shared,
+                Pooling = false,
+            }.ToString();
+            using var connection = new SqliteConnection(connectionString);
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = """
+                SELECT id, parent_id, title, time_created, time_updated,
+                       COALESCE((SELECT status FROM session_target st WHERE st.session_id = session.id), '')
+                FROM session
+                WHERE COALESCE(time_updated, time_created, 0) >= $cutoff
+                ORDER BY time_updated DESC, time_created DESC
+                LIMIT 80;
+                """;
+            command.Parameters.AddWithValue("$cutoff", DateTimeOffset.Now.Add(-RecentWindow).ToUnixTimeMilliseconds());
+
+            var sessions = new List<ZcodeSessionRow>();
+            using (var reader = command.ExecuteReader())
+            {
+                while (reader.Read())
+                {
+                    sessions.Add(new ZcodeSessionRow(
+                        reader.GetString(0), reader.IsDBNull(1) ? null : reader.GetString(1),
+                        reader.IsDBNull(2) ? "" : reader.GetString(2),
+                        reader.IsDBNull(3) ? 0 : reader.GetInt64(3),
+                        reader.IsDBNull(4) ? 0 : reader.GetInt64(4),
+                        reader.IsDBNull(5) ? "" : reader.GetString(5)));
+                }
+            }
+
+            bool claimed = false;
+            foreach (var session in sessions)
+            {
+                var tail = ReadZcodeTail(connection, session.Id);
+                var lastActivity = Max(FromUnixMilliseconds(session.UpdatedAt, modified), tail.LastActivity ?? modified);
+                var fresh = DateTimeOffset.Now - lastActivity < BusyWindow;
+                var live = claimLive && !claimed;
+                if (live) claimed = true;
+
+                var status = !live
+                    ? tail.State == TranscriptState.Failed ? AgentActivityStatus.Failed : AgentActivityStatus.Completed
+                    : session.TargetStatus is "paused" or "complete" || tail.State == TranscriptState.Waiting
+                        ? AgentActivityStatus.Waiting
+                        : fresh ? AgentActivityStatus.Working : AgentActivityStatus.Idle;
+                if (session.TargetStatus == "complete" && !live)
+                    status = AgentActivityStatus.Completed;
+
+                var step = status switch
+                {
+                    AgentActivityStatus.Completed => "Completed",
+                    AgentActivityStatus.Failed => "Failed",
+                    AgentActivityStatus.Waiting => FirstNonEmpty(tail.Step, "Waiting for input"),
+                    AgentActivityStatus.Idle => "Waiting for the next prompt",
+                    _ => FirstNonEmpty(tail.Step, fresh ? "Working" : "Thinking"),
+                };
+                items.Add(new AgentActivityItem(
+                    $"zcode:{session.Id}", ProviderId.Zai,
+                    string.IsNullOrWhiteSpace(session.Title) ? SummarizeTitle(tail.Prompt) ?? "ZCode" : Trim(Clean(session.Title), 72),
+                    step, status, FromUnixMilliseconds(session.CreatedAt, modified), lastActivity,
+                    Detail: tail.Prompt, Model: tail.Model, ThreadId: session.Id, ParentThreadId: session.ParentId));
+            }
+        }
+        catch (SqliteException) { }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+        return items;
+    }
+
+    private static ZcodeTail ReadZcodeTail(SqliteConnection connection, string sessionId)
+    {
+        var messages = new List<(string Role, string Data, long Created, long Updated)>();
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = "SELECT data, time_created, time_updated FROM message WHERE session_id = $session ORDER BY time_created DESC LIMIT 100;";
+            command.Parameters.AddWithValue("$session", sessionId);
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                var data = reader.GetString(0);
+                try
+                {
+                    using var doc = JsonDocument.Parse(data);
+                    var role = FirstString(doc.RootElement, "role").ToLowerInvariant();
+                    messages.Add((role, data, reader.GetInt64(1), reader.GetInt64(2)));
+                }
+                catch (JsonException) { }
+            }
+        }
+
+        var user = messages.FirstOrDefault(x => x.Role == "user");
+        var assistant = messages.FirstOrDefault(x => x.Role == "assistant");
+        var prompt = user.Data.Length == 0 ? "" : ReadZcodeText(user.Data, "content", "text");
+        var model = assistant.Data.Length == 0 ? "" : FirstJsonString(assistant.Data, "modelID", "modelId", "model");
+        var assistantActivity = assistant.Data.Length == 0
+            ? DateTimeOffset.MinValue
+            : FromUnixMilliseconds(Math.Max(assistant.Created, assistant.Updated), DateTimeOffset.MinValue);
+        var activity = messages.Select(x => FromUnixMilliseconds(Math.Max(x.Created, x.Updated), DateTimeOffset.MinValue)).DefaultIfEmpty().Max();
+        var state = assistant.Data.Length == 0 || user.Created > assistant.Updated ? TranscriptState.Action : TranscriptState.Finished;
+        var step = state == TranscriptState.Action ? "Thinking" : "";
+
+        using var partCommand = connection.CreateCommand();
+        partCommand.CommandText = "SELECT data, time_created, time_updated FROM part WHERE session_id = $session ORDER BY time_created DESC LIMIT 200;";
+        partCommand.Parameters.AddWithValue("$session", sessionId);
+        using var parts = partCommand.ExecuteReader();
+        while (parts.Read())
+        {
+            var data = parts.GetString(0);
+            try
+            {
+                using var doc = JsonDocument.Parse(data);
+                var root = doc.RootElement;
+                var type = FirstString(root, "type").ToLowerInvariant();
+                var partActivity = FromUnixMilliseconds(Math.Max(parts.GetInt64(1), parts.GetInt64(2)), DateTimeOffset.MinValue);
+                activity = Max(activity, partActivity);
+                if (type == "tool" && partActivity >= assistantActivity)
+                {
+                    var tool = FirstString(root, "tool", "name", "toolName");
+                    var statusText = root.TryGetProperty("state", out var stateNode) ? FirstString(stateNode, "status") : "";
+                    state = statusText is "error" or "failed" ? TranscriptState.Failed
+                        : statusText is "pending" or "waiting" ? TranscriptState.Waiting : TranscriptState.Action;
+                    step = DescribeAction(tool, FirstStringDeep(root, "command", "path", "input"));
+                    break;
+                }
+                if (type is "reasoning" or "text")
+                    step = FirstNonEmpty(FirstString(root, "text", "reasoning"), step);
+            }
+            catch (JsonException) { }
+        }
+        return new ZcodeTail(prompt, step, model, activity == DateTimeOffset.MinValue ? null : activity, state,
+            FirstStringDeepFromJson(messages.FirstOrDefault(x => x.Role == "assistant").Data, "error"));
+    }
+
+    private static string ReadZcodeText(string json, params string[] names)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return FirstStringDeep(doc.RootElement, names);
+        }
+        catch (JsonException) { return ""; }
+    }
+
+    private static string FirstJsonString(string json, params string[] names) => ReadZcodeText(json, names);
+    private static string FirstStringDeepFromJson(string json, params string[] names) => string.IsNullOrWhiteSpace(json) ? "" : ReadZcodeText(json, names);
 
     private bool TryRead(ProviderId provider, string path, DateTimeOffset modified,
         bool claimLive, out AgentActivityItem item)
@@ -1858,6 +2425,19 @@ internal sealed class AgentActivityScanner
     internal static IReadOnlyList<AgentActivityItem> ReadOpenCodeForTesting(string path, bool claimLive = true)
         => ReadOpenCodeSessions(path, DateTimeOffset.Now, claimLive);
 
+    internal static IReadOnlyList<AgentActivityItem> ReadZcodeForTesting(string path, bool claimLive = true)
+        => ReadZcodeSessions(path, DateTimeOffset.Now, claimLive);
+
+    internal static IReadOnlyList<AgentActivityItem> ReadCopilotForTesting(string path, bool claimLive = true)
+    {
+        var modified = File.GetLastWriteTimeUtc(path);
+        return TryReadCopilotSession(path,
+            new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime(), claimLive,
+            out var item)
+            ? new[] { item }
+            : Array.Empty<AgentActivityItem>();
+    }
+
     private static OpenCodeTail ReadOpenCodeTail(SqliteConnection connection, string sessionId)
     {
         var messages = new List<OpenCodeMessageRow>();
@@ -2557,6 +3137,13 @@ internal sealed class AgentActivityScanner
             case "devin": provider = ProviderId.Devin; return true;
             case "cline": provider = ProviderId.Cline; return true;
             case "kimi": provider = ProviderId.Kimi; return true;
+            case "zcode": provider = ProviderId.Zai; return true;
+            case "code":
+            case "code-insiders": provider = ProviderId.Copilot; return true;
+            case "code - insiders": provider = ProviderId.Copilot; return true;
+            case "copilot":
+            case "github copilot":
+            case "github-copilot": provider = ProviderId.Copilot; return true;
             default: return false;
         }
     }
@@ -2576,7 +3163,7 @@ internal sealed class AgentActivityScanner
             "Name = 'bun.exe' OR Name = 'deno.exe' OR Name = 'npm.exe' OR Name = 'npx.exe' OR " +
             "Name = 'pnpm.exe' OR Name = 'yarn.exe' OR Name = 'wsl.exe' OR Name = 'bash.exe' OR " +
             "Name = 'codex.exe' OR Name = 'claude.exe' OR Name = 'cursor-agent.exe' OR " +
-            "Name = 'opencode.exe' OR Name = 'cline.exe' OR Name = 'kimi.exe' OR Name = 'agy.exe' OR Name = 'grok.exe'";
+            "Name = 'opencode.exe' OR Name = 'cline.exe' OR Name = 'kimi.exe' OR Name = 'agy.exe' OR Name = 'grok.exe' OR Name = 'zcode.exe' OR Name = 'copilot.exe' OR Name = 'github-copilot.exe'";
 
         try
         {
@@ -2611,6 +3198,8 @@ internal sealed class AgentActivityScanner
         if (text.Contains("opencode")) { provider = ProviderId.OpenCode; return true; }
         if (text.Contains("cline")) { provider = ProviderId.Cline; return true; }
         if (text.Contains("kimi")) { provider = ProviderId.Kimi; return true; }
+        if (text.Contains("zcode") || executable.Equals("zcode", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Zai; return true; }
+        if (text.Contains("copilot") || executable.Equals("github-copilot", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Copilot; return true; }
         if (text.Contains(" codex") || executable.Equals("codex", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Codex; return true; }
         return false;
     }
@@ -2712,6 +3301,26 @@ internal sealed class AgentActivityScanner
         string MessageId, string Type, DateTimeOffset ActivityAt, string Tool, string Status, string Input, string Text);
     private sealed record OpenCodeTail(
         string Step, string Summary, string Prompt, DateTimeOffset? LastActivity, TranscriptState State);
+    private sealed record ZcodeTail(
+        string Prompt, string Step, string Model, DateTimeOffset? LastActivity, TranscriptState State, string Error);
+    private sealed record ZcodeSessionRow(
+        string Id, string? ParentId, string Title, long CreatedAt, long UpdatedAt, string TargetStatus);
+    private sealed class CopilotTranscript(string sessionId)
+    {
+        public string SessionId { get; set; } = sessionId;
+        public string Title { get; set; } = "";
+        public string Prompt { get; set; } = "";
+        public string Model { get; set; } = "";
+        public string Step { get; set; } = "";
+        public DateTimeOffset? StartedAt { get; set; }
+        public DateTimeOffset? LastActivity { get; set; }
+        public bool HasUser { get; set; }
+        public bool HasAssistant { get; set; }
+        public bool Pending { get; set; }
+        public bool Waiting { get; set; }
+        public bool Failed { get; set; }
+        public int LatestRequestIndex { get; set; } = -1;
+    }
     private sealed class ClineTail
     {
         public string Prompt { get; set; } = "";

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -912,9 +912,17 @@ internal sealed class AgentActivityScanner
                     continue;
                 var modified = File.GetLastWriteTimeUtc(path);
                 // SQLite WAL mode can leave the main database timestamp unchanged while the
-                // companion -wal file receives the active session writes. The session query below
-                // applies the recency window, so keep the database candidate even when its main
-                // file is older than six hours.
+                // companion -wal file receives the active session writes. Use the newest companion
+                // timestamp so an active OpenCode desktop session stays in the scan's recent set.
+                foreach (var companion in new[] { path + "-wal", path + "-shm" })
+                {
+                    if (File.Exists(companion))
+                    {
+                        var companionModified = File.GetLastWriteTimeUtc(companion);
+                        if (companionModified > modified)
+                            modified = companionModified;
+                    }
+                }
                 output.Add((ProviderId.OpenCode, path, new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
             }
             catch (IOException) { }
@@ -2519,18 +2527,8 @@ internal sealed class AgentActivityScanner
         {
             try
             {
-                switch (process.ProcessName.ToLowerInvariant())
-                {
-                    case "codex":
-                    case "chatgpt": Add(ProviderId.Codex); break;
-                    case "claude": Add(ProviderId.Claude); break;
-                    case "grok": Add(ProviderId.Grok); break;
-                    case "cursor": Add(ProviderId.Cursor); break;
-                    case "antigravity": Add(ProviderId.Antigravity); break;
-                    case "devin": Add(ProviderId.Devin); break;
-                    case "cline": Add(ProviderId.Cline); break;
-                    case "kimi": Add(ProviderId.Kimi); break;
-                }
+                if (TryGetDesktopProvider(process.ProcessName, out var provider))
+                    Add(provider);
             }
             catch { }
             finally { process.Dispose(); }
@@ -2541,6 +2539,30 @@ internal sealed class AgentActivityScanner
         // not several simultaneous tasks.
         void Add(ProviderId provider) => live[provider] = 1;
     }
+
+    private static bool TryGetDesktopProvider(string processName, out ProviderId provider)
+    {
+        provider = default;
+        switch (processName.ToLowerInvariant())
+        {
+            case "codex":
+            case "chatgpt": provider = ProviderId.Codex; return true;
+            case "claude": provider = ProviderId.Claude; return true;
+            case "grok": provider = ProviderId.Grok; return true;
+            case "cursor": provider = ProviderId.Cursor; return true;
+            case "antigravity": provider = ProviderId.Antigravity; return true;
+            case "opencode":
+            case "opencode beta":
+            case "opencode-beta": provider = ProviderId.OpenCode; return true;
+            case "devin": provider = ProviderId.Devin; return true;
+            case "cline": provider = ProviderId.Cline; return true;
+            case "kimi": provider = ProviderId.Kimi; return true;
+            default: return false;
+        }
+    }
+
+    internal static ProviderId? DetectDesktopProviderForTesting(string processName)
+        => TryGetDesktopProvider(processName, out var provider) ? provider : null;
 
     /// <summary>
     /// Finds agents launched from CMD, PowerShell, Windows Terminal, or a script runtime. This is

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -36,6 +36,7 @@ internal sealed class AgentActivityScanner
         var files = new List<(ProviderId Provider, string Path, DateTimeOffset Modified)>();
         AddRecent(files, Path.Combine(_home, ".codex", "sessions"), ProviderId.Codex, cancellationToken);
         AddRecent(files, Path.Combine(_home, ".claude", "projects"), ProviderId.Claude, cancellationToken);
+        AddGrokSessions(files, cancellationToken);
         AddOpenCodeDatabases(files, cancellationToken);
 
         var parsed = new List<AgentActivityItem>();
@@ -46,7 +47,12 @@ internal sealed class AgentActivityScanner
             int claim = liveClaims.TryGetValue(file.Provider, out var currentClaim) ? currentClaim : 0;
             bool claimLive = liveProviders.TryGetValue(file.Provider, out var liveCount) && claim < liveCount;
             liveClaims[file.Provider] = claim + 1;
-            if (file.Provider == ProviderId.OpenCode)
+            if (file.Provider == ProviderId.Grok)
+            {
+                if (TryReadGrokSession(file.Path, file.Modified, claimLive, out var grokItem))
+                    parsed.Add(grokItem);
+            }
+            else if (file.Provider == ProviderId.OpenCode)
             {
                 parsed.AddRange(ReadOpenCodeSessions(file.Path, file.Modified, claimLive));
             }
@@ -77,6 +83,47 @@ internal sealed class AgentActivityScanner
                 var modified = File.GetLastWriteTimeUtc(path);
                 if (DateTime.UtcNow - modified <= RecentWindow)
                     output.Add((provider, path, new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
+            }
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    private void AddGrokSessions(List<(ProviderId, string, DateTimeOffset)> output,
+        CancellationToken cancellationToken)
+    {
+        var grokHome = Environment.GetEnvironmentVariable("GROK_HOME");
+        if (string.IsNullOrWhiteSpace(grokHome))
+            grokHome = Path.Combine(_home, ".grok");
+
+        var root = Path.Combine(grokHome, "sessions");
+        if (!Directory.Exists(root))
+            return;
+
+        try
+        {
+            foreach (var summaryPath in Directory.EnumerateFiles(root, "summary.json", SearchOption.AllDirectories))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var sessionDirectory = Path.GetDirectoryName(summaryPath);
+                if (string.IsNullOrWhiteSpace(sessionDirectory))
+                    continue;
+
+                var modified = File.GetLastWriteTimeUtc(summaryPath);
+                foreach (var name in new[] { "chat_history.jsonl", "events.jsonl", "prompt_context.json" })
+                {
+                    var companion = Path.Combine(sessionDirectory, name);
+                    if (File.Exists(companion))
+                    {
+                        var companionModified = File.GetLastWriteTimeUtc(companion);
+                        if (companionModified > modified)
+                            modified = companionModified;
+                    }
+                }
+
+                if (DateTime.UtcNow - modified <= RecentWindow)
+                    output.Add((ProviderId.Grok, summaryPath,
+                        new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
             }
         }
         catch (IOException) { }
@@ -184,6 +231,307 @@ internal sealed class AgentActivityScanner
         catch (IOException) { return false; }
         catch (UnauthorizedAccessException) { return false; }
         catch (JsonException) { return false; }
+    }
+
+    private static bool TryReadGrokSession(string summaryPath, DateTimeOffset modified,
+        bool claimLive, out AgentActivityItem item)
+    {
+        item = default!;
+        try
+        {
+            var sessionDirectory = Path.GetDirectoryName(summaryPath);
+            if (string.IsNullOrWhiteSpace(sessionDirectory))
+                return false;
+
+            using var summaryDocument = JsonDocument.Parse(File.ReadAllText(summaryPath));
+            var summary = summaryDocument.RootElement;
+            var info = summary.TryGetProperty("info", out var infoNode) && infoNode.ValueKind == JsonValueKind.Object
+                ? infoNode
+                : default;
+            var threadId = FirstNonEmpty(
+                FirstString(info, "id"),
+                FirstString(summary, "session_id", "sessionId", "id"),
+                Path.GetFileName(sessionDirectory));
+            var parentThreadId = FirstString(summary, "parent_session_id", "parentSessionId", "parent_thread_id", "parentThreadId");
+            var model = FirstNonEmpty(
+                FirstString(summary, "current_model_id", "model_id", "model"),
+                FirstString(info, "current_model_id", "model_id", "model"));
+            var createdAt = FirstTimestamp(summary, "created_at", "createdAt")
+                ?? FirstTimestamp(info, "created_at", "createdAt")
+                ?? modified;
+            var summaryUpdatedAt = FirstTimestamp(summary, "last_active_at", "updated_at", "updatedAt")
+                ?? FirstTimestamp(info, "last_active_at", "updated_at", "updatedAt");
+
+            var history = ReadGrokTail(Path.Combine(sessionDirectory, "chat_history.jsonl"));
+            var events = ReadGrokTail(Path.Combine(sessionDirectory, "events.jsonl"));
+            var historyInfo = ParseGrokHistory(history);
+            var eventInfo = ParseGrokEvents(events);
+            var lastActivity = Max(modified, summaryUpdatedAt ?? modified,
+                historyInfo.LastActivity ?? modified, eventInfo.LastActivity ?? modified);
+            var fresh = DateTimeOffset.Now - lastActivity < BusyWindow;
+            var live = claimLive && modified > DateTimeOffset.Now - RecentWindow;
+            var state = eventInfo.State != TranscriptState.Unknown ? eventInfo.State : historyInfo.State;
+            var status = !live
+                ? state == TranscriptState.Failed ? AgentActivityStatus.Failed : AgentActivityStatus.Completed
+                : state == TranscriptState.Waiting
+                    ? AgentActivityStatus.Waiting
+                    : fresh ? AgentActivityStatus.Working : AgentActivityStatus.Idle;
+
+            var prompt = historyInfo.Prompt;
+            var title = FirstNonEmpty(
+                SummarizeTitle(prompt) ?? "",
+                SummarizeTitle(FirstString(summary, "session_summary", "summary")) ?? "",
+                FirstString(summary, "agent_name", "agentName"),
+                "Grok");
+            var step = status == AgentActivityStatus.Completed
+                ? "Completed"
+                : status == AgentActivityStatus.Failed
+                    ? "Failed"
+                    : status == AgentActivityStatus.Waiting
+                        ? string.IsNullOrWhiteSpace(eventInfo.Step) ? "Waiting for input" : eventInfo.Step
+                    : status == AgentActivityStatus.Idle ? "Waiting for the next prompt"
+                    : !string.IsNullOrWhiteSpace(eventInfo.Step) ? eventInfo.Step
+                    : !string.IsNullOrWhiteSpace(historyInfo.Step) ? historyInfo.Step
+                    : !string.IsNullOrWhiteSpace(historyInfo.Summary) ? historyInfo.Summary
+                    : "Thinking";
+            item = new AgentActivityItem(
+                $"grok:{threadId}", ProviderId.Grok, Trim(Clean(title), 72), step, status,
+                createdAt, lastActivity,
+                Detail: prompt,
+                Model: Clean(model),
+                ThreadId: threadId,
+                ParentThreadId: parentThreadId,
+                Host: DetectHost(summary));
+            return true;
+        }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+        catch (JsonException) { return false; }
+    }
+
+    internal static IReadOnlyList<AgentActivityItem> ReadGrokForTesting(string summaryPath,
+        bool claimLive = true)
+    {
+        var modified = File.GetLastWriteTimeUtc(summaryPath);
+        return TryReadGrokSession(summaryPath,
+            new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime(), claimLive,
+            out var item)
+            ? new[] { item }
+            : Array.Empty<AgentActivityItem>();
+    }
+
+    private static string ReadGrokTail(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+                return "";
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete);
+            stream.Seek(Math.Max(0, stream.Length - 262_144), SeekOrigin.Begin);
+            using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            return reader.ReadToEnd();
+        }
+        catch (IOException) { return ""; }
+        catch (UnauthorizedAccessException) { return ""; }
+    }
+
+    private static GrokTranscriptInfo ParseGrokHistory(string text)
+    {
+        string prompt = "", step = "", summary = "";
+        var state = TranscriptState.Unknown;
+        DateTimeOffset? activity = null;
+        foreach (var line in text.Split('\n'))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+            try
+            {
+                using var document = JsonDocument.Parse(line);
+                var root = document.RootElement;
+                var type = FirstString(root, "type");
+                activity = FirstTimestamp(root, "timestamp", "ts", "created_at") ?? activity;
+                if (type == "user")
+                {
+                    var synthetic = FirstString(root, "synthetic_reason", "syntheticReason");
+                    var content = root.TryGetProperty("content", out var contentNode)
+                        ? ExtractGrokText(contentNode)
+                        : "";
+                    if (synthetic.Length == 0 && content.Length > 0)
+                        prompt = content;
+                    if (state == TranscriptState.Unknown || content.Length > 0)
+                    {
+                        state = TranscriptState.Action;
+                        step = "Thinking";
+                    }
+                }
+                else if (type == "assistant")
+                {
+                    if (root.TryGetProperty("tool_calls", out var calls) && calls.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var call in calls.EnumerateArray().Reverse())
+                        {
+                            var name = FirstString(call, "name");
+                            if (name.Length == 0 && call.TryGetProperty("function", out var function))
+                                name = FirstString(function, "name");
+                            if (name.Length > 0)
+                            {
+                                step = DescribeGrokAction(name, GetPayloadDetails(call));
+                                state = TranscriptState.Action;
+                                break;
+                            }
+                        }
+                    }
+                    else if (root.TryGetProperty("content", out var content))
+                    {
+                        summary = ExtractGrokText(content);
+                    }
+                }
+                else if (type is "reasoning" or "backend_tool_call")
+                {
+                    summary = ExtractGrokText(root);
+                    state = TranscriptState.Action;
+                }
+                else if (type is "tool_result" or "backend_tool_result")
+                {
+                    state = TranscriptState.Action;
+                }
+            }
+            catch (JsonException) { }
+        }
+
+        return new GrokTranscriptInfo(prompt, step, summary, state, activity);
+    }
+
+    private static GrokTranscriptInfo ParseGrokEvents(string text)
+    {
+        string step = "";
+        var state = TranscriptState.Unknown;
+        DateTimeOffset? activity = null;
+        foreach (var line in text.Split('\n'))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+            try
+            {
+                using var document = JsonDocument.Parse(line);
+                var root = document.RootElement;
+                var type = FirstString(root, "type");
+                activity = FirstTimestamp(root, "ts", "timestamp", "created_at") ?? activity;
+                switch (type)
+                {
+                    case "turn_started":
+                    case "loop_started":
+                        state = TranscriptState.Action;
+                        step = "Thinking";
+                        break;
+                    case "phase_changed":
+                        var phase = FirstString(root, "phase");
+                        if (phase.Contains("permission", StringComparison.OrdinalIgnoreCase))
+                        {
+                            state = TranscriptState.Waiting;
+                            step = "Waiting for input";
+                        }
+                        else if (phase.Length > 0)
+                        {
+                            state = TranscriptState.Action;
+                            step = phase switch
+                            {
+                                "tool_execution" => "Running command",
+                                "streaming_reasoning" => "Thinking",
+                                "streaming_text" => "Writing response",
+                                _ => step,
+                            };
+                        }
+                        break;
+                    case "tool_started":
+                    case "mcp_tool_call_started":
+                        var tool = FirstString(root, "tool_name", "tool", "name");
+                        state = TranscriptState.Action;
+                        step = tool.Length == 0 ? "Running command" : DescribeGrokAction(tool, GetPayloadDetails(root));
+                        break;
+                    case "permission_requested":
+                        state = TranscriptState.Waiting;
+                        step = "Waiting for input";
+                        break;
+                    case "permission_resolved":
+                        var decision = FirstString(root, "decision");
+                        state = decision.Contains("deny", StringComparison.OrdinalIgnoreCase)
+                            || decision.Contains("cancel", StringComparison.OrdinalIgnoreCase)
+                            ? TranscriptState.Failed
+                            : TranscriptState.Action;
+                        break;
+                    case "turn_ended":
+                        var outcome = FirstString(root, "outcome");
+                        state = outcome.Contains("error", StringComparison.OrdinalIgnoreCase)
+                            ? TranscriptState.Failed
+                            : TranscriptState.Finished;
+                        break;
+                }
+            }
+            catch (JsonException) { }
+        }
+
+        return new GrokTranscriptInfo("", step, "", state, activity);
+    }
+
+    private static string ExtractGrokText(JsonElement value)
+    {
+        if (value.ValueKind == JsonValueKind.String)
+            return Clean(value.GetString());
+        if (value.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var part in value.EnumerateArray().Reverse())
+            {
+                var text = ExtractGrokText(part);
+                if (text.Length > 0)
+                    return text;
+            }
+            return "";
+        }
+        if (value.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var name in new[] { "text", "content", "summary", "summary_text", "message" })
+            {
+                if (!value.TryGetProperty(name, out var nested))
+                    continue;
+                var text = ExtractGrokText(nested);
+                if (text.Length > 0)
+                    return text;
+            }
+        }
+        return "";
+    }
+
+    private static string DescribeGrokAction(string name, string? details)
+    {
+        var normalized = name.ToLowerInvariant();
+        if (normalized.Contains("shell") || normalized.Contains("terminal")
+            || normalized.Contains("command") || normalized is "bash" or "cmd" or "powershell")
+            return DescribeAction("shell_command", details);
+        if (normalized.Contains("patch") || normalized.Contains("edit") || normalized.Contains("write"))
+            return "Edited code";
+        if (normalized.Contains("read") || normalized.Contains("search") || normalized.Contains("grep")
+            || normalized.Contains("glob") || normalized.Contains("list"))
+            return "Inspected files";
+        if (normalized.Contains("agent") || normalized.Contains("subagent"))
+            return "Running subagent";
+        return DescribeAction(name, details);
+    }
+
+    private static DateTimeOffset? FirstTimestamp(JsonElement value, params string[] names)
+    {
+        if (value.ValueKind != JsonValueKind.Object)
+            return null;
+        foreach (var name in names)
+        {
+            if (!value.TryGetProperty(name, out var property))
+                continue;
+            if (property.ValueKind == JsonValueKind.String
+                && DateTimeOffset.TryParse(property.GetString(), out var parsed))
+                return parsed.ToLocalTime();
+        }
+        return null;
     }
 
     private static IReadOnlyList<AgentActivityItem> ReadOpenCodeSessions(
@@ -836,11 +1184,16 @@ internal sealed class AgentActivityScanner
 
     private static string FirstString(JsonElement value, params string[] names)
     {
+        if (value.ValueKind != JsonValueKind.Object)
+            return "";
         foreach (var name in names)
             if (value.TryGetProperty(name, out var property) && property.ValueKind == JsonValueKind.String)
                 return property.GetString() ?? "";
         return "";
     }
+
+    private static string FirstNonEmpty(params string[] values)
+        => values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value)) ?? "";
 
     private static string? SummarizeTitle(string? prompt)
     {
@@ -935,6 +1288,7 @@ internal sealed class AgentActivityScanner
                     case "codex":
                     case "chatgpt": Add(ProviderId.Codex); break;
                     case "claude": Add(ProviderId.Claude); break;
+                    case "grok": Add(ProviderId.Grok); break;
                     case "cursor": Add(ProviderId.Cursor); break;
                     case "antigravity": Add(ProviderId.Antigravity); break;
                     case "devin": Add(ProviderId.Devin); break;
@@ -962,7 +1316,7 @@ internal sealed class AgentActivityScanner
             "Name = 'bun.exe' OR Name = 'deno.exe' OR Name = 'npm.exe' OR Name = 'npx.exe' OR " +
             "Name = 'pnpm.exe' OR Name = 'yarn.exe' OR Name = 'wsl.exe' OR Name = 'bash.exe' OR " +
             "Name = 'codex.exe' OR Name = 'claude.exe' OR Name = 'cursor-agent.exe' OR " +
-            "Name = 'opencode.exe' OR Name = 'cline.exe' OR Name = 'agy.exe'";
+            "Name = 'opencode.exe' OR Name = 'cline.exe' OR Name = 'agy.exe' OR Name = 'grok.exe'";
 
         try
         {
@@ -993,6 +1347,7 @@ internal sealed class AgentActivityScanner
         if (text.Contains("claude-code") || text.Contains(" claude") || executable.Equals("claude", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Claude; return true; }
         if (text.Contains("cursor-agent") || text.Contains("cursor agent")) { provider = ProviderId.Cursor; return true; }
         if (text.Contains("antigravity") || executable.Equals("agy", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Antigravity; return true; }
+        if (text.Contains("grok") || executable.Equals("grok", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Grok; return true; }
         if (text.Contains("opencode")) { provider = ProviderId.OpenCode; return true; }
         if (text.Contains("cline")) { provider = ProviderId.Cline; return true; }
         if (text.Contains(" codex") || executable.Equals("codex", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Codex; return true; }
@@ -1088,6 +1443,8 @@ internal sealed class AgentActivityScanner
     private sealed record OpenCodeSessionRow(string Id, string? ParentId, string Title, string Model, long CreatedAt, long UpdatedAt);
     private sealed record OpenCodeMessageRow(string Id, string Data, long CreatedAt, long UpdatedAt);
     private sealed record OpenCodePartRow(string Id, string MessageId, string Data, long CreatedAt, long UpdatedAt);
+    private sealed record GrokTranscriptInfo(string Prompt, string Step, string Summary,
+        TranscriptState State, DateTimeOffset? LastActivity);
     private sealed record OpenCodeMessageInfo(
         string Id, string Role, DateTimeOffset CreatedAt, DateTimeOffset ActivityAt, bool Completed, bool Failed);
     private sealed record OpenCodePartInfo(

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -7,6 +7,7 @@ using System.Management;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
+using TaskbarQuota.ActiveApp;
 using TaskbarQuota.Diagnostics;
 using TaskbarQuota.Usage;
 
@@ -47,7 +48,7 @@ internal sealed class AgentActivityScanner
                 parsed.Add(item);
         }
 
-        return GroupSessions(parsed)
+        return ApplyActiveHostFallback(GroupSessions(parsed))
             .Where(item => item.IsLive || DateTimeOffset.Now - item.UpdatedAt < RecentWindow)
             .OrderByDescending(item => item.IsLive)
             .ThenByDescending(item => item.UpdatedAt)
@@ -133,7 +134,7 @@ internal sealed class AgentActivityScanner
                 ParentThreadId: provider == ProviderId.Claude
                     ? claude?.ParentThreadId ?? info.ParentThreadId
                     : session.ParentThreadId ?? info.ParentThreadId,
-                Host: session.Host);
+                Host: session.Host ?? info.Host);
             return true;
         }
         catch (IOException) { return false; }
@@ -155,18 +156,10 @@ internal sealed class AgentActivityScanner
             if (!root.TryGetProperty("type", out var type) || type.GetString() != "session_meta"
                 || !root.TryGetProperty("payload", out var payload) || payload.ValueKind != JsonValueKind.Object)
                 return default;
-            var originator = payload.TryGetProperty("originator", out var originatorNode)
-                ? originatorNode.GetString()
-                : null;
-            var host = originator?.Equals("t3code_desktop", StringComparison.OrdinalIgnoreCase) == true
-                ? "T3 Code"
-                : originator?.Contains("synara", StringComparison.OrdinalIgnoreCase) == true
-                    ? "Synara"
-                    : null;
             return new SessionMetadata(
                 payload.TryGetProperty("id", out var id) ? id.GetString() : null,
                 payload.TryGetProperty("parent_thread_id", out var parent) ? parent.GetString() : null,
-                host);
+                DetectHost(payload));
         }
         catch (IOException) { return default; }
         catch (UnauthorizedAccessException) { return default; }
@@ -175,7 +168,7 @@ internal sealed class AgentActivityScanner
 
     private static TailInfo ParseTail(ProviderId provider, string text)
     {
-        string step = "", summary = "", model = "", threadId = "", parentId = "", prompt = "";
+        string step = "", summary = "", model = "", threadId = "", parentId = "", prompt = "", host = "";
         DateTimeOffset? started = null, activity = null;
         var state = TranscriptState.Unknown;
         foreach (var line in text.Split('\n').Reverse())
@@ -195,10 +188,15 @@ internal sealed class AgentActivityScanner
 
                 if (provider == ProviderId.Claude)
                     ParseClaudeEvent(root, ref step, ref summary, ref model, ref threadId,
-                        ref parentId, ref prompt, ref state);
+                        ref parentId, ref prompt, ref host, ref state);
+
+                if (host.Length == 0)
+                    host = DetectHost(root) ?? "";
 
                 if (root.TryGetProperty("payload", out var payload) && payload.ValueKind == JsonValueKind.Object)
                 {
+                    if (host.Length == 0)
+                        host = DetectHost(payload) ?? "";
                     if (parentId.Length == 0 && payload.TryGetProperty("parent_thread_id", out var parent)) parentId = JsonText(parent);
                     if (model.Length == 0 && payload.TryGetProperty("model", out var modelNode)) model = JsonText(modelNode);
 
@@ -257,7 +255,7 @@ internal sealed class AgentActivityScanner
                 break;
         }
 
-        return new TailInfo(step, summary, model, threadId, parentId, prompt, started, activity, state);
+        return new TailInfo(step, summary, model, threadId, parentId, prompt, host, started, activity, state);
     }
 
     internal static TailInfo ParseTranscriptForTesting(ProviderId provider, string text)
@@ -268,11 +266,14 @@ internal sealed class AgentActivityScanner
 
     private static void ParseClaudeEvent(JsonElement root, ref string step, ref string summary,
         ref string model, ref string threadId, ref string parentId, ref string prompt,
-        ref TranscriptState state)
+        ref string host, ref TranscriptState state)
     {
         var type = root.TryGetProperty("type", out var typeNode) ? typeNode.GetString() : null;
         if (type is not ("user" or "assistant"))
             return;
+
+        if (host.Length == 0)
+            host = DetectHost(root) ?? "";
 
         if (threadId.Length == 0)
             threadId = FirstString(root, "sessionId", "session_id", "uuid");
@@ -435,6 +436,40 @@ internal sealed class AgentActivityScanner
 
     private static string JsonText(JsonElement value)
         => value.ValueKind == JsonValueKind.String ? value.GetString() ?? "" : value.ToString();
+
+    private static string? DetectHost(JsonElement value)
+    {
+        foreach (var name in new[] { "originator", "host", "host_app", "source", "origin", "runtime" })
+        {
+            if (!value.TryGetProperty(name, out var property))
+                continue;
+
+            if (property.ValueKind == JsonValueKind.Object)
+            {
+                if (DetectHost(property) is { } nested)
+                    return nested;
+                continue;
+            }
+
+            if (property.ValueKind == JsonValueKind.String && MapHost(property.GetString()) is { } host)
+                return host;
+        }
+
+        return null;
+    }
+
+    private static string? MapHost(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        if (value.Contains("t3code", StringComparison.OrdinalIgnoreCase)
+            || value.Contains("t3 code", StringComparison.OrdinalIgnoreCase))
+            return "T3 Code";
+        if (value.Contains("synara", StringComparison.OrdinalIgnoreCase)
+            || value.Contains("dpcode", StringComparison.OrdinalIgnoreCase))
+            return "Synara";
+        return null;
+    }
 
     private static string FirstString(JsonElement value, params string[] names)
     {
@@ -654,10 +689,36 @@ internal sealed class AgentActivityScanner
         return groups;
     }
 
+    private static IReadOnlyList<AgentActivityItem> ApplyActiveHostFallback(IReadOnlyList<AgentActivityItem> items)
+    {
+        var selection = UsageCoordinator.Instance.ActiveSynaraHost;
+        if (selection is null)
+            return items;
+
+        var host = selection.Host == HostApp.T3Code ? "T3 Code" : "Synara";
+        var candidates = items
+            .Where(item => item.Provider == selection.Provider && string.IsNullOrWhiteSpace(item.Host))
+            .ToArray();
+        if (candidates.Length == 0)
+            return items;
+
+        AgentActivityItem? selected = null;
+        if (!string.IsNullOrWhiteSpace(selection.ThreadTitle))
+            selected = candidates.FirstOrDefault(item => string.Equals(
+                item.Title, selection.ThreadTitle, StringComparison.OrdinalIgnoreCase));
+        selected ??= candidates.Where(item => item.IsLive)
+            .OrderByDescending(item => item.UpdatedAt)
+            .FirstOrDefault()
+            ?? candidates.OrderByDescending(item => item.UpdatedAt).First();
+
+        return items.Select(item => item.Id == selected.Id ? item with { Host = host } : item).ToArray();
+    }
+
     internal enum TranscriptState { Unknown, Action, Waiting, Finished }
 
     internal sealed record TailInfo(string Step, string Summary, string Model, string ThreadId,
-        string ParentThreadId, string Prompt, DateTimeOffset? StartedAt, DateTimeOffset? LastActivity, TranscriptState State);
+        string ParentThreadId, string Prompt, string Host, DateTimeOffset? StartedAt,
+        DateTimeOffset? LastActivity, TranscriptState State);
     private sealed record ClaudeToolAction(string Step, bool Waiting);
     private sealed record ClaudeSessionContext(string? ThreadId, string? ParentThreadId, string? ProjectTitle);
     private readonly record struct SessionMetadata(string? ThreadId, string? ParentThreadId, string? Host);

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -1653,10 +1653,10 @@ internal sealed class AgentActivityScanner
                 && metadataNode.ValueKind == JsonValueKind.Object
                 ? metadataNode
                 : default;
-            var prompt = FirstString(metadata, "prompt") ?? FirstString(root, "prompt") ?? "";
-            var title = FirstString(metadata, "title", "name") ?? FirstString(root, "title") ?? "";
-            var model = FirstString(root, "model") ?? "";
-            var statusText = (FirstString(root, "status") ?? "").ToLowerInvariant();
+            var prompt = FirstNonEmpty(FirstString(metadata, "prompt"), FirstString(root, "prompt"));
+            var title = FirstNonEmpty(FirstString(metadata, "title", "name"), FirstString(root, "title"));
+            var model = FirstString(root, "model");
+            var statusText = FirstString(root, "status").ToLowerInvariant();
             var startedAt = FirstTimestampAny(root, "started_at", "startedAt", "created_at", "createdAt")
                 ?? modified;
             var messagesPath = FirstString(root, "messages_path", "messagesPath");

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Management;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.Data.Sqlite;
 using TaskbarQuota.ActiveApp;
@@ -37,6 +38,7 @@ internal sealed class AgentActivityScanner
         AddRecent(files, Path.Combine(_home, ".codex", "sessions"), ProviderId.Codex, cancellationToken);
         AddRecent(files, Path.Combine(_home, ".claude", "projects"), ProviderId.Claude, cancellationToken);
         AddGrokSessions(files, cancellationToken);
+        AddAntigravityDatabases(files, cancellationToken);
         AddOpenCodeDatabases(files, cancellationToken);
 
         var parsed = new List<AgentActivityItem>();
@@ -51,6 +53,11 @@ internal sealed class AgentActivityScanner
             {
                 if (TryReadGrokSession(file.Path, file.Modified, claimLive, out var grokItem))
                     parsed.Add(grokItem);
+            }
+            else if (file.Provider == ProviderId.Antigravity)
+            {
+                if (TryReadAntigravitySession(file.Path, file.Modified, claimLive, out var antigravityItem))
+                    parsed.Add(antigravityItem);
             }
             else if (file.Provider == ProviderId.OpenCode)
             {
@@ -128,6 +135,301 @@ internal sealed class AgentActivityScanner
         }
         catch (IOException) { }
         catch (UnauthorizedAccessException) { }
+    }
+
+    private void AddAntigravityDatabases(List<(ProviderId, string, DateTimeOffset)> output,
+        CancellationToken cancellationToken)
+    {
+        var root = GetAntigravityCliHome();
+        var conversations = Path.Combine(root, "conversations");
+        if (!Directory.Exists(conversations))
+            return;
+
+        try
+        {
+            foreach (var path in Directory.EnumerateFiles(conversations, "*.db", SearchOption.TopDirectoryOnly))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var modified = File.GetLastWriteTimeUtc(path);
+                var wal = path + "-wal";
+                if (File.Exists(wal))
+                {
+                    var walModified = File.GetLastWriteTimeUtc(wal);
+                    if (walModified > modified)
+                        modified = walModified;
+                }
+
+                if (DateTime.UtcNow - modified <= RecentWindow)
+                    output.Add((ProviderId.Antigravity, path,
+                        new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
+            }
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    private static string GetAntigravityCliHome()
+    {
+        var root = Environment.GetEnvironmentVariable("ANTIGRAVITY_CLI_HOME");
+        return string.IsNullOrWhiteSpace(root)
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "antigravity-cli")
+            : root;
+    }
+
+    private static AntigravityConversationMetadata? ReadAntigravityMetadata(string root, string id)
+    {
+        var path = Path.Combine(root, "cache", "conversation_metadata.json");
+        try
+        {
+            if (!File.Exists(path))
+                return null;
+            return ParseAntigravityMetadata(File.ReadAllText(path), id);
+        }
+        catch (IOException) { return null; }
+        catch (UnauthorizedAccessException) { return null; }
+        catch (JsonException) { return null; }
+    }
+
+    private static AntigravityConversationMetadata? ParseAntigravityMetadata(string json, string id)
+    {
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        if (!root.TryGetProperty("conversations", out var conversations)
+            || conversations.ValueKind != JsonValueKind.Object
+            || !conversations.TryGetProperty(id, out var entry)
+            || entry.ValueKind != JsonValueKind.Object)
+            return null;
+
+        var summary = entry.TryGetProperty("summary", out var summaryNode)
+            && summaryNode.ValueKind == JsonValueKind.Object
+            ? summaryNode
+            : entry;
+        var workspace = "";
+        if (summary.TryGetProperty("WorkspaceURIs", out var workspaceNodes)
+            && workspaceNodes.ValueKind == JsonValueKind.Array)
+        {
+            workspace = workspaceNodes.EnumerateArray()
+                .Where(value => value.ValueKind == JsonValueKind.String)
+                .Select(value => value.GetString() ?? "")
+                .Select(ToAntigravityWorkspacePath)
+                .FirstOrDefault(value => value.Length > 0) ?? "";
+        }
+
+        return new AntigravityConversationMetadata(
+            FirstString(summary, "ID", "id"),
+            Clean(FirstString(summary, "Title", "title")),
+            Clean(FirstString(summary, "Preview", "preview")),
+            workspace,
+            FirstTimestamp(summary, "UpdatedAt", "updatedAt", "updated_at"),
+            Clean(FirstString(summary, "AgentName", "agentName")));
+    }
+
+    internal static (string Title, string Preview, string Workspace)? ParseAntigravityMetadataForTesting(
+        string json, string id)
+    {
+        var metadata = ParseAntigravityMetadata(json, id);
+        return metadata is null ? null : (metadata.Title, metadata.Preview, metadata.Workspace);
+    }
+
+    private static string ToAntigravityWorkspacePath(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return "";
+        if (Uri.TryCreate(value, UriKind.Absolute, out var uri) && uri.IsFile)
+            return NormalizeAntigravityPath(uri.LocalPath);
+        return NormalizeAntigravityPath(value.StartsWith("file://", StringComparison.OrdinalIgnoreCase)
+            ? Uri.UnescapeDataString(value[7..]).Replace('/', '\\')
+            : value);
+    }
+
+    private static string NormalizeAntigravityPath(string value)
+    {
+        if (value.Length >= 2 && value[1] == ':' && char.IsLetter(value[0]))
+            return char.ToUpperInvariant(value[0]) + value[1..];
+        return value;
+    }
+
+    private static bool TryReadAntigravitySession(string dbPath, DateTimeOffset modified,
+        bool claimLive, out AgentActivityItem item)
+    {
+        item = default!;
+        try
+        {
+            var id = Path.GetFileNameWithoutExtension(dbPath);
+            var metadata = ReadAntigravityMetadata(GetAntigravityCliHome(), id);
+            var rows = ReadAntigravitySteps(dbPath);
+            if (rows.Count == 0 && metadata is null)
+                return false;
+
+            var blobs = rows.SelectMany(row => row.Blobs).ToArray();
+            var toolSummary = ExtractAntigravityField(blobs, "toolSummary");
+            var toolAction = ExtractAntigravityField(blobs, "toolAction");
+            var toolName = ExtractAntigravityField(blobs, "toolName", "tool_name", "name");
+            var prompt = FirstNonEmpty(
+                metadata?.Preview ?? "",
+                ExtractAntigravityField(blobs, "prompt", "userMessage", "user_message"));
+            var model = ExtractAntigravityField(blobs, "model", "model_id", "modelId");
+            var parentId = ExtractAntigravityField(blobs,
+                "parent_conversation_id", "parentConversationId", "parent_thread_id");
+            var lastActivity = Max(modified, metadata?.UpdatedAt ?? modified);
+            var fresh = DateTimeOffset.Now - lastActivity < BusyWindow;
+            var live = claimLive && modified > DateTimeOffset.Now - RecentWindow;
+            var waiting = AntigravityContainsAny(rows.Select(row => row.Permissions),
+                "permission", "approval", "confirmation", "waiting_for_user", "request_user_input")
+                || AntigravityContainsAny(blobs,
+                    "waiting_for_user", "request_confirmation", "permission_requested", "needs_confirmation");
+            var failed = AntigravityContainsAny(rows.Select(row => row.ErrorDetails),
+                "error", "failed", "failure", "exception");
+            var state = !live
+                ? failed ? AgentActivityStatus.Failed : AgentActivityStatus.Completed
+                : waiting
+                    ? AgentActivityStatus.Waiting
+                    : fresh ? AgentActivityStatus.Working : AgentActivityStatus.Idle;
+
+            var action = FirstNonEmpty(Clean(toolSummary), Clean(toolAction));
+            var step = state == AgentActivityStatus.Completed
+                ? "Completed"
+                : state == AgentActivityStatus.Failed
+                    ? "Failed"
+                    : state == AgentActivityStatus.Waiting
+                        ? "Waiting for input"
+                    : state == AgentActivityStatus.Idle
+                        ? "Waiting for the next prompt"
+                    : action.Length > 0
+                        ? action
+                        : DescribeAntigravityAction(toolName, ExtractAntigravityField(blobs, "command", "input"));
+            var title = FirstNonEmpty(
+                metadata?.Title ?? "",
+                metadata?.Preview ?? "",
+                SummarizeTitle(prompt) ?? "",
+                metadata?.AgentName ?? "",
+                "Antigravity");
+            item = new AgentActivityItem(
+                $"antigravity:{id}", ProviderId.Antigravity, Trim(Clean(title), 72), step, state,
+                metadata?.UpdatedAt ?? modified, lastActivity,
+                SubagentCount: rows.Count(row => row.HasSubtrajectory),
+                Detail: prompt,
+                Model: Clean(model),
+                ThreadId: id,
+                ParentThreadId: Clean(parentId));
+            return true;
+        }
+        catch (SqliteException) { return false; }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+        catch (InvalidOperationException) { return false; }
+        catch (JsonException) { return false; }
+    }
+
+    internal static IReadOnlyList<AgentActivityItem> ReadAntigravityForTesting(string dbPath,
+        bool claimLive = true)
+    {
+        var modified = File.GetLastWriteTimeUtc(dbPath);
+        return TryReadAntigravitySession(dbPath,
+            new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime(), claimLive,
+            out var item)
+            ? new[] { item }
+            : Array.Empty<AgentActivityItem>();
+    }
+
+    private static IReadOnlyList<AntigravityStepRow> ReadAntigravitySteps(string path)
+    {
+        var rows = new List<AntigravityStepRow>();
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = path,
+            Mode = SqliteOpenMode.ReadOnly,
+            Cache = SqliteCacheMode.Shared,
+            Pooling = false,
+        }.ToString();
+        using var connection = new SqliteConnection(connectionString);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT idx, step_type, status, has_subtrajectory,
+                   metadata, error_details, permissions, task_details,
+                   render_info, step_payload
+            FROM steps
+            ORDER BY idx DESC
+            LIMIT 80;
+            """;
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            rows.Add(new AntigravityStepRow(
+                reader.GetInt32(0),
+                reader.GetInt32(1),
+                reader.GetInt32(2),
+                !reader.IsDBNull(3) && reader.GetBoolean(3),
+                ReadAntigravityBlob(reader, 4),
+                ReadAntigravityBlob(reader, 5),
+                ReadAntigravityBlob(reader, 6),
+                ReadAntigravityBlob(reader, 7),
+                ReadAntigravityBlob(reader, 8),
+                ReadAntigravityBlob(reader, 9)));
+        }
+        return rows;
+    }
+
+    private static byte[]? ReadAntigravityBlob(SqliteDataReader reader, int ordinal)
+        => reader.IsDBNull(ordinal) ? null : reader.GetFieldValue<byte[]>(ordinal);
+
+    private static string ExtractAntigravityField(IEnumerable<byte[]?> blobs, params string[] names)
+    {
+        foreach (var blob in blobs)
+        {
+            if (blob is null || blob.Length == 0)
+                continue;
+            var text = Encoding.UTF8.GetString(blob);
+            foreach (var name in names)
+            {
+                var pattern = $"\\\"{Regex.Escape(name)}\\\"\\s*:\\s*\\\"(?<value>(?:\\\\.|[^\\\"\\\\])*)\\\"";
+                var match = Regex.Match(text, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+                if (!match.Success)
+                    continue;
+                var raw = match.Groups["value"].Value;
+                try
+                {
+                    return Clean(JsonSerializer.Deserialize<string>($"\\\"{raw}\\\"") ?? raw);
+                }
+                catch (JsonException)
+                {
+                    return Clean(raw);
+                }
+            }
+        }
+        return "";
+    }
+
+    private static bool AntigravityContainsAny(IEnumerable<byte[]?> blobs, params string[] markers)
+    {
+        foreach (var blob in blobs)
+        {
+            if (blob is null || blob.Length == 0)
+                continue;
+            var text = Encoding.UTF8.GetString(blob);
+            if (markers.Any(marker => text.Contains(marker, StringComparison.OrdinalIgnoreCase)))
+                return true;
+        }
+        return false;
+    }
+
+    private static string DescribeAntigravityAction(string name, string details)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return "Thinking";
+        var normalized = name.ToLowerInvariant();
+        if (normalized.Contains("shell") || normalized.Contains("terminal")
+            || normalized.Contains("command") || normalized is "bash" or "cmd" or "powershell")
+            return DescribeAction("shell_command", details);
+        if (normalized.Contains("edit") || normalized.Contains("write") || normalized.Contains("patch"))
+            return "Edited code";
+        if (normalized.Contains("read") || normalized.Contains("search") || normalized.Contains("grep")
+            || normalized.Contains("glob") || normalized.Contains("list"))
+            return "Inspected files";
+        if (normalized.Contains("agent") || normalized.Contains("subagent"))
+            return "Running subagent";
+        return $"Running {Clean(name)}";
     }
 
     private void AddOpenCodeDatabases(List<(ProviderId, string, DateTimeOffset)> output,
@@ -1451,4 +1753,14 @@ internal sealed class AgentActivityScanner
         string MessageId, string Type, DateTimeOffset ActivityAt, string Tool, string Status, string Input, string Text);
     private sealed record OpenCodeTail(
         string Step, string Summary, string Prompt, DateTimeOffset? LastActivity, TranscriptState State);
+    private sealed record AntigravityConversationMetadata(
+        string Id, string Title, string Preview, string Workspace, DateTimeOffset? UpdatedAt, string AgentName);
+    private sealed record AntigravityStepRow(
+        int Index, int StepType, int Status, bool HasSubtrajectory,
+        byte[]? Metadata, byte[]? ErrorDetails, byte[]? Permissions,
+        byte[]? TaskDetails, byte[]? RenderInfo, byte[]? Payload)
+    {
+        public IEnumerable<byte[]?> Blobs => new[]
+            { Payload, RenderInfo, TaskDetails, Metadata, ErrorDetails, Permissions };
+    }
 }

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -39,6 +39,7 @@ internal sealed class AgentActivityScanner
         AddRecent(files, Path.Combine(_home, ".claude", "projects"), ProviderId.Claude, cancellationToken);
         AddGrokSessions(files, cancellationToken);
         AddAntigravityDatabases(files, cancellationToken);
+        AddAntigravityGuiTranscripts(files, cancellationToken);
         AddOpenCodeDatabases(files, cancellationToken);
 
         var parsed = new List<AgentActivityItem>();
@@ -56,7 +57,10 @@ internal sealed class AgentActivityScanner
             }
             else if (file.Provider == ProviderId.Antigravity)
             {
-                if (TryReadAntigravitySession(file.Path, file.Modified, claimLive, out var antigravityItem))
+                var read = IsAntigravityGuiTranscript(file.Path)
+                    ? TryReadAntigravityGuiSession(file.Path, file.Modified, claimLive, out var antigravityItem)
+                    : TryReadAntigravitySession(file.Path, file.Modified, claimLive, out antigravityItem);
+                if (read)
                     parsed.Add(antigravityItem);
             }
             else if (file.Provider == ProviderId.OpenCode)
@@ -175,6 +179,41 @@ internal sealed class AgentActivityScanner
             ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "antigravity-cli")
             : root;
     }
+
+    private static string GetAntigravityGuiHome()
+    {
+        var root = Environment.GetEnvironmentVariable("ANTIGRAVITY_GUI_HOME");
+        return string.IsNullOrWhiteSpace(root)
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "antigravity")
+            : root;
+    }
+
+    private void AddAntigravityGuiTranscripts(List<(ProviderId, string, DateTimeOffset)> output,
+        CancellationToken cancellationToken)
+    {
+        var root = Path.Combine(GetAntigravityGuiHome(), "brain");
+        if (!Directory.Exists(root))
+            return;
+
+        try
+        {
+            foreach (var path in Directory.EnumerateFiles(root, "transcript.jsonl", SearchOption.AllDirectories))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var modified = File.GetLastWriteTimeUtc(path);
+                if (DateTime.UtcNow - modified <= RecentWindow)
+                    output.Add((ProviderId.Antigravity, path,
+                        new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
+            }
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    private static bool IsAntigravityGuiTranscript(string path)
+        => Path.GetFileName(path).Equals("transcript.jsonl", StringComparison.OrdinalIgnoreCase)
+            && path.Contains($"{Path.DirectorySeparatorChar}brain{Path.DirectorySeparatorChar}",
+                StringComparison.OrdinalIgnoreCase);
 
     private static AntigravityConversationMetadata? ReadAntigravityMetadata(string root, string id)
     {
@@ -330,6 +369,286 @@ internal sealed class AgentActivityScanner
             out var item)
             ? new[] { item }
             : Array.Empty<AgentActivityItem>();
+    }
+
+    private static bool TryReadAntigravityGuiSession(string transcriptPath, DateTimeOffset modified,
+        bool claimLive, out AgentActivityItem item)
+    {
+        item = default!;
+        try
+        {
+            var transcript = ReadAntigravityGuiTranscript(transcriptPath);
+            var info = ParseAntigravityGuiTranscript(transcript);
+            if (!info.HasConversation)
+                return false;
+
+            var lastActivity = Max(modified, info.LastActivity ?? modified);
+            var fresh = DateTimeOffset.Now - lastActivity < BusyWindow;
+            var live = claimLive && modified > DateTimeOffset.Now - RecentWindow;
+            var status = !live
+                ? info.State == TranscriptState.Failed ? AgentActivityStatus.Failed : AgentActivityStatus.Completed
+                : info.State == TranscriptState.Waiting
+                    ? AgentActivityStatus.Waiting
+                    : fresh ? AgentActivityStatus.Working : AgentActivityStatus.Idle;
+            var title = FirstNonEmpty(SummarizeTitle(info.Prompt) ?? "", "Antigravity");
+            var step = status == AgentActivityStatus.Completed
+                ? "Completed"
+                : status == AgentActivityStatus.Failed
+                    ? "Failed"
+                    : status == AgentActivityStatus.Waiting
+                        ? "Waiting for input"
+                    : status == AgentActivityStatus.Idle
+                        ? "Waiting for the next prompt"
+                    : FirstNonEmpty(info.Step, info.Summary, "Thinking");
+            var threadId = GetAntigravityGuiConversationId(transcriptPath);
+            item = new AgentActivityItem(
+                $"antigravity-gui:{threadId}", ProviderId.Antigravity, Trim(Clean(title), 72), step, status,
+                info.StartedAt ?? modified, lastActivity,
+                SubagentCount: info.SubagentCount,
+                Detail: info.Prompt,
+                Model: info.Model,
+                ThreadId: threadId);
+            return true;
+        }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+        catch (JsonException) { return false; }
+    }
+
+    internal static IReadOnlyList<AgentActivityItem> ReadAntigravityGuiForTesting(
+        string transcriptPath, bool claimLive = true)
+    {
+        var modified = File.GetLastWriteTimeUtc(transcriptPath);
+        return TryReadAntigravityGuiSession(transcriptPath,
+            new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime(), claimLive,
+            out var item)
+            ? new[] { item }
+            : Array.Empty<AgentActivityItem>();
+    }
+
+    private static string ReadAntigravityGuiTranscript(string path)
+    {
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete);
+        if (stream.Length <= 524_288)
+        {
+            using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            return reader.ReadToEnd();
+        }
+
+        const int headBytes = 131_072;
+        using var headReader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true,
+            bufferSize: 16_384, leaveOpen: true);
+        var head = new char[headBytes];
+        var headCount = headReader.ReadBlock(head, 0, head.Length);
+        stream.Seek(-393_216, SeekOrigin.End);
+        using var tailReader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false);
+        return new string(head, 0, headCount) + Environment.NewLine + tailReader.ReadToEnd();
+    }
+
+    private static string GetAntigravityGuiConversationId(string transcriptPath)
+    {
+        var logs = Directory.GetParent(transcriptPath);
+        var systemGenerated = logs?.Parent;
+        var brain = systemGenerated?.Parent;
+        return brain?.Name ?? Path.GetFileNameWithoutExtension(transcriptPath);
+    }
+
+    private static AntigravityGuiTranscriptInfo ParseAntigravityGuiTranscript(string text)
+    {
+        var prompt = "";
+        var step = "";
+        var summary = "";
+        var model = "";
+        var state = TranscriptState.Unknown;
+        var hasConversation = false;
+        var subagents = 0;
+        DateTimeOffset? started = null;
+        DateTimeOffset? activity = null;
+
+        foreach (var line in text.Split('\n'))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+            try
+            {
+                using var document = JsonDocument.Parse(line);
+                var root = document.RootElement;
+                var type = FirstString(root, "type");
+                var timestamp = FirstTimestamp(root, "created_at", "createdAt", "timestamp", "time");
+                if (timestamp is { } parsedTimestamp)
+                {
+                    started ??= parsedTimestamp;
+                    activity = activity is { } previous
+                        ? Max(previous, parsedTimestamp)
+                        : parsedTimestamp;
+                }
+
+                if (root.TryGetProperty("status", out var statusNode)
+                    && statusNode.ValueKind == JsonValueKind.String)
+                {
+                    var statusText = statusNode.GetString() ?? "";
+                    if (statusText.Contains("error", StringComparison.OrdinalIgnoreCase)
+                        || statusText.Contains("fail", StringComparison.OrdinalIgnoreCase))
+                        state = TranscriptState.Failed;
+                    else if (statusText.Contains("wait", StringComparison.OrdinalIgnoreCase)
+                        || statusText.Contains("pending", StringComparison.OrdinalIgnoreCase))
+                        state = TranscriptState.Waiting;
+                }
+
+                switch (type.ToUpperInvariant())
+                {
+                    case "USER_INPUT":
+                        var content = root.TryGetProperty("content", out var contentNode)
+                            ? ExtractAntigravityGuiContent(contentNode)
+                            : "";
+                        if (content.Length > 0)
+                            prompt = content;
+                        hasConversation = true;
+                        if (state is TranscriptState.Unknown or TranscriptState.Finished)
+                            state = TranscriptState.Action;
+                        step = "Thinking";
+                        break;
+
+                    case "PLANNER_RESPONSE":
+                        hasConversation = true;
+                        if (root.TryGetProperty("tool_calls", out var toolCalls)
+                            && toolCalls.ValueKind == JsonValueKind.Array)
+                        {
+                            foreach (var call in toolCalls.EnumerateArray().Reverse())
+                            {
+                                var name = FirstString(call, "name");
+                                if (name.Length == 0)
+                                    continue;
+                                var args = call.TryGetProperty("args", out var argsNode)
+                                    ? argsNode
+                                    : default;
+                                var toolSummary = FirstString(args, "toolSummary", "toolAction");
+                                var action = string.IsNullOrWhiteSpace(toolSummary)
+                                    ? DescribeAntigravityGuiAction(name, JsonText(args))
+                                    : Clean(toolSummary);
+                                var waiting = name.Contains("permission", StringComparison.OrdinalIgnoreCase)
+                                    || name.Contains("question", StringComparison.OrdinalIgnoreCase)
+                                    || name.Contains("approval", StringComparison.OrdinalIgnoreCase)
+                                    || name.Equals("ask_permission", StringComparison.OrdinalIgnoreCase)
+                                    || name.Equals("ask_question", StringComparison.OrdinalIgnoreCase);
+                                state = waiting ? TranscriptState.Waiting : TranscriptState.Action;
+                                step = waiting ? "Waiting for input" : action;
+                                if (name.Contains("subagent", StringComparison.OrdinalIgnoreCase)
+                                    || name.Equals("invoke_subagent", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    if (args.ValueKind == JsonValueKind.Object
+                                        && args.TryGetProperty("Subagents", out var subagentNodes)
+                                        && subagentNodes.ValueKind == JsonValueKind.Array)
+                                        subagents += subagentNodes.GetArrayLength();
+                                    else
+                                        subagents++;
+                                }
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            var thinking = FirstString(root, "thinking");
+                            if (thinking.Length > 0)
+                                summary = Clean(thinking);
+                            if (state == TranscriptState.Unknown)
+                                state = TranscriptState.Action;
+                            if (step.Length == 0)
+                                step = "Thinking";
+                        }
+                        model = FirstNonEmpty(model, FirstString(root, "model", "model_id", "modelId"));
+                        break;
+
+                    case "ERROR_MESSAGE":
+                        hasConversation = true;
+                        state = TranscriptState.Failed;
+                        step = "Failed";
+                        break;
+
+                    case "RUN_COMMAND":
+                    case "COMMAND_STATUS":
+                        hasConversation = true;
+                        state = TranscriptState.Action;
+                        step = "Running command";
+                        break;
+
+                    case "VIEW_FILE":
+                    case "LIST_DIRECTORY":
+                    case "GREP_SEARCH":
+                    case "FIND_BY_NAME":
+                        hasConversation = true;
+                        state = TranscriptState.Action;
+                        step = "Inspected files";
+                        break;
+
+                    case "CODE_ACTION":
+                    case "WRITE_TO_FILE":
+                    case "REPLACE_FILE_CONTENT":
+                    case "MULTI_REPLACE_FILE_CONTENT":
+                        hasConversation = true;
+                        state = TranscriptState.Action;
+                        step = "Edited code";
+                        break;
+                }
+            }
+            catch (JsonException) { }
+        }
+
+        return new AntigravityGuiTranscriptInfo(prompt, step, summary, model, started, activity,
+            state, hasConversation, subagents);
+    }
+
+    internal static AgentActivityScanner.TranscriptState ParseAntigravityGuiStateForTesting(string text)
+        => ParseAntigravityGuiTranscript(text).State;
+
+    private static string ExtractAntigravityGuiContent(JsonElement value)
+    {
+        if (value.ValueKind == JsonValueKind.String)
+            return Clean(value.GetString());
+        if (value.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var name in new[] { "text", "message", "content", "prompt" })
+            {
+                if (value.TryGetProperty(name, out var nested))
+                {
+                    var text = ExtractAntigravityGuiContent(nested);
+                    if (text.Length > 0)
+                        return text;
+                }
+            }
+        }
+        if (value.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var part in value.EnumerateArray().Reverse())
+            {
+                var text = ExtractAntigravityGuiContent(part);
+                if (text.Length > 0)
+                    return text;
+            }
+        }
+        return "";
+    }
+
+    private static string DescribeAntigravityGuiAction(string name, string details)
+    {
+        if (name is "run_command" or "command_status")
+            return DescribeAction("shell_command", details);
+        if (name.Contains("write", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("replace", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("edit", StringComparison.OrdinalIgnoreCase))
+            return "Edited code";
+        if (name.Contains("read", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("view", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("grep", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("search", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("list", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("find", StringComparison.OrdinalIgnoreCase))
+            return "Inspected files";
+        if (name.Contains("subagent", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("task", StringComparison.OrdinalIgnoreCase))
+            return "Running subagent";
+        return $"Running {Clean(name)}";
     }
 
     private static IReadOnlyList<AntigravityStepRow> ReadAntigravitySteps(string path)
@@ -1763,4 +2082,8 @@ internal sealed class AgentActivityScanner
         public IEnumerable<byte[]?> Blobs => new[]
             { Payload, RenderInfo, TaskDetails, Metadata, ErrorDetails, Permissions };
     }
+    private sealed record AntigravityGuiTranscriptInfo(
+        string Prompt, string Step, string Summary, string Model,
+        DateTimeOffset? StartedAt, DateTimeOffset? LastActivity,
+        TranscriptState State, bool HasConversation, int SubagentCount);
 }

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -7,6 +7,7 @@ using System.Management;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
+using Microsoft.Data.Sqlite;
 using TaskbarQuota.ActiveApp;
 using TaskbarQuota.Diagnostics;
 using TaskbarQuota.Usage;
@@ -35,6 +36,7 @@ internal sealed class AgentActivityScanner
         var files = new List<(ProviderId Provider, string Path, DateTimeOffset Modified)>();
         AddRecent(files, Path.Combine(_home, ".codex", "sessions"), ProviderId.Codex, cancellationToken);
         AddRecent(files, Path.Combine(_home, ".claude", "projects"), ProviderId.Claude, cancellationToken);
+        AddOpenCodeDatabases(files, cancellationToken);
 
         var parsed = new List<AgentActivityItem>();
         var liveClaims = new Dictionary<ProviderId, int>();
@@ -44,8 +46,14 @@ internal sealed class AgentActivityScanner
             int claim = liveClaims.TryGetValue(file.Provider, out var currentClaim) ? currentClaim : 0;
             bool claimLive = liveProviders.TryGetValue(file.Provider, out var liveCount) && claim < liveCount;
             liveClaims[file.Provider] = claim + 1;
-            if (TryRead(file.Provider, file.Path, file.Modified, claimLive, out var item))
+            if (file.Provider == ProviderId.OpenCode)
+            {
+                parsed.AddRange(ReadOpenCodeSessions(file.Path, file.Modified, claimLive));
+            }
+            else if (TryRead(file.Provider, file.Path, file.Modified, claimLive, out var item))
+            {
                 parsed.Add(item);
+            }
         }
 
         return ApplyActiveHostFallback(GroupSessions(parsed))
@@ -73,6 +81,42 @@ internal sealed class AgentActivityScanner
         }
         catch (IOException) { }
         catch (UnauthorizedAccessException) { }
+    }
+
+    private void AddOpenCodeDatabases(List<(ProviderId, string, DateTimeOffset)> output,
+        CancellationToken cancellationToken)
+    {
+        var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var overridePath = Environment.GetEnvironmentVariable("OPENCODE_DB_PATH");
+        if (!string.IsNullOrWhiteSpace(overridePath))
+            candidates.Add(overridePath);
+
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var xdgData = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+        candidates.Add(Path.Combine(localAppData, "opencode", "opencode.db"));
+        candidates.Add(Path.Combine(appData, "opencode", "opencode.db"));
+        candidates.Add(Path.Combine(_home, ".local", "share", "opencode", "opencode.db"));
+        if (!string.IsNullOrWhiteSpace(xdgData))
+            candidates.Add(Path.Combine(xdgData, "opencode", "opencode.db"));
+
+        foreach (var path in candidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                if (!File.Exists(path))
+                    continue;
+                var modified = File.GetLastWriteTimeUtc(path);
+                // SQLite WAL mode can leave the main database timestamp unchanged while the
+                // companion -wal file receives the active session writes. The session query below
+                // applies the recency window, so keep the database candidate even when its main
+                // file is older than six hours.
+                output.Add((ProviderId.OpenCode, path, new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
     }
 
     private bool TryRead(ProviderId provider, string path, DateTimeOffset modified,
@@ -141,6 +185,325 @@ internal sealed class AgentActivityScanner
         catch (UnauthorizedAccessException) { return false; }
         catch (JsonException) { return false; }
     }
+
+    private static IReadOnlyList<AgentActivityItem> ReadOpenCodeSessions(
+        string path, DateTimeOffset modified, bool claimLive)
+    {
+        var items = new List<AgentActivityItem>();
+        try
+        {
+            var connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = path,
+                Mode = SqliteOpenMode.ReadOnly,
+                Cache = SqliteCacheMode.Shared,
+                Pooling = false,
+            }.ToString();
+            using var connection = new SqliteConnection(connectionString);
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = """
+                SELECT id, parent_id, title, model, time_created, time_updated
+                FROM session
+                WHERE COALESCE(time_updated, time_created, 0) >= $cutoff
+                ORDER BY time_updated DESC, time_created DESC
+                LIMIT 80;
+                """;
+            command.Parameters.AddWithValue("$cutoff", DateTimeOffset.Now.Add(-RecentWindow).ToUnixTimeMilliseconds());
+
+            var sessions = new List<OpenCodeSessionRow>();
+            using (var reader = command.ExecuteReader())
+            {
+                while (reader.Read())
+                {
+                    sessions.Add(new OpenCodeSessionRow(
+                        reader.GetString(0),
+                        reader.IsDBNull(1) ? null : reader.GetString(1),
+                        reader.IsDBNull(2) ? "" : reader.GetString(2),
+                        reader.IsDBNull(3) ? "" : reader.GetString(3),
+                        reader.IsDBNull(4) ? 0 : reader.GetInt64(4),
+                        reader.IsDBNull(5) ? 0 : reader.GetInt64(5)));
+                }
+            }
+
+            // OpenCode normally has one process serving several stored sessions. The newest session
+            // receives the process claim; older sessions remain visible as recent/completed history.
+            bool claimed = false;
+            foreach (var session in sessions)
+            {
+                var tail = ReadOpenCodeTail(connection, session.Id);
+                var lastActivity = Max(
+                    FromUnixMilliseconds(session.UpdatedAt, modified),
+                    tail.LastActivity ?? modified);
+                var fresh = DateTimeOffset.Now - lastActivity < BusyWindow;
+                var live = claimLive && !claimed;
+                if (live)
+                    claimed = true;
+
+                var status = !live
+                    ? tail.State == TranscriptState.Failed ? AgentActivityStatus.Failed : AgentActivityStatus.Completed
+                    : tail.State == TranscriptState.Waiting
+                        ? AgentActivityStatus.Waiting
+                        : fresh ? AgentActivityStatus.Working : AgentActivityStatus.Idle;
+                var step = status == AgentActivityStatus.Completed
+                    ? "Completed"
+                    : status == AgentActivityStatus.Failed
+                        ? "Failed"
+                        : status == AgentActivityStatus.Waiting
+                            ? string.IsNullOrWhiteSpace(tail.Step) ? "Waiting for input" : tail.Step
+                        : status == AgentActivityStatus.Idle ? "Waiting for the next prompt"
+                        : !string.IsNullOrWhiteSpace(tail.Step) ? tail.Step
+                        : !string.IsNullOrWhiteSpace(tail.Summary) ? tail.Summary
+                        : fresh ? "Working" : "Thinking";
+
+                items.Add(new AgentActivityItem(
+                    $"opencode:{session.Id}", ProviderId.OpenCode,
+                    string.IsNullOrWhiteSpace(session.Title)
+                        ? SummarizeTitle(tail.Prompt) ?? "OpenCode"
+                        : Trim(Clean(session.Title), 72),
+                    step, status,
+                    FromUnixMilliseconds(session.CreatedAt, modified), lastActivity,
+                    Detail: tail.Prompt,
+                    Model: ParseOpenCodeModel(session.Model),
+                    ThreadId: session.Id,
+                    ParentThreadId: session.ParentId));
+            }
+        }
+        catch (SqliteException) { }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+
+        return items;
+    }
+
+    internal static IReadOnlyList<AgentActivityItem> ReadOpenCodeForTesting(string path, bool claimLive = true)
+        => ReadOpenCodeSessions(path, DateTimeOffset.Now, claimLive);
+
+    private static OpenCodeTail ReadOpenCodeTail(SqliteConnection connection, string sessionId)
+    {
+        var messages = new List<OpenCodeMessageRow>();
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = """
+                SELECT id, data, time_created, time_updated
+                FROM message
+                WHERE session_id = $session
+                ORDER BY time_created DESC, id DESC
+                LIMIT 100;
+                """;
+            command.Parameters.AddWithValue("$session", sessionId);
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                messages.Add(new OpenCodeMessageRow(
+                    reader.GetString(0), reader.GetString(1),
+                    reader.IsDBNull(2) ? 0 : reader.GetInt64(2),
+                    reader.IsDBNull(3) ? 0 : reader.GetInt64(3)));
+            }
+        }
+
+        var parts = new List<OpenCodePartRow>();
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = """
+                SELECT id, message_id, data, time_created, time_updated
+                FROM part
+                WHERE session_id = $session
+                ORDER BY time_created DESC, id DESC
+                LIMIT 200;
+                """;
+            command.Parameters.AddWithValue("$session", sessionId);
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                parts.Add(new OpenCodePartRow(
+                    reader.GetString(0), reader.GetString(1), reader.GetString(2),
+                    reader.IsDBNull(3) ? 0 : reader.GetInt64(3),
+                    reader.IsDBNull(4) ? 0 : reader.GetInt64(4)));
+            }
+        }
+
+        var parsedMessages = messages
+            .Select(ParseOpenCodeMessage)
+            .Where(message => message is not null)
+            .Cast<OpenCodeMessageInfo>()
+            .ToArray();
+        var parsedParts = parts
+            .Select(ParseOpenCodePart)
+            .Where(part => part is not null)
+            .Cast<OpenCodePartInfo>()
+            .ToArray();
+        var latestUser = parsedMessages.FirstOrDefault(message => message.Role == "user");
+        var latestAssistant = parsedMessages.FirstOrDefault(message => message.Role == "assistant");
+        var latestTool = parsedParts.FirstOrDefault(part => part.Type == "tool");
+        var latestReasoning = parsedParts.FirstOrDefault(part => part.Type == "reasoning");
+
+        var prompt = latestUser is null ? "" : ExtractOpenCodeMessageText(latestUser.Id, parts);
+        var summary = latestAssistant is null ? "" : ExtractOpenCodeMessageText(latestAssistant.Id, parts);
+        if (summary.Length == 0 && latestReasoning is not null)
+            summary = latestReasoning.Text;
+
+        var state = TranscriptState.Unknown;
+        var step = "";
+        if (latestTool is not null
+            && (latestAssistant is null || latestTool.ActivityAt >= latestAssistant.CreatedAt))
+        {
+            state = latestTool.Status switch
+            {
+                "pending" => TranscriptState.Waiting,
+                "running" => TranscriptState.Action,
+                "error" => TranscriptState.Failed,
+                _ => TranscriptState.Action,
+            };
+            step = DescribeOpenCodeTool(latestTool.Tool, latestTool.Input);
+        }
+        else if (latestUser is not null
+            && (latestAssistant is null || latestUser.CreatedAt > latestAssistant.CreatedAt || !latestAssistant.Completed))
+        {
+            state = TranscriptState.Action;
+            step = "Thinking";
+        }
+        else if (latestAssistant?.Failed == true)
+        {
+            state = TranscriptState.Failed;
+        }
+        else if (latestAssistant is not null)
+        {
+            state = TranscriptState.Finished;
+        }
+
+        var activity = parsedMessages.Select(message => message.ActivityAt)
+            .Concat(parsedParts.Select(part => part.ActivityAt))
+            .DefaultIfEmpty()
+            .Max();
+        return new OpenCodeTail(step, summary, prompt,
+            activity == default ? null : activity, state);
+    }
+
+    private static OpenCodeMessageInfo? ParseOpenCodeMessage(OpenCodeMessageRow row)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(row.Data);
+            var root = document.RootElement;
+            var role = root.TryGetProperty("role", out var roleNode) ? roleNode.GetString() : null;
+            if (role is not ("user" or "assistant"))
+                return null;
+
+            var created = FromUnixMilliseconds(row.CreatedAt, DateTimeOffset.MinValue);
+            var completed = 0L;
+            if (root.TryGetProperty("time", out var time) && time.ValueKind == JsonValueKind.Object
+                && time.TryGetProperty("completed", out var completedNode)
+                && completedNode.TryGetInt64(out var parsedCompleted))
+                completed = parsedCompleted;
+            var finish = root.TryGetProperty("finish", out var finishNode) ? finishNode.GetString() : null;
+            var failed = root.TryGetProperty("error", out var errorNode) && errorNode.ValueKind != JsonValueKind.Null;
+            var isComplete = completed > 0 || !string.IsNullOrWhiteSpace(finish) && finish != "tool-calls";
+            var activity = Max(
+                FromUnixMilliseconds(row.CreatedAt, DateTimeOffset.MinValue),
+                FromUnixMilliseconds(row.UpdatedAt, DateTimeOffset.MinValue),
+                FromUnixMilliseconds(completed, DateTimeOffset.MinValue));
+            return new OpenCodeMessageInfo(row.Id, role!, created, activity, isComplete, failed);
+        }
+        catch (JsonException) { return null; }
+    }
+
+    private static OpenCodePartInfo? ParseOpenCodePart(OpenCodePartRow row)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(row.Data);
+            var root = document.RootElement;
+            var type = root.TryGetProperty("type", out var typeNode) ? typeNode.GetString() : null;
+            if (string.IsNullOrWhiteSpace(type))
+                return null;
+
+            var activity = Max(
+                FromUnixMilliseconds(row.CreatedAt, DateTimeOffset.MinValue),
+                FromUnixMilliseconds(row.UpdatedAt, DateTimeOffset.MinValue));
+            if (root.TryGetProperty("time", out var time) && time.ValueKind == JsonValueKind.Object)
+            {
+                if (time.TryGetProperty("start", out var start) && start.TryGetInt64(out var startTime))
+                    activity = Max(activity, FromUnixMilliseconds(startTime, DateTimeOffset.MinValue));
+                if (time.TryGetProperty("end", out var end) && end.TryGetInt64(out var endTime))
+                    activity = Max(activity, FromUnixMilliseconds(endTime, DateTimeOffset.MinValue));
+            }
+
+            if (type == "tool")
+            {
+                var tool = root.TryGetProperty("tool", out var toolNode) ? toolNode.GetString() ?? "tool" : "tool";
+                var status = "";
+                var input = "";
+                if (root.TryGetProperty("state", out var state) && state.ValueKind == JsonValueKind.Object)
+                {
+                    status = state.TryGetProperty("status", out var statusNode) ? statusNode.GetString() ?? "" : "";
+                    if (state.TryGetProperty("input", out var inputNode))
+                        input = JsonText(inputNode);
+                }
+                return new OpenCodePartInfo(row.MessageId, type, activity, tool, status, input, "");
+            }
+
+            var text = root.TryGetProperty("text", out var textNode) ? Clean(textNode.GetString()) : "";
+            return new OpenCodePartInfo(row.MessageId, type, activity, "", "", "", text);
+        }
+        catch (JsonException) { return null; }
+    }
+
+    private static string ExtractOpenCodeMessageText(string messageId, IEnumerable<OpenCodePartRow> rows)
+    {
+        var text = rows
+            .Where(row => row.MessageId == messageId)
+            .Select(ParseOpenCodePart)
+            .Where(part => part is not null)
+            .Select(part => part!.Text)
+            .Where(value => value.Length > 0)
+            .LastOrDefault();
+        return text ?? "";
+    }
+
+    private static string DescribeOpenCodeTool(string name, string input)
+    {
+        if (name is "bash" or "shell" or "terminal" or "run_terminal_command")
+            return DescribeAction("shell_command", input);
+        if (name.Contains("edit", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("write", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("patch", StringComparison.OrdinalIgnoreCase))
+            return "Edited code";
+        if (name is "read" or "grep" or "glob" or "list" or "search")
+            return "Inspected files";
+        if (name is "task" or "subtask" or "agent")
+            return "Running subagent";
+        if (name.Contains("question", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("approval", StringComparison.OrdinalIgnoreCase))
+            return "Waiting for input";
+        return $"Running {name}";
+    }
+
+    private static string ParseOpenCodeModel(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return "";
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            return document.RootElement.TryGetProperty("id", out var id)
+                ? Clean(id.GetString())
+                : "";
+        }
+        catch (JsonException) { return ""; }
+    }
+
+    private static DateTimeOffset FromUnixMilliseconds(long value, DateTimeOffset fallback)
+    {
+        if (value <= 0)
+            return fallback;
+        try { return DateTimeOffset.FromUnixTimeMilliseconds(value).ToLocalTime(); }
+        catch (ArgumentOutOfRangeException) { return fallback; }
+    }
+
+    private static DateTimeOffset Max(params DateTimeOffset[] values)
+        => values.Max();
 
     private static SessionMetadata ReadSessionMetadata(string path)
     {
@@ -714,7 +1077,7 @@ internal sealed class AgentActivityScanner
         return items.Select(item => item.Id == selected.Id ? item with { Host = host } : item).ToArray();
     }
 
-    internal enum TranscriptState { Unknown, Action, Waiting, Finished }
+    internal enum TranscriptState { Unknown, Action, Waiting, Finished, Failed }
 
     internal sealed record TailInfo(string Step, string Summary, string Model, string ThreadId,
         string ParentThreadId, string Prompt, string Host, DateTimeOffset? StartedAt,
@@ -722,4 +1085,13 @@ internal sealed class AgentActivityScanner
     private sealed record ClaudeToolAction(string Step, bool Waiting);
     private sealed record ClaudeSessionContext(string? ThreadId, string? ParentThreadId, string? ProjectTitle);
     private readonly record struct SessionMetadata(string? ThreadId, string? ParentThreadId, string? Host);
+    private sealed record OpenCodeSessionRow(string Id, string? ParentId, string Title, string Model, long CreatedAt, long UpdatedAt);
+    private sealed record OpenCodeMessageRow(string Id, string Data, long CreatedAt, long UpdatedAt);
+    private sealed record OpenCodePartRow(string Id, string MessageId, string Data, long CreatedAt, long UpdatedAt);
+    private sealed record OpenCodeMessageInfo(
+        string Id, string Role, DateTimeOffset CreatedAt, DateTimeOffset ActivityAt, bool Completed, bool Failed);
+    private sealed record OpenCodePartInfo(
+        string MessageId, string Type, DateTimeOffset ActivityAt, string Tool, string Status, string Input, string Text);
+    private sealed record OpenCodeTail(
+        string Step, string Summary, string Prompt, DateTimeOffset? LastActivity, TranscriptState State);
 }

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -1,0 +1,410 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Management;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using TaskbarQuota.Diagnostics;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.AgentActivity;
+
+/// <summary>
+/// Windows equivalent of agent-notch's process-plus-transcript scanner. Process liveness is authoritative;
+/// transcript timestamps only distinguish busy from alive-but-quiet.
+/// </summary>
+internal sealed class AgentActivityScanner
+{
+    private static readonly TimeSpan RecentWindow = TimeSpan.FromHours(6);
+    private static readonly TimeSpan BusyWindow = TimeSpan.FromSeconds(30);
+    private readonly string _home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+    private readonly CodexThreadNameResolver _threadNames = new();
+
+    public IReadOnlyList<AgentActivityItem> Scan(CancellationToken cancellationToken = default)
+    {
+        // This deliberately does not use ActiveAppDetector: foreground-provider detection drives the
+        // quota tiles, while activity follows every running agent in the desktop or a terminal.
+        var desktopApps = ScanDesktopAgentApps();
+        var terminalAgents = ScanTerminalAgentCommands();
+        var liveProviders = MergeLiveProviders(desktopApps, terminalAgents);
+        Log.Information($"[activity] agent discovery: desktop={desktopApps.Values.Sum()}, terminal={terminalAgents.Values.Sum()}");
+        var files = new List<(ProviderId Provider, string Path, DateTimeOffset Modified)>();
+        AddRecent(files, Path.Combine(_home, ".codex", "sessions"), ProviderId.Codex, cancellationToken);
+        AddRecent(files, Path.Combine(_home, ".claude", "projects"), ProviderId.Claude, cancellationToken);
+
+        var parsed = new List<AgentActivityItem>();
+        var liveClaims = new Dictionary<ProviderId, int>();
+        foreach (var file in files.OrderByDescending(f => f.Modified).Take(80))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            int claim = liveClaims.TryGetValue(file.Provider, out var currentClaim) ? currentClaim : 0;
+            bool claimLive = liveProviders.TryGetValue(file.Provider, out var liveCount) && claim < liveCount;
+            liveClaims[file.Provider] = claim + 1;
+            if (TryRead(file.Provider, file.Path, file.Modified, claimLive, out var item))
+                parsed.Add(item);
+        }
+
+        return GroupCodex(parsed)
+            .Where(item => item.IsLive || DateTimeOffset.Now - item.UpdatedAt < RecentWindow)
+            .OrderByDescending(item => item.IsLive)
+            .ThenByDescending(item => item.UpdatedAt)
+            .ToArray();
+    }
+
+    private void AddRecent(List<(ProviderId, string, DateTimeOffset)> output, string root,
+        ProviderId provider, CancellationToken cancellationToken)
+    {
+        if (!Directory.Exists(root))
+            return;
+
+        try
+        {
+            foreach (var path in Directory.EnumerateFiles(root, "*.jsonl", SearchOption.AllDirectories))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var modified = File.GetLastWriteTimeUtc(path);
+                if (DateTime.UtcNow - modified <= RecentWindow)
+                    output.Add((provider, path, new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
+            }
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    private bool TryRead(ProviderId provider, string path, DateTimeOffset modified,
+        bool claimLive, out AgentActivityItem item)
+    {
+        item = default!;
+        try
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            if (stream.Length == 0)
+                return false;
+
+            stream.Seek(Math.Max(0, stream.Length - 131_072), SeekOrigin.Begin);
+            using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            var text = reader.ReadToEnd();
+            var info = ParseTail(provider, text);
+            var session = provider == ProviderId.Codex ? ReadSessionMetadata(path) : default;
+            bool freshAgentEvent = info.LastActivity is { } activity && DateTimeOffset.Now - activity < BusyWindow;
+            // One desktop provider process can host several concurrent threads. A fresh reasoning/tool
+            // event is therefore also a liveness signal, not just the process-count claim.
+            bool live = (claimLive || (info.State == TranscriptState.Action && freshAgentEvent))
+                && modified > DateTimeOffset.Now - RecentWindow;
+            bool busy = live && freshAgentEvent;
+            // A desktop process can stay alive after the agent's final response. The transcript is the
+            // authority for completion, mirroring agent-notch's event-based state model.
+            var status = info.State == TranscriptState.Finished || !live
+                ? AgentActivityStatus.Completed
+                : AgentActivityStatus.Working;
+            // The user's initial prompt is intentionally not mirrored into the taskbar or activity panel.
+            // It is often long and belongs to the provider conversation, not the compact activity signal.
+            var threadId = session.ThreadId ?? info.ThreadId;
+            var title = provider == ProviderId.Codex ? _threadNames.GetName(threadId) ?? provider.ToString() : provider.ToString();
+            // A reasoning summary is useful while the agent is working, but becomes stale and misleading
+            // once a final response has landed. Completion is deliberately a stable, unambiguous state.
+            var step = status == AgentActivityStatus.Completed
+                ? "Completed"
+                : info.State == TranscriptState.Action && !string.IsNullOrWhiteSpace(info.Step)
+                    ? info.Step
+                    : !string.IsNullOrWhiteSpace(info.Summary) ? info.Summary
+                    : string.IsNullOrWhiteSpace(info.Step) ? (busy ? "Working" : "Thinking") : info.Step;
+            item = new AgentActivityItem(
+                path, provider, title, step, status,
+                info.StartedAt ?? modified, info.LastActivity ?? modified,
+                SubagentCount: 0,
+                Detail: null,
+                Model: info.Model,
+                ThreadId: threadId,
+                ParentThreadId: session.ParentThreadId ?? info.ParentThreadId);
+            return true;
+        }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+        catch (JsonException) { return false; }
+    }
+
+    private static SessionMetadata ReadSessionMetadata(string path)
+    {
+        try
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            var line = reader.ReadLine();
+            if (string.IsNullOrWhiteSpace(line))
+                return default;
+            using var document = JsonDocument.Parse(line);
+            var root = document.RootElement;
+            if (!root.TryGetProperty("type", out var type) || type.GetString() != "session_meta"
+                || !root.TryGetProperty("payload", out var payload) || payload.ValueKind != JsonValueKind.Object)
+                return default;
+            return new SessionMetadata(
+                payload.TryGetProperty("id", out var id) ? id.GetString() : null,
+                payload.TryGetProperty("parent_thread_id", out var parent) ? parent.GetString() : null);
+        }
+        catch (IOException) { return default; }
+        catch (UnauthorizedAccessException) { return default; }
+        catch (JsonException) { return default; }
+    }
+
+    private static TailInfo ParseTail(ProviderId provider, string text)
+    {
+        string step = "", summary = "", model = "", threadId = "", parentId = "";
+        DateTimeOffset? started = null, activity = null;
+        var state = TranscriptState.Unknown;
+        foreach (var line in text.Split('\n').Reverse())
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            try
+            {
+                using var doc = JsonDocument.Parse(line);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("timestamp", out var timestamp)
+                    && timestamp.ValueKind == JsonValueKind.String
+                    && DateTimeOffset.TryParse(timestamp.GetString(), out var parsedTime))
+                {
+                    started ??= parsedTime;
+                    if (activity is null && IsConversationEvent(root, provider)) activity = parsedTime;
+                }
+
+                if (root.TryGetProperty("payload", out var payload) && payload.ValueKind == JsonValueKind.Object)
+                {
+                    if (threadId.Length == 0 && payload.TryGetProperty("id", out var id)) threadId = id.GetString() ?? "";
+                    if (parentId.Length == 0 && payload.TryGetProperty("parent_thread_id", out var parent)) parentId = parent.GetString() ?? "";
+                    if (model.Length == 0 && payload.TryGetProperty("model", out var modelNode)) model = modelNode.GetString() ?? "";
+
+                    var type = payload.TryGetProperty("type", out var typeNode) ? typeNode.GetString() : null;
+                    if (summary.Length == 0 && type is "agent_reasoning" && payload.TryGetProperty("text", out var summaryText))
+                        summary = Clean(summaryText.GetString());
+                    if (summary.Length == 0 && type is "reasoning" && payload.TryGetProperty("summary", out var reasoningSummary))
+                        summary = ExtractSummary(reasoningSummary);
+                    if (state == TranscriptState.Unknown && type is "task_complete")
+                        state = TranscriptState.Finished;
+                    if (state == TranscriptState.Unknown && type is "message"
+                        && payload.TryGetProperty("role", out var role) && role.GetString() == "assistant"
+                        && payload.TryGetProperty("phase", out var messagePhase) && messagePhase.GetString() == "final_answer")
+                        state = TranscriptState.Finished;
+                    if (type is "user_message")
+                    {
+                        // A new user turn always supersedes an older completed turn in the same transcript.
+                        if (state == TranscriptState.Unknown)
+                        {
+                            state = TranscriptState.Action;
+                            step = "Thinking";
+                        }
+                    }
+                    if (state == TranscriptState.Unknown && type is "agent_reasoning" or "reasoning")
+                        state = TranscriptState.Action;
+                    if (step.Length == 0 && type is "custom_tool_call" or "function_call")
+                    {
+                        var name = payload.TryGetProperty("name", out var nameNode) ? nameNode.GetString() : null;
+                        if (IsAction(name))
+                        {
+                            state = state == TranscriptState.Unknown ? TranscriptState.Action : state;
+                            step = DescribeAction(name!, payload);
+                        }
+                    }
+                    if (step.Length == 0 && type is "agent_reasoning" && payload.TryGetProperty("text", out var reasoning))
+                        step = Clean(reasoning.GetString());
+                }
+
+                if (state == TranscriptState.Unknown && root.TryGetProperty("payload", out var eventPayload)
+                    && eventPayload.ValueKind == JsonValueKind.Object
+                    && eventPayload.TryGetProperty("phase", out var phase)
+                    && phase.GetString() == "final_answer")
+                    state = TranscriptState.Finished;
+
+            }
+            catch (JsonException) { }
+
+            if (state != TranscriptState.Unknown && (step.Length > 0 || summary.Length > 0)
+                && activity is not null && threadId.Length > 0)
+                break;
+        }
+
+        return new TailInfo(step, summary, model, threadId, parentId, started, activity, state);
+    }
+
+    private static string ExtractSummary(JsonElement value)
+    {
+        if (value.ValueKind != JsonValueKind.Array)
+            return "";
+
+        foreach (var part in value.EnumerateArray().Reverse())
+            if (part.ValueKind == JsonValueKind.Object && part.TryGetProperty("summary_text", out var text))
+                return Clean(text.GetString());
+        return "";
+    }
+
+    private static bool IsAction(string? name)
+        => !string.IsNullOrWhiteSpace(name) && name is not "wait";
+
+    private static string DescribeAction(string name, JsonElement payload)
+    {
+        var details = payload.TryGetProperty("arguments", out var arguments) ? arguments.GetString()
+            : payload.TryGetProperty("input", out var input) ? input.GetString() : "";
+        details ??= "";
+        if (name.Equals("apply_patch", StringComparison.OrdinalIgnoreCase) || details.Contains("apply_patch", StringComparison.OrdinalIgnoreCase))
+            return "Edited code";
+        if (details.Contains("Get-Content", StringComparison.OrdinalIgnoreCase))
+            return "Ran Get-Content";
+        if (details.Contains("rg ", StringComparison.OrdinalIgnoreCase) || details.Contains("rg -", StringComparison.OrdinalIgnoreCase))
+            return "Searched files";
+        if (details.Contains("dotnet build", StringComparison.OrdinalIgnoreCase))
+            return "Built the app";
+        if (details.Contains("dotnet test", StringComparison.OrdinalIgnoreCase))
+            return "Ran tests";
+        return name.Equals("shell_command", StringComparison.OrdinalIgnoreCase) || name.Equals("exec", StringComparison.OrdinalIgnoreCase)
+            ? "Running command"
+            : $"Running {name}";
+    }
+
+    private static bool IsConversationEvent(JsonElement root, ProviderId provider)
+    {
+        if (provider == ProviderId.Claude)
+            return root.TryGetProperty("type", out var type) && type.GetString() is "user" or "assistant";
+        return root.TryGetProperty("payload", out var payload)
+            && payload.TryGetProperty("type", out var typeNode)
+            && typeNode.GetString() is "user_message" or "message" or "reasoning" or "agent_reasoning" or "custom_tool_call" or "function_call";
+    }
+
+    private static string ExtractText(JsonElement value)
+    {
+        if (value.ValueKind == JsonValueKind.String) return Clean(value.GetString());
+        if (value.ValueKind == JsonValueKind.Array)
+            foreach (var part in value.EnumerateArray().Reverse())
+                if (part.ValueKind == JsonValueKind.Object && part.TryGetProperty("text", out var text))
+                    return Clean(text.GetString());
+        return "";
+    }
+
+    private static string Clean(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return "";
+        var result = value.Trim().Replace('\n', ' ')
+            .Replace("**", "", StringComparison.Ordinal)
+            .Replace("__", "", StringComparison.Ordinal)
+            .Replace("`", "", StringComparison.Ordinal);
+        if (result.StartsWith('<') || result.StartsWith('{')) return "";
+        return Trim(result, 120);
+    }
+
+    private static string Trim(string value, int length)
+        => value.Length <= length ? value : value[..length].TrimEnd() + "…";
+
+    /// <summary>Finds installed desktop agent apps, regardless of which window is foreground.</summary>
+    private static IReadOnlyDictionary<ProviderId, int> ScanDesktopAgentApps()
+    {
+        var live = new Dictionary<ProviderId, int>();
+        foreach (var process in Process.GetProcesses())
+        {
+            try
+            {
+                switch (process.ProcessName.ToLowerInvariant())
+                {
+                    case "codex":
+                    case "chatgpt": Add(ProviderId.Codex); break;
+                    case "claude": Add(ProviderId.Claude); break;
+                    case "cursor": Add(ProviderId.Cursor); break;
+                    case "antigravity": Add(ProviderId.Antigravity); break;
+                    case "devin": Add(ProviderId.Devin); break;
+                }
+            }
+            catch { }
+            finally { process.Dispose(); }
+        }
+        return live;
+
+        // Electron-style apps may have many helper processes. They represent one desktop agent,
+        // not several simultaneous tasks.
+        void Add(ProviderId provider) => live[provider] = 1;
+    }
+
+    /// <summary>
+    /// Finds agents launched from CMD, PowerShell, Windows Terminal, or a script runtime. This is
+    /// intentionally a separate scan from desktop apps and never consults the foreground window.
+    /// </summary>
+    private static IReadOnlyDictionary<ProviderId, int> ScanTerminalAgentCommands()
+    {
+        var live = new Dictionary<ProviderId, int>();
+        const string query = "SELECT Name, CommandLine FROM Win32_Process WHERE " +
+            "Name = 'cmd.exe' OR Name = 'powershell.exe' OR Name = 'pwsh.exe' OR Name = 'node.exe' OR " +
+            "Name = 'bun.exe' OR Name = 'deno.exe' OR Name = 'npm.exe' OR Name = 'npx.exe' OR " +
+            "Name = 'pnpm.exe' OR Name = 'yarn.exe' OR Name = 'wsl.exe' OR Name = 'bash.exe' OR " +
+            "Name = 'codex.exe' OR Name = 'claude.exe' OR Name = 'cursor-agent.exe' OR " +
+            "Name = 'opencode.exe' OR Name = 'cline.exe' OR Name = 'agy.exe'";
+
+        try
+        {
+            using var searcher = new ManagementObjectSearcher(query);
+            using var processes = searcher.Get();
+            foreach (ManagementObject process in processes)
+            {
+                using (process)
+                {
+                    var name = Path.GetFileNameWithoutExtension(process["Name"]?.ToString() ?? "");
+                    var commandLine = process["CommandLine"]?.ToString() ?? "";
+                    if (TryGetTerminalProvider(name, commandLine, out var provider))
+                        Add(provider);
+                }
+            }
+        }
+        catch (ManagementException) { }
+        catch (UnauthorizedAccessException) { }
+
+        return live;
+        void Add(ProviderId provider) => live[provider] = live.TryGetValue(provider, out var count) ? count + 1 : 1;
+    }
+
+    private static bool TryGetTerminalProvider(string executable, string commandLine, out ProviderId provider)
+    {
+        provider = default;
+        var text = (executable + " " + commandLine).ToLowerInvariant();
+        if (text.Contains("claude-code") || text.Contains(" claude") || executable.Equals("claude", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Claude; return true; }
+        if (text.Contains("cursor-agent") || text.Contains("cursor agent")) { provider = ProviderId.Cursor; return true; }
+        if (text.Contains("antigravity") || executable.Equals("agy", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Antigravity; return true; }
+        if (text.Contains("opencode")) { provider = ProviderId.OpenCode; return true; }
+        if (text.Contains("cline")) { provider = ProviderId.Cline; return true; }
+        if (text.Contains(" codex") || executable.Equals("codex", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Codex; return true; }
+        return false;
+    }
+
+    private static IReadOnlyDictionary<ProviderId, int> MergeLiveProviders(
+        IReadOnlyDictionary<ProviderId, int> desktopApps,
+        IReadOnlyDictionary<ProviderId, int> terminalAgents)
+    {
+        var merged = new Dictionary<ProviderId, int>(desktopApps);
+        foreach (var (provider, count) in terminalAgents)
+            // A native CLI can be visible to both scans. Keep the greater count rather than
+            // claiming two transcript tasks for that one process.
+            merged[provider] = merged.TryGetValue(provider, out var current) ? Math.Max(current, count) : count;
+        return merged;
+    }
+
+    private static IReadOnlyList<AgentActivityItem> GroupCodex(IReadOnlyList<AgentActivityItem> items)
+    {
+        var codex = items.Where(item => item.Provider == ProviderId.Codex).ToArray();
+        if (codex.Length < 2) return items;
+        var groups = new List<AgentActivityItem>();
+        var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var root in codex.Where(item => string.IsNullOrWhiteSpace(item.ParentThreadId)))
+        {
+            var children = codex.Where(item => item.ParentThreadId == root.ThreadId).ToArray();
+            used.Add(root.Id);
+            foreach (var child in children) used.Add(child.Id);
+            groups.Add(root with { SubagentCount = children.Length });
+        }
+        groups.AddRange(codex.Where(item => !used.Contains(item.Id)));
+        groups.AddRange(items.Where(item => item.Provider != ProviderId.Codex));
+        return groups;
+    }
+
+    private enum TranscriptState { Unknown, Action, Finished }
+
+    private sealed record TailInfo(string Step, string Summary, string Model, string ThreadId,
+        string ParentThreadId, DateTimeOffset? StartedAt, DateTimeOffset? LastActivity, TranscriptState State);
+    private readonly record struct SessionMetadata(string? ThreadId, string? ParentThreadId);
+}

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -119,7 +119,8 @@ internal sealed class AgentActivityScanner
                 Detail: null,
                 Model: info.Model,
                 ThreadId: threadId,
-                ParentThreadId: session.ParentThreadId ?? info.ParentThreadId);
+                ParentThreadId: session.ParentThreadId ?? info.ParentThreadId,
+                Host: session.Host);
             return true;
         }
         catch (IOException) { return false; }
@@ -141,9 +142,18 @@ internal sealed class AgentActivityScanner
             if (!root.TryGetProperty("type", out var type) || type.GetString() != "session_meta"
                 || !root.TryGetProperty("payload", out var payload) || payload.ValueKind != JsonValueKind.Object)
                 return default;
+            var originator = payload.TryGetProperty("originator", out var originatorNode)
+                ? originatorNode.GetString()
+                : null;
+            var host = originator?.Equals("t3code_desktop", StringComparison.OrdinalIgnoreCase) == true
+                ? "T3 Code"
+                : originator?.Contains("synara", StringComparison.OrdinalIgnoreCase) == true
+                    ? "Synara"
+                    : null;
             return new SessionMetadata(
                 payload.TryGetProperty("id", out var id) ? id.GetString() : null,
-                payload.TryGetProperty("parent_thread_id", out var parent) ? parent.GetString() : null);
+                payload.TryGetProperty("parent_thread_id", out var parent) ? parent.GetString() : null,
+                host);
         }
         catch (IOException) { return default; }
         catch (UnauthorizedAccessException) { return default; }
@@ -406,5 +416,5 @@ internal sealed class AgentActivityScanner
 
     private sealed record TailInfo(string Step, string Summary, string Model, string ThreadId,
         string ParentThreadId, DateTimeOffset? StartedAt, DateTimeOffset? LastActivity, TranscriptState State);
-    private readonly record struct SessionMetadata(string? ThreadId, string? ParentThreadId);
+    private readonly record struct SessionMetadata(string? ThreadId, string? ParentThreadId, string? Host);
 }

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -41,6 +41,8 @@ internal sealed class AgentActivityScanner
         AddAntigravityDatabases(files, cancellationToken);
         AddAntigravityGuiTranscripts(files, cancellationToken);
         AddOpenCodeDatabases(files, cancellationToken);
+        AddClineSessions(files, cancellationToken);
+        AddKimiSessions(files, cancellationToken);
 
         var parsed = new List<AgentActivityItem>();
         var liveClaims = new Dictionary<ProviderId, int>();
@@ -66,6 +68,16 @@ internal sealed class AgentActivityScanner
             else if (file.Provider == ProviderId.OpenCode)
             {
                 parsed.AddRange(ReadOpenCodeSessions(file.Path, file.Modified, claimLive));
+            }
+            else if (file.Provider == ProviderId.Cline)
+            {
+                if (TryReadClineSession(file.Path, file.Modified, claimLive, out var clineItem))
+                    parsed.Add(clineItem);
+            }
+            else if (file.Provider == ProviderId.Kimi)
+            {
+                if (TryReadKimiSession(file.Path, file.Modified, claimLive, out var kimiItem))
+                    parsed.Add(kimiItem);
             }
             else if (TryRead(file.Provider, file.Path, file.Modified, claimLive, out var item))
             {
@@ -98,6 +110,110 @@ internal sealed class AgentActivityScanner
         }
         catch (IOException) { }
         catch (UnauthorizedAccessException) { }
+    }
+
+    private void AddClineSessions(List<(ProviderId, string, DateTimeOffset)> output,
+        CancellationToken cancellationToken)
+    {
+        var configuredRoot = Environment.GetEnvironmentVariable("CLINE_DATA_DIR");
+        var root = string.IsNullOrWhiteSpace(configuredRoot)
+            ? Path.Combine(_home, ".cline", "data")
+            : configuredRoot;
+        var sessions = Path.Combine(root, "sessions");
+        if (!Directory.Exists(sessions))
+            return;
+
+        try
+        {
+            foreach (var path in Directory.EnumerateFiles(sessions, "*.json", SearchOption.AllDirectories))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (path.EndsWith(".messages.json", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var modified = File.GetLastWriteTimeUtc(path);
+                var messagesPath = Path.Combine(
+                    Path.GetDirectoryName(path) ?? "",
+                    Path.GetFileNameWithoutExtension(path) + ".messages.json");
+                if (File.Exists(messagesPath))
+                {
+                    var messagesModified = File.GetLastWriteTimeUtc(messagesPath);
+                    if (messagesModified > modified)
+                        modified = messagesModified;
+                }
+
+                if (DateTime.UtcNow - modified <= RecentWindow)
+                    output.Add((ProviderId.Cline, path,
+                        new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
+            }
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    private void AddKimiSessions(List<(ProviderId, string, DateTimeOffset)> output,
+        CancellationToken cancellationToken)
+    {
+        foreach (var root in KimiHomeCandidates())
+        {
+            var sessions = Path.Combine(root, "sessions");
+            if (!Directory.Exists(sessions))
+                continue;
+
+            try
+            {
+                foreach (var statePath in Directory.EnumerateFiles(sessions, "state.json", SearchOption.AllDirectories))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var sessionDirectory = Path.GetDirectoryName(statePath);
+                    if (string.IsNullOrWhiteSpace(sessionDirectory))
+                        continue;
+
+                    var modified = File.GetLastWriteTimeUtc(statePath);
+                    var agentsDirectory = Path.Combine(sessionDirectory, "agents");
+                    if (Directory.Exists(agentsDirectory))
+                    {
+                        foreach (var wirePath in Directory.EnumerateFiles(
+                            agentsDirectory, "wire.jsonl", SearchOption.AllDirectories))
+                        {
+                            var wireModified = File.GetLastWriteTimeUtc(wirePath);
+                            if (wireModified > modified)
+                                modified = wireModified;
+                        }
+                    }
+                    foreach (var companion in new[] { "wire.jsonl", "context.jsonl" })
+                    {
+                        var companionPath = Path.Combine(sessionDirectory, companion);
+                        if (File.Exists(companionPath))
+                        {
+                            var companionModified = File.GetLastWriteTimeUtc(companionPath);
+                            if (companionModified > modified)
+                                modified = companionModified;
+                        }
+                    }
+
+                    if (DateTime.UtcNow - modified <= RecentWindow)
+                        output.Add((ProviderId.Kimi, statePath,
+                            new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
+                }
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+
+    private IEnumerable<string> KimiHomeCandidates()
+    {
+        var explicitHome = Environment.GetEnvironmentVariable("KIMI_CODE_HOME");
+        if (!string.IsNullOrWhiteSpace(explicitHome))
+            yield return explicitHome;
+
+        var legacyHome = Environment.GetEnvironmentVariable("KIMI_SHARE_DIR");
+        if (!string.IsNullOrWhiteSpace(legacyHome))
+            yield return legacyHome;
+
+        yield return Path.Combine(_home, ".kimi-code");
+        yield return Path.Combine(_home, ".kimi");
     }
 
     private void AddGrokSessions(List<(ProviderId, string, DateTimeOffset)> output,
@@ -873,6 +989,354 @@ internal sealed class AgentActivityScanner
         catch (JsonException) { return false; }
     }
 
+    private static bool TryReadClineSession(string metadataPath, DateTimeOffset modified,
+        bool claimLive, out AgentActivityItem item)
+    {
+        item = default!;
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(metadataPath));
+            var root = document.RootElement;
+            var sessionId = FirstString(root, "session_id", "sessionId")
+                ?? Path.GetFileNameWithoutExtension(metadataPath);
+            var metadata = root.TryGetProperty("metadata", out var metadataNode)
+                && metadataNode.ValueKind == JsonValueKind.Object
+                ? metadataNode
+                : default;
+            var prompt = FirstString(metadata, "prompt") ?? FirstString(root, "prompt") ?? "";
+            var title = FirstString(metadata, "title", "name") ?? FirstString(root, "title") ?? "";
+            var model = FirstString(root, "model") ?? "";
+            var statusText = (FirstString(root, "status") ?? "").ToLowerInvariant();
+            var startedAt = FirstTimestampAny(root, "started_at", "startedAt", "created_at", "createdAt")
+                ?? modified;
+            var messagesPath = FirstString(root, "messages_path", "messagesPath");
+            if (string.IsNullOrWhiteSpace(messagesPath))
+            {
+                messagesPath = Path.Combine(
+                    Path.GetDirectoryName(metadataPath) ?? "",
+                    Path.GetFileNameWithoutExtension(metadataPath) + ".messages.json");
+            }
+            else if (!Path.IsPathRooted(messagesPath))
+            {
+                messagesPath = Path.Combine(Path.GetDirectoryName(metadataPath) ?? "", messagesPath);
+            }
+
+            var tail = ReadClineMessages(messagesPath);
+            prompt = FirstNonEmpty(prompt, tail.Prompt);
+            title = FirstNonEmpty(title, SummarizeTitle(prompt) ?? "Cline");
+            model = FirstNonEmpty(model, tail.Model);
+            var lastActivity = Max(modified, tail.LastActivity ?? modified);
+            var live = claimLive && modified > DateTimeOffset.Now - RecentWindow;
+            var fresh = DateTimeOffset.Now - lastActivity < BusyWindow;
+            var failed = statusText.Contains("fail", StringComparison.Ordinal)
+                || statusText.Contains("error", StringComparison.Ordinal)
+                || tail.State == TranscriptState.Failed;
+            var status = !live
+                ? failed ? AgentActivityStatus.Failed : AgentActivityStatus.Completed
+                : tail.State == TranscriptState.Waiting
+                    ? AgentActivityStatus.Waiting
+                    : fresh ? AgentActivityStatus.Working : AgentActivityStatus.Idle;
+            var step = status switch
+            {
+                AgentActivityStatus.Completed => "Completed",
+                AgentActivityStatus.Failed => "Failed",
+                AgentActivityStatus.Waiting => FirstNonEmpty(tail.Step, "Waiting for input"),
+                AgentActivityStatus.Idle => "Waiting for the next prompt",
+                _ => FirstNonEmpty(tail.Step, tail.Summary, "Thinking"),
+            };
+            item = new AgentActivityItem(
+                $"cline:{sessionId}", ProviderId.Cline, Trim(Clean(title), 72), step, status,
+                startedAt, lastActivity,
+                Detail: prompt,
+                Model: model,
+                ThreadId: sessionId);
+            return true;
+        }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+        catch (JsonException) { return false; }
+    }
+
+    private static ClineTail ReadClineMessages(string path)
+    {
+        if (!File.Exists(path))
+            return new ClineTail();
+
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(path));
+            var root = document.RootElement;
+            var messages = root.ValueKind == JsonValueKind.Array
+                ? root
+                : root.TryGetProperty("messages", out var messagesNode)
+                    && messagesNode.ValueKind == JsonValueKind.Array
+                    ? messagesNode
+                    : default;
+            if (messages.ValueKind != JsonValueKind.Array)
+                return new ClineTail();
+
+            var result = new ClineTail();
+            foreach (var message in messages.EnumerateArray())
+            {
+                var timestamp = FirstTimestampAny(message, "ts", "timestamp", "created_at", "createdAt");
+                if (timestamp is { } activity
+                    && (result.LastActivity is null || activity > result.LastActivity))
+                    result.LastActivity = activity;
+
+                var role = (FirstString(message, "role") ?? "").ToLowerInvariant();
+                if (!message.TryGetProperty("content", out var content))
+                    continue;
+
+                if (content.ValueKind == JsonValueKind.String)
+                {
+                    ApplyClineText(role, content.GetString(), result);
+                    continue;
+                }
+                if (content.ValueKind != JsonValueKind.Array)
+                    continue;
+
+                foreach (var part in content.EnumerateArray())
+                {
+                    if (part.ValueKind != JsonValueKind.Object)
+                        continue;
+                    var type = (FirstString(part, "type") ?? "").ToLowerInvariant();
+                    if (type is "text" or "thinking" or "reasoning")
+                    {
+                        var text = FirstString(part, "text", "thinking", "reasoning") ?? "";
+                        ApplyClineText(role, text, result, type != "text");
+                    }
+                    else if (type is "tool_use" or "tool_call" or "function_call")
+                    {
+                        var name = FirstString(part, "name", "tool_name", "toolName", "function") ?? "tool";
+                        var details = GetPayloadDetails(part);
+                        result.State = IsWaitingTool(name) ? TranscriptState.Waiting : TranscriptState.Action;
+                        result.Step = result.State == TranscriptState.Waiting
+                            ? "Waiting for input"
+                            : DescribeAction(name, details);
+                    }
+                    else if (type is "tool_result" or "tool_output" or "function_result")
+                    {
+                        if (IsTrue(part, "is_error", "isError", "error"))
+                        {
+                            result.State = TranscriptState.Failed;
+                            result.Step = "Failed";
+                        }
+                        else
+                        {
+                            result.State = TranscriptState.Action;
+                            result.Step = "Processing tool result";
+                        }
+                    }
+                }
+            }
+            return result;
+        }
+        catch (IOException) { return new ClineTail(); }
+        catch (UnauthorizedAccessException) { return new ClineTail(); }
+        catch (JsonException) { return new ClineTail(); }
+    }
+
+    private static void ApplyClineText(string role, string? rawText, ClineTail result, bool thinking = false)
+    {
+        var text = Clean(rawText);
+        if (text.Length == 0)
+            return;
+        if (role == "user")
+        {
+            var prompt = ExtractUserPrompt(text);
+            if (result.Prompt.Length == 0 && prompt.Length > 0)
+                result.Prompt = prompt;
+            result.State = TranscriptState.Action;
+            result.Step = "Thinking";
+        }
+        else if (thinking)
+        {
+            result.State = TranscriptState.Action;
+            result.Step = "Thinking";
+        }
+        else if (role == "assistant")
+        {
+            result.State = TranscriptState.Finished;
+            result.Summary = text;
+        }
+    }
+
+    private static string ExtractUserPrompt(string text)
+    {
+        var match = Regex.Match(text, "<user_input(?:\\s+[^>]*)?>(?<prompt>.*?)</user_input>",
+            RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        return match.Success ? Clean(match.Groups["prompt"].Value) : text;
+    }
+
+    private static bool IsWaitingTool(string name)
+        => name.Equals("AskUserQuestion", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("ExitPlanMode", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("approval", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("confirm", StringComparison.OrdinalIgnoreCase);
+
+    private static bool TryReadKimiSession(string statePath, DateTimeOffset modified,
+        bool claimLive, out AgentActivityItem item)
+    {
+        item = default!;
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(statePath));
+            var root = document.RootElement;
+            var sessionDirectory = Path.GetDirectoryName(statePath) ?? "";
+            var sessionId = Path.GetFileName(sessionDirectory);
+            var title = FirstString(root, "title") ?? "";
+            var startedAt = FirstTimestampAny(root, "createdAt", "created_at") ?? modified;
+            var agents = root.TryGetProperty("agents", out var agentsNode)
+                && agentsNode.ValueKind == JsonValueKind.Object
+                ? agentsNode.EnumerateObject().Count()
+                : 0;
+            var wirePath = Path.Combine(sessionDirectory, "agents", "main", "wire.jsonl");
+            if (!File.Exists(wirePath))
+                wirePath = File.Exists(Path.Combine(sessionDirectory, "wire.jsonl"))
+                    ? Path.Combine(sessionDirectory, "wire.jsonl")
+                    : Directory.Exists(Path.Combine(sessionDirectory, "agents"))
+                    ? Directory.EnumerateFiles(Path.Combine(sessionDirectory, "agents"), "wire.jsonl", SearchOption.AllDirectories).FirstOrDefault() ?? ""
+                    : "";
+
+            var tail = ReadKimiWire(wirePath);
+            title = FirstNonEmpty(
+                string.Equals(title, "New Session", StringComparison.OrdinalIgnoreCase) ? "" : title,
+                SummarizeTitle(tail.Prompt) ?? "",
+                "Kimi");
+            var lastActivity = Max(modified, tail.LastActivity ?? modified);
+            var live = claimLive && modified > DateTimeOffset.Now - RecentWindow;
+            var fresh = DateTimeOffset.Now - lastActivity < BusyWindow;
+            var status = !live
+                ? tail.State == TranscriptState.Failed ? AgentActivityStatus.Failed : AgentActivityStatus.Completed
+                : tail.State == TranscriptState.Waiting
+                    ? AgentActivityStatus.Waiting
+                    : fresh ? AgentActivityStatus.Working : AgentActivityStatus.Idle;
+            var step = status switch
+            {
+                AgentActivityStatus.Completed => "Completed",
+                AgentActivityStatus.Failed => "Failed",
+                AgentActivityStatus.Waiting => FirstNonEmpty(tail.Step, "Waiting for input"),
+                AgentActivityStatus.Idle => "Waiting for the next prompt",
+                _ => FirstNonEmpty(tail.Step, tail.Summary, "Thinking"),
+            };
+            item = new AgentActivityItem(
+                $"kimi:{sessionId}", ProviderId.Kimi, Trim(Clean(title), 72), step, status,
+                startedAt, lastActivity,
+                SubagentCount: Math.Max(0, agents - 1),
+                Detail: tail.Prompt,
+                Model: tail.Model,
+                ThreadId: sessionId);
+            return true;
+        }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+        catch (JsonException) { return false; }
+    }
+
+    private static KimiTail ReadKimiWire(string path)
+    {
+        var result = new KimiTail();
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            return result;
+
+        try
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete);
+            stream.Seek(Math.Max(0, stream.Length - 262_144), SeekOrigin.Begin);
+            using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            while (reader.ReadLine() is { } line)
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
+                try
+                {
+                    using var document = JsonDocument.Parse(line);
+                    ParseKimiRecord(document.RootElement, result);
+                }
+                catch (JsonException) { }
+            }
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+        return result;
+    }
+
+    private static void ParseKimiRecord(JsonElement value, KimiTail result)
+    {
+        if (value.ValueKind != JsonValueKind.Object)
+            return;
+
+        var timestamp = FirstTimestampAny(value, "time", "timestamp", "created_at", "createdAt", "ts");
+        if (timestamp is { } activity
+            && (result.LastActivity is null || activity > result.LastActivity))
+            result.LastActivity = activity;
+
+        var nested = FirstObject(value, "event", "payload", "data", "params");
+        if (nested.ValueKind == JsonValueKind.Object)
+            ParseKimiRecord(nested, result);
+
+        var type = FirstString(value, "type", "event", "kind", "method", "role") ?? "";
+        var normalized = type.ToLowerInvariant();
+        var text = FirstStringDeep(value, "prompt", "user_input", "text", "content", "message");
+        var name = FirstStringDeep(value, "tool_name", "toolName", "function_name", "function", "tool", "name");
+        var details = FirstStringDeep(value, "command", "path");
+        if (details.Length == 0)
+            details = FirstJsonTextDeep(value, "arguments", "input", "params");
+
+        if (normalized.Contains("user", StringComparison.Ordinal)
+            || normalized.Contains("prompt", StringComparison.Ordinal)
+            || normalized.Contains("input", StringComparison.Ordinal))
+        {
+            if (result.Prompt.Length == 0 && text.Length > 0)
+                result.Prompt = text;
+            result.State = TranscriptState.Action;
+            result.Step = "Thinking";
+        }
+        else if (normalized.Contains("approval", StringComparison.Ordinal)
+            || normalized.Contains("permission", StringComparison.Ordinal)
+            || normalized.Contains("ask_user", StringComparison.Ordinal)
+            || normalized.Contains("request", StringComparison.Ordinal))
+        {
+            result.State = TranscriptState.Waiting;
+            result.Step = "Waiting for input";
+        }
+        else if (normalized.Contains("error", StringComparison.Ordinal)
+            || normalized.Contains("fail", StringComparison.Ordinal))
+        {
+            result.State = TranscriptState.Failed;
+            result.Step = "Failed";
+        }
+        else if (normalized.Contains("tool", StringComparison.Ordinal)
+            || normalized.Contains("function_call", StringComparison.Ordinal)
+            || normalized.Contains("shell", StringComparison.Ordinal)
+            || normalized.Contains("command", StringComparison.Ordinal))
+        {
+            result.State = TranscriptState.Action;
+            result.Step = string.IsNullOrWhiteSpace(name) ? "Running tool" : DescribeAction(name, details);
+        }
+        else if (normalized.Contains("complete", StringComparison.Ordinal)
+            || normalized.Contains("finish", StringComparison.Ordinal)
+            || normalized.Contains("turn_end", StringComparison.Ordinal)
+            || normalized.Contains("session_end", StringComparison.Ordinal))
+        {
+            result.State = TranscriptState.Finished;
+            if (text.Length > 0)
+                result.Summary = text;
+        }
+        else if (normalized.Contains("assistant", StringComparison.Ordinal)
+            || normalized.Contains("response", StringComparison.Ordinal)
+            || normalized.Contains("message", StringComparison.Ordinal))
+        {
+            if (text.Length > 0)
+                result.Summary = text;
+            result.State = TranscriptState.Finished;
+        }
+
+        if (result.Model.Length == 0)
+            result.Model = FirstStringDeep(value, "model", "model_name", "modelName");
+    }
+
     private static bool TryReadGrokSession(string summaryPath, DateTimeOffset modified,
         bool claimLive, out AgentActivityItem item)
     {
@@ -1172,6 +1636,124 @@ internal sealed class AgentActivityScanner
                 return parsed.ToLocalTime();
         }
         return null;
+    }
+
+    private static DateTimeOffset? FirstTimestampAny(JsonElement value, params string[] names)
+    {
+        if (value.ValueKind != JsonValueKind.Object)
+            return null;
+        foreach (var name in names)
+        {
+            if (!value.TryGetProperty(name, out var property))
+                continue;
+            if (property.ValueKind == JsonValueKind.String
+                && DateTimeOffset.TryParse(property.GetString(), out var parsed))
+                return parsed.ToLocalTime();
+            if (property.ValueKind == JsonValueKind.Number
+                && property.TryGetInt64(out var numeric))
+            {
+                try
+                {
+                    return numeric > 10_000_000_000
+                        ? DateTimeOffset.FromUnixTimeMilliseconds(numeric).ToLocalTime()
+                        : DateTimeOffset.FromUnixTimeSeconds(numeric).ToLocalTime();
+                }
+                catch (ArgumentOutOfRangeException) { }
+            }
+        }
+        return null;
+    }
+
+    private static JsonElement FirstObject(JsonElement value, params string[] names)
+    {
+        if (value.ValueKind != JsonValueKind.Object)
+            return default;
+        foreach (var name in names)
+            if (value.TryGetProperty(name, out var property) && property.ValueKind == JsonValueKind.Object)
+                return property;
+        return default;
+    }
+
+    private static string FirstStringDeep(JsonElement value, params string[] names)
+    {
+        if (value.ValueKind == JsonValueKind.String)
+            return Clean(value.GetString());
+        if (value.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var child in value.EnumerateArray())
+            {
+                var result = FirstStringDeep(child, names);
+                if (result.Length > 0)
+                    return result;
+            }
+            return "";
+        }
+        if (value.ValueKind != JsonValueKind.Object)
+            return "";
+
+        foreach (var name in names)
+        {
+            if (!value.TryGetProperty(name, out var property))
+                continue;
+            var result = property.ValueKind == JsonValueKind.String
+                ? Clean(property.GetString())
+                : ExtractContentText(property);
+            if (result.Length > 0)
+                return result;
+        }
+
+        foreach (var property in value.EnumerateObject())
+        {
+            if (property.Value.ValueKind is not (JsonValueKind.Object or JsonValueKind.Array))
+                continue;
+            var result = FirstStringDeep(property.Value, names);
+            if (result.Length > 0)
+                return result;
+        }
+        return "";
+    }
+
+    private static string FirstJsonTextDeep(JsonElement value, params string[] names)
+    {
+        if (value.ValueKind != JsonValueKind.Object)
+            return "";
+        foreach (var name in names)
+        {
+            if (!value.TryGetProperty(name, out var property))
+                continue;
+            if (property.ValueKind == JsonValueKind.String)
+                return property.GetString() ?? "";
+            if (property.ValueKind is JsonValueKind.Object or JsonValueKind.Array)
+                return property.ToString();
+        }
+        foreach (var property in value.EnumerateObject())
+        {
+            if (property.Value.ValueKind is not (JsonValueKind.Object or JsonValueKind.Array))
+                continue;
+            var result = FirstJsonTextDeep(property.Value, names);
+            if (result.Length > 0)
+                return result;
+        }
+        return "";
+    }
+
+    private static bool IsTrue(JsonElement value, params string[] names)
+    {
+        if (value.ValueKind != JsonValueKind.Object)
+            return false;
+        foreach (var name in names)
+        {
+            if (!value.TryGetProperty(name, out var property))
+                continue;
+            if (property.ValueKind == JsonValueKind.True)
+                return true;
+            if (property.ValueKind == JsonValueKind.String
+                && bool.TryParse(property.GetString(), out var parsed))
+                return parsed;
+            if (property.ValueKind == JsonValueKind.Object)
+                return true;
+        }
+        return false;
     }
 
     private static IReadOnlyList<AgentActivityItem> ReadOpenCodeSessions(
@@ -1615,6 +2197,20 @@ internal sealed class AgentActivityScanner
     internal static string? SummarizeTitleForTesting(string? prompt)
         => SummarizeTitle(prompt);
 
+    internal static AgentActivityItem? ReadClineForTesting(string metadataPath, bool claimLive = true)
+        => TryReadClineSession(
+            metadataPath,
+            new DateTimeOffset(File.GetLastWriteTimeUtc(metadataPath), TimeSpan.Zero).ToLocalTime(),
+            claimLive,
+            out var item) ? item : null;
+
+    internal static AgentActivityItem? ReadKimiForTesting(string statePath, bool claimLive = true)
+        => TryReadKimiSession(
+            statePath,
+            new DateTimeOffset(File.GetLastWriteTimeUtc(statePath), TimeSpan.Zero).ToLocalTime(),
+            claimLive,
+            out var item) ? item : null;
+
     private static void ParseClaudeEvent(JsonElement root, ref string step, ref string summary,
         ref string model, ref string threadId, ref string parentId, ref string prompt,
         ref string host, ref TranscriptState state)
@@ -1932,6 +2528,8 @@ internal sealed class AgentActivityScanner
                     case "cursor": Add(ProviderId.Cursor); break;
                     case "antigravity": Add(ProviderId.Antigravity); break;
                     case "devin": Add(ProviderId.Devin); break;
+                    case "cline": Add(ProviderId.Cline); break;
+                    case "kimi": Add(ProviderId.Kimi); break;
                 }
             }
             catch { }
@@ -1956,7 +2554,7 @@ internal sealed class AgentActivityScanner
             "Name = 'bun.exe' OR Name = 'deno.exe' OR Name = 'npm.exe' OR Name = 'npx.exe' OR " +
             "Name = 'pnpm.exe' OR Name = 'yarn.exe' OR Name = 'wsl.exe' OR Name = 'bash.exe' OR " +
             "Name = 'codex.exe' OR Name = 'claude.exe' OR Name = 'cursor-agent.exe' OR " +
-            "Name = 'opencode.exe' OR Name = 'cline.exe' OR Name = 'agy.exe' OR Name = 'grok.exe'";
+            "Name = 'opencode.exe' OR Name = 'cline.exe' OR Name = 'kimi.exe' OR Name = 'agy.exe' OR Name = 'grok.exe'";
 
         try
         {
@@ -1990,6 +2588,7 @@ internal sealed class AgentActivityScanner
         if (text.Contains("grok") || executable.Equals("grok", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Grok; return true; }
         if (text.Contains("opencode")) { provider = ProviderId.OpenCode; return true; }
         if (text.Contains("cline")) { provider = ProviderId.Cline; return true; }
+        if (text.Contains("kimi")) { provider = ProviderId.Kimi; return true; }
         if (text.Contains(" codex") || executable.Equals("codex", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Codex; return true; }
         return false;
     }
@@ -2091,6 +2690,24 @@ internal sealed class AgentActivityScanner
         string MessageId, string Type, DateTimeOffset ActivityAt, string Tool, string Status, string Input, string Text);
     private sealed record OpenCodeTail(
         string Step, string Summary, string Prompt, DateTimeOffset? LastActivity, TranscriptState State);
+    private sealed class ClineTail
+    {
+        public string Prompt { get; set; } = "";
+        public string Step { get; set; } = "";
+        public string Summary { get; set; } = "";
+        public string Model { get; set; } = "";
+        public DateTimeOffset? LastActivity { get; set; }
+        public TranscriptState State { get; set; }
+    }
+    private sealed class KimiTail
+    {
+        public string Prompt { get; set; } = "";
+        public string Step { get; set; } = "";
+        public string Summary { get; set; } = "";
+        public string Model { get; set; } = "";
+        public DateTimeOffset? LastActivity { get; set; }
+        public TranscriptState State { get; set; }
+    }
     private sealed record AntigravityConversationMetadata(
         string Id, string Title, string Preview, string Workspace, DateTimeOffset? UpdatedAt, string AgentName);
     private sealed record AntigravityStepRow(

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -23,11 +23,13 @@ internal sealed class AgentActivityScanner
 {
     private static readonly TimeSpan RecentWindow = TimeSpan.FromHours(6);
     private static readonly TimeSpan BusyWindow = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan CandidateDiscoveryInterval = TimeSpan.FromSeconds(5);
     private readonly string _home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
     private CodexThreadNameResolver _threadNames = new();
     private readonly object _candidateGate = new();
     private readonly Dictionary<string, (ProviderId Provider, string Path, DateTimeOffset Modified)> _knownCandidates =
         new(StringComparer.OrdinalIgnoreCase);
+    private DateTimeOffset _lastCandidateDiscovery = DateTimeOffset.MinValue;
 
     public IReadOnlyList<AgentActivityItem> Scan(CancellationToken cancellationToken = default)
     {
@@ -38,30 +40,34 @@ internal sealed class AgentActivityScanner
         var liveProviders = MergeLiveProviders(desktopApps, terminalAgents);
         Log.Debug($"[activity] agent discovery: desktop={desktopApps.Values.Sum()}, terminal={terminalAgents.Values.Sum()}");
         var files = new List<(ProviderId Provider, string Path, DateTimeOffset Modified)>();
+        bool discoverCandidates = DateTimeOffset.UtcNow - _lastCandidateDiscovery >= CandidateDiscoveryInterval;
         // Process discovery is intentionally the gate for transcript/database work. Most agent
         // stores are SQLite or recursive file trees, so reopening them every tick when the app is
         // closed wastes the bulk of the activity refresh time.
-        if (IsDetected(ProviderId.Codex))
+        if (discoverCandidates && IsDetected(ProviderId.Codex))
             AddRecent(files, Path.Combine(_home, ".codex", "sessions"), ProviderId.Codex, cancellationToken);
-        if (IsDetected(ProviderId.Claude))
+        if (discoverCandidates && IsDetected(ProviderId.Claude))
             AddRecent(files, Path.Combine(_home, ".claude", "projects"), ProviderId.Claude, cancellationToken);
-        if (IsDetected(ProviderId.Grok))
+        if (discoverCandidates && IsDetected(ProviderId.Grok))
             AddGrokSessions(files, cancellationToken);
-        if (IsDetected(ProviderId.Antigravity))
+        if (discoverCandidates && IsDetected(ProviderId.Antigravity))
         {
             AddAntigravityDatabases(files, cancellationToken);
             AddAntigravityGuiTranscripts(files, cancellationToken);
         }
-        if (IsDetected(ProviderId.OpenCode))
+        if (discoverCandidates && IsDetected(ProviderId.OpenCode))
             AddOpenCodeDatabases(files, cancellationToken);
-        if (IsDetected(ProviderId.Cline))
+        if (discoverCandidates && IsDetected(ProviderId.Cline))
             AddClineSessions(files, cancellationToken);
-        if (IsDetected(ProviderId.Kimi))
+        if (discoverCandidates && IsDetected(ProviderId.Kimi))
             AddKimiSessions(files, cancellationToken);
-        if (IsDetected(ProviderId.Copilot))
+        if (discoverCandidates && IsDetected(ProviderId.Copilot))
             AddCopilotSessions(files, cancellationToken);
-        if (IsDetected(ProviderId.Zai))
+        if (discoverCandidates && IsDetected(ProviderId.Zai))
             AddZcodeDatabase(files, cancellationToken);
+
+        if (discoverCandidates)
+            _lastCandidateDiscovery = DateTimeOffset.UtcNow;
 
         bool IsDetected(ProviderId provider) => liveProviders.ContainsKey(provider);
 
@@ -156,13 +162,20 @@ internal sealed class AgentActivityScanner
             var existingPaths = files.Select(file => file.Path).ToHashSet(StringComparer.OrdinalIgnoreCase);
             foreach (var (path, candidate) in _knownCandidates.ToArray())
             {
-                if (!File.Exists(path) || DateTimeOffset.Now - candidate.Modified > RecentWindow)
+                if (!File.Exists(path))
+                {
+                    _knownCandidates.Remove(path);
+                    continue;
+                }
+                var modifiedUtc = File.GetLastWriteTimeUtc(path);
+                var modified = new DateTimeOffset(modifiedUtc, TimeSpan.Zero).ToLocalTime();
+                if (DateTimeOffset.Now - modified > RecentWindow)
                 {
                     _knownCandidates.Remove(path);
                     continue;
                 }
                 if (!existingPaths.Contains(path))
-                    files.Add(candidate);
+                    files.Add((candidate.Provider, candidate.Path, modified));
             }
         }
     }
@@ -189,6 +202,7 @@ internal sealed class AgentActivityScanner
     {
         lock (_candidateGate)
             _knownCandidates.Clear();
+        _lastCandidateDiscovery = DateTimeOffset.MinValue;
         _threadNames = new CodexThreadNameResolver();
     }
 

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -47,7 +47,7 @@ internal sealed class AgentActivityScanner
                 parsed.Add(item);
         }
 
-        return GroupCodex(parsed)
+        return GroupSessions(parsed)
             .Where(item => item.IsLive || DateTimeOffset.Now - item.UpdatedAt < RecentWindow)
             .OrderByDescending(item => item.IsLive)
             .ThenByDescending(item => item.UpdatedAt)
@@ -89,37 +89,50 @@ internal sealed class AgentActivityScanner
             var text = reader.ReadToEnd();
             var info = ParseTail(provider, text);
             var session = provider == ProviderId.Codex ? ReadSessionMetadata(path) : default;
+            ClaudeSessionContext? claude = provider == ProviderId.Claude
+                ? ReadClaudeSessionContext(path, info.ThreadId)
+                : null;
             bool freshAgentEvent = info.LastActivity is { } activity && DateTimeOffset.Now - activity < BusyWindow;
-            // One desktop provider process can host several concurrent threads. A fresh reasoning/tool
-            // event is therefore also a liveness signal, not just the process-count claim.
-            bool live = (claimLive || (info.State == TranscriptState.Action && freshAgentEvent))
-                && modified > DateTimeOffset.Now - RecentWindow;
+            // One desktop provider process can host several concurrent threads. The process claim marks
+            // the session live; transcript timestamps then distinguish working from quiet/idle.
+            bool live = claimLive && modified > DateTimeOffset.Now - RecentWindow;
             bool busy = live && freshAgentEvent;
-            // A desktop process can stay alive after the agent's final response. The transcript is the
-            // authority for completion, mirroring agent-notch's event-based state model.
-            var status = info.State == TranscriptState.Finished || !live
+            // Process liveness is authoritative: a quiet live process is idle, not completed. This is the
+            // same busy/idle/done model used by agent-notch and avoids treating Claude's interactive shell
+            // as finished merely because its last assistant turn ended.
+            var status = !live
                 ? AgentActivityStatus.Completed
-                : AgentActivityStatus.Working;
-            // The user's initial prompt is intentionally not mirrored into the taskbar or activity panel.
-            // It is often long and belongs to the provider conversation, not the compact activity signal.
-            var threadId = session.ThreadId ?? info.ThreadId;
-            var title = provider == ProviderId.Codex ? _threadNames.GetName(threadId) ?? provider.ToString() : provider.ToString();
+                : info.State == TranscriptState.Waiting
+                    ? AgentActivityStatus.Waiting
+                    : freshAgentEvent ? AgentActivityStatus.Working : AgentActivityStatus.Idle;
+            string? threadId = session.ThreadId ?? info.ThreadId;
+            if (provider == ProviderId.Claude && string.IsNullOrWhiteSpace(threadId))
+                threadId = claude?.ThreadId;
+
+            var title = provider == ProviderId.Codex
+                ? _threadNames.GetName(threadId) ?? SummarizeTitle(info.Prompt) ?? provider.ToString()
+                : SummarizeTitle(info.Prompt) ?? claude?.ProjectTitle ?? provider.ToString();
             // A reasoning summary is useful while the agent is working, but becomes stale and misleading
             // once a final response has landed. Completion is deliberately a stable, unambiguous state.
             var step = status == AgentActivityStatus.Completed
                 ? "Completed"
+                : status == AgentActivityStatus.Waiting
+                    ? string.IsNullOrWhiteSpace(info.Step) ? "Waiting for input" : info.Step
+                : status == AgentActivityStatus.Idle ? "Waiting for the next prompt"
                 : info.State == TranscriptState.Action && !string.IsNullOrWhiteSpace(info.Step)
                     ? info.Step
-                    : !string.IsNullOrWhiteSpace(info.Summary) ? info.Summary
+                : !string.IsNullOrWhiteSpace(info.Summary) ? info.Summary
                     : string.IsNullOrWhiteSpace(info.Step) ? (busy ? "Working" : "Thinking") : info.Step;
             item = new AgentActivityItem(
                 path, provider, title, step, status,
                 info.StartedAt ?? modified, info.LastActivity ?? modified,
                 SubagentCount: 0,
-                Detail: null,
+                Detail: info.Prompt,
                 Model: info.Model,
                 ThreadId: threadId,
-                ParentThreadId: session.ParentThreadId ?? info.ParentThreadId,
+                ParentThreadId: provider == ProviderId.Claude
+                    ? claude?.ParentThreadId ?? info.ParentThreadId
+                    : session.ParentThreadId ?? info.ParentThreadId,
                 Host: session.Host);
             return true;
         }
@@ -162,7 +175,7 @@ internal sealed class AgentActivityScanner
 
     private static TailInfo ParseTail(ProviderId provider, string text)
     {
-        string step = "", summary = "", model = "", threadId = "", parentId = "";
+        string step = "", summary = "", model = "", threadId = "", parentId = "", prompt = "";
         DateTimeOffset? started = null, activity = null;
         var state = TranscriptState.Unknown;
         foreach (var line in text.Split('\n').Reverse())
@@ -180,13 +193,22 @@ internal sealed class AgentActivityScanner
                     if (activity is null && IsConversationEvent(root, provider)) activity = parsedTime;
                 }
 
+                if (provider == ProviderId.Claude)
+                    ParseClaudeEvent(root, ref step, ref summary, ref model, ref threadId,
+                        ref parentId, ref prompt, ref state);
+
                 if (root.TryGetProperty("payload", out var payload) && payload.ValueKind == JsonValueKind.Object)
                 {
-                    if (threadId.Length == 0 && payload.TryGetProperty("id", out var id)) threadId = id.GetString() ?? "";
-                    if (parentId.Length == 0 && payload.TryGetProperty("parent_thread_id", out var parent)) parentId = parent.GetString() ?? "";
-                    if (model.Length == 0 && payload.TryGetProperty("model", out var modelNode)) model = modelNode.GetString() ?? "";
+                    if (parentId.Length == 0 && payload.TryGetProperty("parent_thread_id", out var parent)) parentId = JsonText(parent);
+                    if (model.Length == 0 && payload.TryGetProperty("model", out var modelNode)) model = JsonText(modelNode);
 
                     var type = payload.TryGetProperty("type", out var typeNode) ? typeNode.GetString() : null;
+                    // Tool-call and message ids are not thread ids. Codex's session_meta entry is the
+                    // authoritative source; the caller also reads it from the transcript header.
+                    if (threadId.Length == 0 && type == "session_meta" && payload.TryGetProperty("id", out var id))
+                        threadId = JsonText(id);
+                    if (prompt.Length == 0 && type is "user_message")
+                        prompt = ExtractPayloadText(payload);
                     if (summary.Length == 0 && type is "agent_reasoning" && payload.TryGetProperty("text", out var summaryText))
                         summary = Clean(summaryText.GetString());
                     if (summary.Length == 0 && type is "reasoning" && payload.TryGetProperty("summary", out var reasoningSummary))
@@ -214,7 +236,7 @@ internal sealed class AgentActivityScanner
                         if (IsAction(name))
                         {
                             state = state == TranscriptState.Unknown ? TranscriptState.Action : state;
-                            step = DescribeAction(name!, payload);
+                            step = DescribeAction(name!, GetPayloadDetails(payload));
                         }
                     }
                     if (step.Length == 0 && type is "agent_reasoning" && payload.TryGetProperty("text", out var reasoning))
@@ -230,12 +252,132 @@ internal sealed class AgentActivityScanner
             }
             catch (JsonException) { }
 
-            if (state != TranscriptState.Unknown && (step.Length > 0 || summary.Length > 0)
-                && activity is not null && threadId.Length > 0)
+            if (activity is not null && (step.Length > 0 || summary.Length > 0)
+                && prompt.Length > 0 && (provider == ProviderId.Claude || threadId.Length > 0))
                 break;
         }
 
-        return new TailInfo(step, summary, model, threadId, parentId, started, activity, state);
+        return new TailInfo(step, summary, model, threadId, parentId, prompt, started, activity, state);
+    }
+
+    internal static TailInfo ParseTranscriptForTesting(ProviderId provider, string text)
+        => ParseTail(provider, text);
+
+    internal static string? SummarizeTitleForTesting(string? prompt)
+        => SummarizeTitle(prompt);
+
+    private static void ParseClaudeEvent(JsonElement root, ref string step, ref string summary,
+        ref string model, ref string threadId, ref string parentId, ref string prompt,
+        ref TranscriptState state)
+    {
+        var type = root.TryGetProperty("type", out var typeNode) ? typeNode.GetString() : null;
+        if (type is not ("user" or "assistant"))
+            return;
+
+        if (threadId.Length == 0)
+            threadId = FirstString(root, "sessionId", "session_id", "uuid");
+        if (parentId.Length == 0)
+            parentId = FirstString(root, "parentThreadId", "parent_thread_id");
+        if (!root.TryGetProperty("message", out var message) || message.ValueKind != JsonValueKind.Object)
+            return;
+
+        if (model.Length == 0)
+            model = FirstString(message, "model");
+
+        if (type == "user")
+        {
+            if (prompt.Length == 0 && message.TryGetProperty("content", out var content))
+                prompt = ExtractContentText(content);
+            if (state == TranscriptState.Unknown)
+            {
+                state = TranscriptState.Action;
+                if (step.Length == 0)
+                    step = "Thinking";
+            }
+            return;
+        }
+
+        if (!message.TryGetProperty("content", out var assistantContent))
+            return;
+
+        if (FindClaudeToolAction(assistantContent) is { } action)
+        {
+            if (step.Length == 0)
+                step = action.Step;
+            state = action.Waiting ? TranscriptState.Waiting : TranscriptState.Action;
+            return;
+        }
+
+        if (summary.Length == 0)
+            summary = ExtractContentText(assistantContent);
+    }
+
+    private static string ExtractPayloadText(JsonElement payload)
+    {
+        if (payload.TryGetProperty("message", out var message))
+        {
+            var value = message.ValueKind == JsonValueKind.Object && message.TryGetProperty("content", out var nested)
+                ? nested
+                : message;
+            var text = ExtractContentText(value);
+            if (text.Length > 0)
+                return text;
+        }
+
+        if (payload.TryGetProperty("content", out var content))
+            return ExtractContentText(content);
+        return "";
+    }
+
+    private static string ExtractContentText(JsonElement content)
+    {
+        if (content.ValueKind == JsonValueKind.String)
+            return Clean(content.GetString());
+
+        if (content.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var part in content.EnumerateArray().Reverse())
+            {
+                if (part.ValueKind != JsonValueKind.Object)
+                    continue;
+                if (part.TryGetProperty("text", out var text))
+                {
+                    var value = Clean(text.GetString());
+                    if (value.Length > 0)
+                        return value;
+                }
+            }
+        }
+
+        return "";
+    }
+
+    private static ClaudeToolAction? FindClaudeToolAction(JsonElement content)
+    {
+        if (content.ValueKind != JsonValueKind.Array)
+            return null;
+
+        foreach (var part in content.EnumerateArray().Reverse())
+        {
+            if (part.ValueKind != JsonValueKind.Object
+                || !part.TryGetProperty("type", out var type)
+                || type.GetString() != "tool_use")
+            {
+                continue;
+            }
+
+            var name = part.TryGetProperty("name", out var nameNode) ? nameNode.GetString() : null;
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+
+            var input = part.TryGetProperty("input", out var inputNode) ? inputNode.ToString() : "";
+            bool waiting = name.Equals("AskUserQuestion", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("ExitPlanMode", StringComparison.OrdinalIgnoreCase)
+                || name.Contains("approval", StringComparison.OrdinalIgnoreCase);
+            return new ClaudeToolAction(waiting ? "Waiting for input" : DescribeAction(name, input), waiting);
+        }
+
+        return null;
     }
 
     private static string ExtractSummary(JsonElement value)
@@ -252,13 +394,21 @@ internal sealed class AgentActivityScanner
     private static bool IsAction(string? name)
         => !string.IsNullOrWhiteSpace(name) && name is not "wait";
 
-    private static string DescribeAction(string name, JsonElement payload)
+    private static string DescribeAction(string name, string? rawDetails)
     {
-        var details = payload.TryGetProperty("arguments", out var arguments) ? arguments.GetString()
-            : payload.TryGetProperty("input", out var input) ? input.GetString() : "";
-        details ??= "";
+        var details = rawDetails ?? "";
         if (name.Equals("apply_patch", StringComparison.OrdinalIgnoreCase) || details.Contains("apply_patch", StringComparison.OrdinalIgnoreCase))
             return "Edited code";
+        if (name is "Write" or "Edit" or "MultiEdit" or "NotebookEdit")
+            return "Edited code";
+        if (name is "Read" or "Glob" or "Grep" or "LS")
+            return "Inspected files";
+        if (name is "Task" or "Agent")
+            return "Running subagent";
+        if (name is "WebFetch" or "WebSearch")
+            return "Fetching information";
+        if (name is "TodoWrite")
+            return "Updating plan";
         if (details.Contains("Get-Content", StringComparison.OrdinalIgnoreCase))
             return "Ran Get-Content";
         if (details.Contains("rg ", StringComparison.OrdinalIgnoreCase) || details.Contains("rg -", StringComparison.OrdinalIgnoreCase))
@@ -267,9 +417,78 @@ internal sealed class AgentActivityScanner
             return "Built the app";
         if (details.Contains("dotnet test", StringComparison.OrdinalIgnoreCase))
             return "Ran tests";
-        return name.Equals("shell_command", StringComparison.OrdinalIgnoreCase) || name.Equals("exec", StringComparison.OrdinalIgnoreCase)
+        return name.Equals("shell_command", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("exec", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("Bash", StringComparison.OrdinalIgnoreCase)
             ? "Running command"
             : $"Running {name}";
+    }
+
+    private static string GetPayloadDetails(JsonElement payload)
+    {
+        if (payload.TryGetProperty("arguments", out var arguments))
+            return JsonText(arguments);
+        if (payload.TryGetProperty("input", out var input))
+            return JsonText(input);
+        return "";
+    }
+
+    private static string JsonText(JsonElement value)
+        => value.ValueKind == JsonValueKind.String ? value.GetString() ?? "" : value.ToString();
+
+    private static string FirstString(JsonElement value, params string[] names)
+    {
+        foreach (var name in names)
+            if (value.TryGetProperty(name, out var property) && property.ValueKind == JsonValueKind.String)
+                return property.GetString() ?? "";
+        return "";
+    }
+
+    private static string? SummarizeTitle(string? prompt)
+    {
+        if (string.IsNullOrWhiteSpace(prompt))
+            return null;
+
+        var firstLine = prompt
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Trim().TrimStart('-', '*', '#').Trim())
+            .FirstOrDefault(line => line.Length > 0);
+        var cleaned = Clean(firstLine);
+        return cleaned.Length == 0 ? null : Trim(cleaned, 72);
+    }
+
+    private static ClaudeSessionContext ReadClaudeSessionContext(string path, string threadId)
+    {
+        try
+        {
+            var file = new FileInfo(path);
+            var directory = file.Directory;
+            DirectoryInfo? project = directory;
+            string? parent = null;
+
+            if (directory?.Name.Equals("subagents", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                var sessionDirectory = directory.Parent;
+                parent = sessionDirectory is null ? null : Path.GetFileNameWithoutExtension(sessionDirectory.Name);
+                project = sessionDirectory?.Parent;
+            }
+
+            var id = string.IsNullOrWhiteSpace(threadId)
+                ? Path.GetFileNameWithoutExtension(file.Name)
+                : threadId;
+            var projectName = project?.Name;
+            if (!string.IsNullOrWhiteSpace(projectName))
+            {
+                var parts = projectName.Split('-', StringSplitOptions.RemoveEmptyEntries);
+                projectName = parts.Length == 0 ? projectName : parts[^1];
+            }
+
+            return new ClaudeSessionContext(id, parent, projectName);
+        }
+        catch (ArgumentException)
+        {
+            return new ClaudeSessionContext(null, null, null);
+        }
     }
 
     private static bool IsConversationEvent(JsonElement root, ProviderId provider)
@@ -394,27 +613,52 @@ internal sealed class AgentActivityScanner
         return merged;
     }
 
-    private static IReadOnlyList<AgentActivityItem> GroupCodex(IReadOnlyList<AgentActivityItem> items)
+    private static IReadOnlyList<AgentActivityItem> GroupSessions(IReadOnlyList<AgentActivityItem> items)
     {
-        var codex = items.Where(item => item.Provider == ProviderId.Codex).ToArray();
-        if (codex.Length < 2) return items;
         var groups = new List<AgentActivityItem>();
         var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var root in codex.Where(item => string.IsNullOrWhiteSpace(item.ParentThreadId)))
+        foreach (var root in items.Where(item => string.IsNullOrWhiteSpace(item.ParentThreadId)))
         {
-            var children = codex.Where(item => item.ParentThreadId == root.ThreadId).ToArray();
+            if (string.IsNullOrWhiteSpace(root.ThreadId))
+            {
+                groups.Add(root);
+                used.Add(root.Id);
+                continue;
+            }
+
+            var children = items
+                .Where(item => item.Provider == root.Provider && item.ParentThreadId == root.ThreadId)
+                .ToArray();
             used.Add(root.Id);
             foreach (var child in children) used.Add(child.Id);
-            groups.Add(root with { SubagentCount = children.Length });
+            var grouped = root with { SubagentCount = children.Length };
+            var liveMember = children
+                .Append(root)
+                .Where(item => item.IsLive)
+                .OrderByDescending(item => item.UpdatedAt)
+                .FirstOrDefault();
+            if (liveMember is { } member && member.Id != root.Id)
+            {
+                grouped = grouped with
+                {
+                    Status = member.Status,
+                    Step = member.Step,
+                    UpdatedAt = member.UpdatedAt,
+                    Model = string.IsNullOrWhiteSpace(root.Model) ? member.Model : root.Model,
+                    Detail = string.IsNullOrWhiteSpace(root.Detail) ? member.Detail : root.Detail,
+                };
+            }
+            groups.Add(grouped);
         }
-        groups.AddRange(codex.Where(item => !used.Contains(item.Id)));
-        groups.AddRange(items.Where(item => item.Provider != ProviderId.Codex));
+        groups.AddRange(items.Where(item => !used.Contains(item.Id)));
         return groups;
     }
 
-    private enum TranscriptState { Unknown, Action, Finished }
+    internal enum TranscriptState { Unknown, Action, Waiting, Finished }
 
-    private sealed record TailInfo(string Step, string Summary, string Model, string ThreadId,
-        string ParentThreadId, DateTimeOffset? StartedAt, DateTimeOffset? LastActivity, TranscriptState State);
+    internal sealed record TailInfo(string Step, string Summary, string Model, string ThreadId,
+        string ParentThreadId, string Prompt, DateTimeOffset? StartedAt, DateTimeOffset? LastActivity, TranscriptState State);
+    private sealed record ClaudeToolAction(string Step, bool Waiting);
+    private sealed record ClaudeSessionContext(string? ThreadId, string? ParentThreadId, string? ProjectTitle);
     private readonly record struct SessionMetadata(string? ThreadId, string? ParentThreadId, string? Host);
 }

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -24,7 +24,10 @@ internal sealed class AgentActivityScanner
     private static readonly TimeSpan RecentWindow = TimeSpan.FromHours(6);
     private static readonly TimeSpan BusyWindow = TimeSpan.FromSeconds(30);
     private readonly string _home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-    private readonly CodexThreadNameResolver _threadNames = new();
+    private CodexThreadNameResolver _threadNames = new();
+    private readonly object _candidateGate = new();
+    private readonly Dictionary<string, (ProviderId Provider, string Path, DateTimeOffset Modified)> _knownCandidates =
+        new(StringComparer.OrdinalIgnoreCase);
 
     public IReadOnlyList<AgentActivityItem> Scan(CancellationToken cancellationToken = default)
     {
@@ -33,7 +36,7 @@ internal sealed class AgentActivityScanner
         var desktopApps = ScanDesktopAgentApps();
         var terminalAgents = ScanTerminalAgentCommands();
         var liveProviders = MergeLiveProviders(desktopApps, terminalAgents);
-        Log.Information($"[activity] agent discovery: desktop={desktopApps.Values.Sum()}, terminal={terminalAgents.Values.Sum()}");
+        Log.Debug($"[activity] agent discovery: desktop={desktopApps.Values.Sum()}, terminal={terminalAgents.Values.Sum()}");
         var files = new List<(ProviderId Provider, string Path, DateTimeOffset Modified)>();
         // Process discovery is intentionally the gate for transcript/database work. Most agent
         // stores are SQLite or recursive file trees, so reopening them every tick when the app is
@@ -76,18 +79,22 @@ internal sealed class AgentActivityScanner
         files.RemoveAll(file => file.Provider == ProviderId.Copilot);
         files.AddRange(copilotFiles);
 
+        AddRememberedCandidates(files);
+        var candidates = SelectCandidates(files);
+        RememberCandidates(candidates);
+
         var parsed = new List<AgentActivityItem>();
         var liveClaims = new Dictionary<ProviderId, int>();
-        foreach (var file in files.OrderByDescending(f => f.Modified).Take(80))
+        foreach (var file in candidates)
         {
             cancellationToken.ThrowIfCancellationRequested();
             int claim = liveClaims.TryGetValue(file.Provider, out var currentClaim) ? currentClaim : 0;
             bool claimLive = liveProviders.TryGetValue(file.Provider, out var liveCount) && claim < liveCount;
-            liveClaims[file.Provider] = claim + 1;
+            var candidateItems = new List<AgentActivityItem>();
             if (file.Provider == ProviderId.Grok)
             {
                 if (TryReadGrokSession(file.Path, file.Modified, claimLive, out var grokItem))
-                    parsed.Add(grokItem);
+                    candidateItems.Add(grokItem);
             }
             else if (file.Provider == ProviderId.Antigravity)
             {
@@ -95,35 +102,43 @@ internal sealed class AgentActivityScanner
                     ? TryReadAntigravityGuiSession(file.Path, file.Modified, claimLive, out var antigravityItem)
                     : TryReadAntigravitySession(file.Path, file.Modified, claimLive, out antigravityItem);
                 if (read)
-                    parsed.Add(antigravityItem);
+                    candidateItems.Add(antigravityItem);
             }
             else if (file.Provider == ProviderId.OpenCode)
             {
-                parsed.AddRange(ReadOpenCodeSessions(file.Path, file.Modified, claimLive));
+                candidateItems.AddRange(ReadOpenCodeSessions(file.Path, file.Modified, claimLive));
             }
             else if (file.Provider == ProviderId.Cline)
             {
                 if (TryReadClineSession(file.Path, file.Modified, claimLive, out var clineItem))
-                    parsed.Add(clineItem);
+                    candidateItems.Add(clineItem);
             }
             else if (file.Provider == ProviderId.Kimi)
             {
                 if (TryReadKimiSession(file.Path, file.Modified, claimLive, out var kimiItem))
-                    parsed.Add(kimiItem);
+                    candidateItems.Add(kimiItem);
             }
             else if (file.Provider == ProviderId.Copilot)
             {
                 if (TryReadCopilotSession(file.Path, file.Modified, claimLive, out var copilotItem))
-                    parsed.Add(copilotItem);
+                    candidateItems.Add(copilotItem);
             }
             else if (file.Provider == ProviderId.Zai)
             {
-                parsed.AddRange(ReadZcodeSessions(file.Path, file.Modified, claimLive));
+                candidateItems.AddRange(ReadZcodeSessions(file.Path, file.Modified, claimLive));
             }
             else if (TryRead(file.Provider, file.Path, file.Modified, claimLive, out var item))
             {
-                parsed.Add(item);
+                candidateItems.Add(item);
             }
+
+            // A concurrently-written or malformed newest file must not consume the only live-process
+            // claim and force the next valid session to look completed.
+            if (candidateItems.Count == 0)
+                continue;
+
+            liveClaims[file.Provider] = claim + 1;
+            parsed.AddRange(candidateItems);
         }
 
         return ApplyActiveHostFallback(GroupSessions(parsed))
@@ -132,6 +147,59 @@ internal sealed class AgentActivityScanner
             .ThenByDescending(item => item.UpdatedAt)
             .ToArray();
     }
+
+    private void AddRememberedCandidates(
+        List<(ProviderId Provider, string Path, DateTimeOffset Modified)> files)
+    {
+        lock (_candidateGate)
+        {
+            var existingPaths = files.Select(file => file.Path).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (var (path, candidate) in _knownCandidates.ToArray())
+            {
+                if (!File.Exists(path) || DateTimeOffset.Now - candidate.Modified > RecentWindow)
+                {
+                    _knownCandidates.Remove(path);
+                    continue;
+                }
+                if (!existingPaths.Contains(path))
+                    files.Add(candidate);
+            }
+        }
+    }
+
+    private void RememberCandidates(
+        IReadOnlyList<(ProviderId Provider, string Path, DateTimeOffset Modified)> candidates)
+    {
+        lock (_candidateGate)
+        {
+            foreach (var candidate in candidates)
+                _knownCandidates[candidate.Path] = candidate;
+
+            var retainedPaths = _knownCandidates.Values
+                .GroupBy(candidate => candidate.Provider)
+                .SelectMany(group => group.OrderByDescending(candidate => candidate.Modified).Take(20))
+                .Select(candidate => candidate.Path)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (var path in _knownCandidates.Keys.Where(path => !retainedPaths.Contains(path)).ToArray())
+                _knownCandidates.Remove(path);
+        }
+    }
+
+    public void ClearCache()
+    {
+        lock (_candidateGate)
+            _knownCandidates.Clear();
+        _threadNames = new CodexThreadNameResolver();
+    }
+
+    internal static IReadOnlyList<(ProviderId Provider, string Path, DateTimeOffset Modified)> SelectCandidates(
+        IEnumerable<(ProviderId Provider, string Path, DateTimeOffset Modified)> files,
+        int maxPerProvider = 20)
+        => files
+            .GroupBy(file => file.Provider)
+            .SelectMany(group => group.OrderByDescending(file => file.Modified).Take(maxPerProvider))
+            .OrderByDescending(file => file.Modified)
+            .ToArray();
 
     private void AddRecent(List<(ProviderId, string, DateTimeOffset)> output, string root,
         ProviderId provider, CancellationToken cancellationToken)
@@ -361,7 +429,13 @@ internal sealed class AgentActivityScanner
 
             transcript.LastActivity ??= modified;
             transcript.StartedAt ??= transcript.LastActivity;
-            var live = claimLive;
+            // VS Code being open is not proof that Copilot is currently running a turn. Require a
+            // pending/waiting request or a fresh transcript write so an old chat does not stay live for
+            // the lifetime of the editor process.
+            var live = claimLive
+                && (transcript.Pending
+                    || transcript.Waiting
+                    || DateTimeOffset.Now - transcript.LastActivity.Value < BusyWindow);
             var status = !live
                 ? transcript.Failed ? AgentActivityStatus.Failed : AgentActivityStatus.Completed
                 : transcript.Failed ? AgentActivityStatus.Failed
@@ -1572,8 +1646,9 @@ internal sealed class AgentActivityScanner
         {
             using var document = JsonDocument.Parse(File.ReadAllText(metadataPath));
             var root = document.RootElement;
-            var sessionId = FirstString(root, "session_id", "sessionId")
-                ?? Path.GetFileNameWithoutExtension(metadataPath);
+            var sessionId = FirstNonEmpty(
+                FirstString(root, "session_id", "sessionId"),
+                Path.GetFileNameWithoutExtension(metadataPath));
             var metadata = root.TryGetProperty("metadata", out var metadataNode)
                 && metadataNode.ValueKind == JsonValueKind.Object
                 ? metadataNode
@@ -3158,7 +3233,8 @@ internal sealed class AgentActivityScanner
     private static IReadOnlyDictionary<ProviderId, int> ScanTerminalAgentCommands()
     {
         var live = new Dictionary<ProviderId, int>();
-        const string query = "SELECT Name, CommandLine FROM Win32_Process WHERE " +
+        var matches = new List<(int ProcessId, int ParentProcessId, ProviderId Provider)>();
+        const string query = "SELECT ProcessId, ParentProcessId, Name, CommandLine FROM Win32_Process WHERE " +
             "Name = 'cmd.exe' OR Name = 'powershell.exe' OR Name = 'pwsh.exe' OR Name = 'node.exe' OR " +
             "Name = 'bun.exe' OR Name = 'deno.exe' OR Name = 'npm.exe' OR Name = 'npx.exe' OR " +
             "Name = 'pnpm.exe' OR Name = 'yarn.exe' OR Name = 'wsl.exe' OR Name = 'bash.exe' OR " +
@@ -3176,12 +3252,41 @@ internal sealed class AgentActivityScanner
                     var name = Path.GetFileNameWithoutExtension(process["Name"]?.ToString() ?? "");
                     var commandLine = process["CommandLine"]?.ToString() ?? "";
                     if (TryGetTerminalProvider(name, commandLine, out var provider))
-                        Add(provider);
+                    {
+                        var processId = Convert.ToInt32(process["ProcessId"] ?? 0);
+                        if (processId <= 0)
+                            continue;
+                        matches.Add((
+                            processId,
+                            Convert.ToInt32(process["ParentProcessId"] ?? 0),
+                            provider));
+                    }
                 }
             }
         }
         catch (ManagementException) { }
         catch (UnauthorizedAccessException) { }
+
+        var byId = matches.ToDictionary(match => match.ProcessId);
+        foreach (var match in matches)
+        {
+            // npm/npx/node and shell launchers can all describe the same agent process tree. Count only
+            // the highest matching ancestor so a single task receives one transcript claim.
+            var parentId = match.ParentProcessId;
+            var hasMatchingAncestor = false;
+            var visited = new HashSet<int>();
+            while (parentId != 0 && visited.Add(parentId) && byId.TryGetValue(parentId, out var parent))
+            {
+                if (parent.Provider == match.Provider)
+                {
+                    hasMatchingAncestor = true;
+                    break;
+                }
+                parentId = parent.ParentProcessId;
+            }
+            if (!hasMatchingAncestor)
+                Add(match.Provider);
+        }
 
         return live;
         void Add(ProviderId provider) => live[provider] = live.TryGetValue(provider, out var count) ? count + 1 : 1;
@@ -3190,19 +3295,55 @@ internal sealed class AgentActivityScanner
     private static bool TryGetTerminalProvider(string executable, string commandLine, out ProviderId provider)
     {
         provider = default;
-        var text = (executable + " " + commandLine).ToLowerInvariant();
-        if (text.Contains("claude-code") || text.Contains(" claude") || executable.Equals("claude", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Claude; return true; }
-        if (text.Contains("cursor-agent") || text.Contains("cursor agent")) { provider = ProviderId.Cursor; return true; }
-        if (text.Contains("antigravity") || executable.Equals("agy", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Antigravity; return true; }
-        if (text.Contains("grok") || executable.Equals("grok", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Grok; return true; }
-        if (text.Contains("opencode")) { provider = ProviderId.OpenCode; return true; }
-        if (text.Contains("cline")) { provider = ProviderId.Cline; return true; }
-        if (text.Contains("kimi")) { provider = ProviderId.Kimi; return true; }
-        if (text.Contains("zcode") || executable.Equals("zcode", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Zai; return true; }
-        if (text.Contains("copilot") || executable.Equals("github-copilot", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Copilot; return true; }
-        if (text.Contains(" codex") || executable.Equals("codex", StringComparison.OrdinalIgnoreCase)) { provider = ProviderId.Codex; return true; }
+        var exe = executable.ToLowerInvariant();
+        if (TryGetDirectTerminalProvider(exe, out provider))
+            return true;
+
+        // Shell command lines routinely contain paths such as .codex or user-entered search terms. Do
+        // not infer an agent from arbitrary substrings. Runtime wrappers are accepted only when their
+        // command line names a known package/entry point.
+        if (exe is not ("node" or "bun" or "deno" or "npm" or "npx" or "pnpm" or "yarn" or "wsl" or "bash"))
+            return false;
+
+        var text = commandLine.ToLowerInvariant().Replace('/', '\\');
+        if (ContainsPackage(text, "@anthropic-ai\\claude-code", "claude-code\\cli", "\\claude-code.")) { provider = ProviderId.Claude; return true; }
+        if (ContainsPackage(text, "@openai\\codex", "\\codex\\bin\\codex", "\\codex-cli")) { provider = ProviderId.Codex; return true; }
+        if (ContainsPackage(text, "cursor-agent", "@cursor\\agent")) { provider = ProviderId.Cursor; return true; }
+        if (ContainsPackage(text, "opencode-ai", "\\opencode\\bin", "\\opencode-ai")) { provider = ProviderId.OpenCode; return true; }
+        if (ContainsPackage(text, "@cline\\", "\\cline\\bin", "cline-cli")) { provider = ProviderId.Cline; return true; }
+        if (ContainsPackage(text, "kimi-cli", "\\kimi\\cli")) { provider = ProviderId.Kimi; return true; }
+        if (ContainsPackage(text, "antigravity-cli", "\\agy\\cli")) { provider = ProviderId.Antigravity; return true; }
+        if (ContainsPackage(text, "grok-cli", "@xai\\grok")) { provider = ProviderId.Grok; return true; }
+        if (ContainsPackage(text, "zcode-cli", "\\zcode\\cli")) { provider = ProviderId.Zai; return true; }
+        if (ContainsPackage(text, "github-copilot", "@github\\copilot", "copilot-cli")) { provider = ProviderId.Copilot; return true; }
         return false;
     }
+
+    private static bool TryGetDirectTerminalProvider(string executable, out ProviderId provider)
+    {
+        provider = executable switch
+        {
+            "claude" => ProviderId.Claude,
+            "codex" => ProviderId.Codex,
+            "cursor-agent" => ProviderId.Cursor,
+            "opencode" => ProviderId.OpenCode,
+            "cline" => ProviderId.Cline,
+            "kimi" => ProviderId.Kimi,
+            "agy" => ProviderId.Antigravity,
+            "grok" => ProviderId.Grok,
+            "zcode" => ProviderId.Zai,
+            "copilot" or "github-copilot" => ProviderId.Copilot,
+            _ => default,
+        };
+        return executable is "claude" or "codex" or "cursor-agent" or "opencode" or "cline" or
+            "kimi" or "agy" or "grok" or "zcode" or "copilot" or "github-copilot";
+    }
+
+    private static bool ContainsPackage(string commandLine, params string[] markers)
+        => markers.Any(marker => commandLine.Contains(marker, StringComparison.Ordinal));
+
+    internal static ProviderId? DetectTerminalProviderForTesting(string executable, string commandLine)
+        => TryGetTerminalProvider(executable, commandLine, out var provider) ? provider : null;
 
     private static IReadOnlyDictionary<ProviderId, int> MergeLiveProviders(
         IReadOnlyDictionary<ProviderId, int> desktopApps,

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -390,7 +390,7 @@ internal sealed class AgentActivityScanner
                 : info.State == TranscriptState.Waiting
                     ? AgentActivityStatus.Waiting
                     : fresh ? AgentActivityStatus.Working : AgentActivityStatus.Idle;
-            var title = FirstNonEmpty(SummarizeTitle(info.Prompt) ?? "", "Antigravity");
+            var title = FirstNonEmpty(info.ConversationTitle, SummarizeTitle(info.Prompt) ?? "", "Antigravity");
             var step = status == AgentActivityStatus.Completed
                 ? "Completed"
                 : status == AgentActivityStatus.Failed
@@ -459,6 +459,7 @@ internal sealed class AgentActivityScanner
         var prompt = "";
         var step = "";
         var summary = "";
+        var conversationTitle = "";
         var model = "";
         var state = TranscriptState.Unknown;
         var hasConversation = false;
@@ -498,6 +499,13 @@ internal sealed class AgentActivityScanner
 
                 switch (type.ToUpperInvariant())
                 {
+                    case "CHECKPOINT":
+                        var checkpoint = FirstString(root, "content");
+                        var checkpointTitle = ExtractAntigravityConversationTitle(checkpoint);
+                        if (checkpointTitle.Length > 0)
+                            conversationTitle = checkpointTitle;
+                        break;
+
                     case "USER_INPUT":
                         var content = root.TryGetProperty("content", out var contentNode)
                             ? ExtractAntigravityGuiContent(contentNode)
@@ -595,8 +603,19 @@ internal sealed class AgentActivityScanner
             catch (JsonException) { }
         }
 
-        return new AntigravityGuiTranscriptInfo(prompt, step, summary, model, started, activity,
+        return new AntigravityGuiTranscriptInfo(prompt, step, summary, conversationTitle, model, started, activity,
             state, hasConversation, subagents);
+    }
+
+    private static string ExtractAntigravityConversationTitle(string content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return "";
+
+        var match = Regex.Match(content,
+            @"^\s*#\s*USER\s+OBJECTIVE\s*:\s*(?<title>[^\r\n]+)",
+            RegexOptions.IgnoreCase | RegexOptions.Multiline);
+        return match.Success ? Clean(match.Groups["title"].Value) : "";
     }
 
     internal static AgentActivityScanner.TranscriptState ParseAntigravityGuiStateForTesting(string text)
@@ -2083,7 +2102,7 @@ internal sealed class AgentActivityScanner
             { Payload, RenderInfo, TaskDetails, Metadata, ErrorDetails, Permissions };
     }
     private sealed record AntigravityGuiTranscriptInfo(
-        string Prompt, string Step, string Summary, string Model,
+        string Prompt, string Step, string Summary, string ConversationTitle, string Model,
         DateTimeOffset? StartedAt, DateTimeOffset? LastActivity,
         TranscriptState State, bool HasConversation, int SubagentCount);
 }

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityService.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,14 +16,19 @@ public sealed class AgentActivityService
 {
     public static AgentActivityService Instance { get; } = new();
 
+    internal static readonly TimeSpan CompletedRetention = TimeSpan.FromMinutes(10);
+    private const int MaxRetainedItems = 100;
+
     private readonly object _gate = new();
     private readonly Dictionary<string, AgentActivityItem> _items = new(StringComparer.Ordinal);
     private readonly HashSet<string> _acknowledged = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _scannedIds = new(StringComparer.Ordinal);
     // A run is the set of threads that were alive together. Completed members stay here until the
     // remaining members finish, allowing the taskbar to advance through concurrent project agents.
     private readonly HashSet<string> _runIds = new(StringComparer.Ordinal);
     private readonly AgentActivityScanner _scanner = new();
     private int _refreshInProgress;
+    private int _generation;
 
     public event Action<AgentActivitySnapshot>? Changed;
 
@@ -34,8 +38,8 @@ public sealed class AgentActivityService
         // than queuing stale scans behind it.
         if (Interlocked.Exchange(ref _refreshInProgress, 1) != 0)
             return;
+        var generation = Volatile.Read(ref _generation);
 
-        Log.Information("[activity] refresh started");
         try
         {
             IReadOnlyList<AgentActivityItem> scanned;
@@ -43,39 +47,79 @@ public sealed class AgentActivityService
             {
                 scanned = await Task.Run(() => _scanner.Scan()).ConfigureAwait(false);
             }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (Exception ex)
             {
                 Log.Warning(ex, "[activity] transcript scan failed");
                 return;
             }
 
-            lock (_gate)
-            {
-                bool trackedRunIsLive = _runIds.Any(id => _items.TryGetValue(id, out var existing) && existing.IsLive);
-                var scannedLive = scanned.Where(item => item.IsLive).Select(item => item.Id).ToArray();
-                if (scannedLive.Length > 0 && !trackedRunIsLive && _runIds.Count > 0)
-                    _runIds.Clear();
-                foreach (var id in scannedLive)
-                    _runIds.Add(id);
-
-                foreach (var key in _items.Keys.Where(key => key.StartsWith("presence:", StringComparison.Ordinal)).ToArray())
-                    if (scanned.Any(item => item.IsLive && _items[key].Provider == item.Provider))
-                        _items.Remove(key);
-
-                foreach (var item in scanned)
-                {
-                    if (item.IsLive)
-                        _acknowledged.Remove(item.Id);
-                    _items[item.Id] = item;
-                }
-                Log.Information($"[activity] transcript scan: {scanned.Count} session(s), live={scanned.Count(item => item.IsLive)}");
-                Publish();
-            }
+            if (generation == Volatile.Read(ref _generation))
+                ApplyScan(scanned);
         }
         finally
         {
             Interlocked.Exchange(ref _refreshInProgress, 0);
         }
+    }
+
+    internal void ApplyScan(IReadOnlyList<AgentActivityItem> scanned)
+    {
+        AgentActivitySnapshot? snapshot = null;
+        Action<AgentActivitySnapshot>? handlers = null;
+        lock (_gate)
+        {
+            var before = BuildSnapshot();
+            var nextScannedIds = scanned.Select(item => item.Id).ToHashSet(StringComparer.Ordinal);
+
+            // Scanner-owned rows are a point-in-time view. If a transcript disappears, ages out, or can
+            // no longer be correlated with a process, retaining its previous live state is incorrect.
+            foreach (var missingId in _scannedIds.Where(id => !nextScannedIds.Contains(id)).ToArray())
+            {
+                _items.Remove(missingId);
+                _acknowledged.Remove(missingId);
+                _runIds.Remove(missingId);
+            }
+
+            _scannedIds.Clear();
+            foreach (var id in nextScannedIds)
+                _scannedIds.Add(id);
+
+            bool trackedRunIsLive = _runIds.Any(id => _items.TryGetValue(id, out var existing) && existing.IsLive);
+            var scannedLive = scanned.Where(item => item.IsLive).Select(item => item.Id).ToArray();
+            if (scannedLive.Length > 0 && !trackedRunIsLive && _runIds.Count > 0)
+                _runIds.Clear();
+            foreach (var id in scannedLive)
+                _runIds.Add(id);
+
+            foreach (var key in _items.Keys.Where(key => key.StartsWith("presence:", StringComparison.Ordinal)).ToArray())
+                if (scanned.Any(item => item.IsLive && _items[key].Provider == item.Provider))
+                    RemoveItem(key);
+
+            var completionCutoff = DateTimeOffset.Now - CompletedRetention;
+            foreach (var item in scanned)
+            {
+                if (item.IsLive)
+                    _acknowledged.Remove(item.Id);
+                if (item.IsLive || item.UpdatedAt >= completionCutoff)
+                    _items[item.Id] = item;
+                else
+                    _items.Remove(item.Id);
+            }
+
+            Prune(completionCutoff);
+            var after = BuildSnapshot();
+            if (!SnapshotsEqual(before, after))
+            {
+                snapshot = after;
+                handlers = Changed;
+            }
+        }
+
+        Publish(handlers, snapshot);
     }
 
     public AgentActivitySnapshot Snapshot
@@ -93,6 +137,8 @@ public sealed class AgentActivityService
             return;
 
         string key = $"presence:{id}";
+        AgentActivitySnapshot snapshot;
+        Action<AgentActivitySnapshot>? handlers;
         lock (_gate)
         {
             if (isPresent)
@@ -118,13 +164,17 @@ public sealed class AgentActivityService
                 };
             }
 
-            Publish();
+            snapshot = BuildSnapshot();
+            handlers = Changed;
         }
+        Publish(handlers, snapshot);
     }
 
     public void Report(string id, ProviderId provider, string title, string step,
         AgentActivityStatus status, DateTimeOffset? startedAt = null, int subagentCount = 0, string? detail = null)
     {
+        AgentActivitySnapshot snapshot;
+        Action<AgentActivitySnapshot>? handlers;
         lock (_gate)
         {
             var now = DateTimeOffset.Now;
@@ -132,28 +182,59 @@ public sealed class AgentActivityService
                 id, provider, title, step, status, startedAt ?? now, now, subagentCount, detail);
             if (status is AgentActivityStatus.Working or AgentActivityStatus.Waiting)
                 _acknowledged.Remove(id);
-            Publish();
+            Prune(DateTimeOffset.Now - CompletedRetention);
+            snapshot = BuildSnapshot();
+            handlers = Changed;
         }
+        Publish(handlers, snapshot);
     }
 
     public void Acknowledge(string id)
     {
+        AgentActivitySnapshot snapshot;
+        Action<AgentActivitySnapshot>? handlers;
         lock (_gate)
         {
             _acknowledged.Add(id);
-            Publish();
+            _runIds.Remove(id);
+            snapshot = BuildSnapshot();
+            handlers = Changed;
         }
+        Publish(handlers, snapshot);
     }
 
     public void AcknowledgeAll()
     {
+        AgentActivitySnapshot snapshot;
+        Action<AgentActivitySnapshot>? handlers;
         lock (_gate)
         {
             foreach (var item in _items.Values)
                 if (!item.IsLive)
                     _acknowledged.Add(item.Id);
-            Publish();
+            _runIds.RemoveWhere(id => _acknowledged.Contains(id));
+            snapshot = BuildSnapshot();
+            handlers = Changed;
         }
+        Publish(handlers, snapshot);
+    }
+
+    public void Clear()
+    {
+        Interlocked.Increment(ref _generation);
+        _scanner.ClearCache();
+        AgentActivitySnapshot snapshot;
+        Action<AgentActivitySnapshot>? handlers;
+        lock (_gate)
+        {
+            _items.Clear();
+            _acknowledged.Clear();
+            _scannedIds.Clear();
+            _runIds.Clear();
+            snapshot = BuildSnapshot();
+            handlers = Changed;
+        }
+        Publish(handlers, snapshot);
     }
 
     private AgentActivitySnapshot BuildSnapshot()
@@ -170,7 +251,47 @@ public sealed class AgentActivityService
         return new AgentActivitySnapshot(items, runItems);
     }
 
-    private void Publish() => Changed?.Invoke(BuildSnapshot());
+    private void Prune(DateTimeOffset completionCutoff)
+    {
+        foreach (var id in _items.Values
+                     .Where(item => !item.IsLive && item.UpdatedAt < completionCutoff)
+                     .Select(item => item.Id)
+                     .ToArray())
+            RemoveItem(id);
+
+        foreach (var id in _items.Values
+                     .OrderByDescending(item => item.IsLive)
+                     .ThenByDescending(item => item.UpdatedAt)
+                     .Skip(MaxRetainedItems)
+                     .Select(item => item.Id)
+                     .ToArray())
+            RemoveItem(id);
+
+        _acknowledged.RemoveWhere(id => !_items.ContainsKey(id) && !_scannedIds.Contains(id));
+        _runIds.RemoveWhere(id => !_items.ContainsKey(id));
+    }
+
+    private void RemoveItem(string id)
+    {
+        _items.Remove(id);
+        _runIds.Remove(id);
+    }
+
+    private static bool SnapshotsEqual(AgentActivitySnapshot left, AgentActivitySnapshot right)
+        => left.Items.SequenceEqual(right.Items)
+            && left.TrackedItems.SequenceEqual(right.TrackedItems);
+
+    private static void Publish(Action<AgentActivitySnapshot>? handlers, AgentActivitySnapshot? snapshot)
+    {
+        if (handlers is null || snapshot is null)
+            return;
+
+        foreach (Action<AgentActivitySnapshot> handler in handlers.GetInvocationList())
+        {
+            try { handler(snapshot); }
+            catch (Exception ex) { Log.Warning(ex, "[activity] subscriber failed"); }
+        }
+    }
 
     private static string DisplayName(ProviderId provider) => provider switch
     {

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityService.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityService.cs
@@ -32,7 +32,7 @@ public sealed class AgentActivityService
 
     public event Action<AgentActivitySnapshot>? Changed;
 
-    public async Task RefreshFromTranscriptsAsync()
+    public async Task RefreshFromTranscriptsAsync(CancellationToken cancellationToken = default)
     {
         // WMI/process inspection can occasionally outlive a tick; keep the newest completed scan rather
         // than queuing stale scans behind it.
@@ -45,7 +45,8 @@ public sealed class AgentActivityService
             IReadOnlyList<AgentActivityItem> scanned;
             try
             {
-                scanned = await Task.Run(() => _scanner.Scan()).ConfigureAwait(false);
+                scanned = await Task.Run(() => _scanner.Scan(cancellationToken), cancellationToken)
+                    .ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityService.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityService.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using TaskbarQuota.Diagnostics;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.AgentActivity;
+
+/// <summary>
+/// Shared activity state for the taskbar summary and flyout. Provider adapters can report exact steps
+/// through Report; the current presence bridge provides a useful fallback until transcript adapters exist.
+/// </summary>
+public sealed class AgentActivityService
+{
+    public static AgentActivityService Instance { get; } = new();
+
+    private readonly object _gate = new();
+    private readonly Dictionary<string, AgentActivityItem> _items = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _acknowledged = new(StringComparer.Ordinal);
+    // A run is the set of threads that were alive together. Completed members stay here until the
+    // remaining members finish, allowing the taskbar to advance through concurrent project agents.
+    private readonly HashSet<string> _runIds = new(StringComparer.Ordinal);
+    private readonly AgentActivityScanner _scanner = new();
+    private int _refreshInProgress;
+
+    public event Action<AgentActivitySnapshot>? Changed;
+
+    public async Task RefreshFromTranscriptsAsync()
+    {
+        // WMI/process inspection can occasionally outlive a tick; keep the newest completed scan rather
+        // than queuing stale scans behind it.
+        if (Interlocked.Exchange(ref _refreshInProgress, 1) != 0)
+            return;
+
+        Log.Information("[activity] refresh started");
+        try
+        {
+            IReadOnlyList<AgentActivityItem> scanned;
+            try
+            {
+                scanned = await Task.Run(() => _scanner.Scan()).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                Log.Warning(ex, "[activity] transcript scan failed");
+                return;
+            }
+
+            lock (_gate)
+            {
+                bool trackedRunIsLive = _runIds.Any(id => _items.TryGetValue(id, out var existing) && existing.IsLive);
+                var scannedLive = scanned.Where(item => item.IsLive).Select(item => item.Id).ToArray();
+                if (scannedLive.Length > 0 && !trackedRunIsLive && _runIds.Count > 0)
+                    _runIds.Clear();
+                foreach (var id in scannedLive)
+                    _runIds.Add(id);
+
+                foreach (var key in _items.Keys.Where(key => key.StartsWith("presence:", StringComparison.Ordinal)).ToArray())
+                    if (scanned.Any(item => item.IsLive && _items[key].Provider == item.Provider))
+                        _items.Remove(key);
+
+                foreach (var item in scanned)
+                {
+                    if (item.IsLive)
+                        _acknowledged.Remove(item.Id);
+                    _items[item.Id] = item;
+                }
+                Log.Information($"[activity] transcript scan: {scanned.Count} session(s), live={scanned.Count(item => item.IsLive)}");
+                Publish();
+            }
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _refreshInProgress, 0);
+        }
+    }
+
+    public AgentActivitySnapshot Snapshot
+    {
+        get
+        {
+            lock (_gate)
+                return BuildSnapshot();
+        }
+    }
+
+    public void SyncPresence(ProviderId? provider, bool isPresent)
+    {
+        if (provider is not { } id)
+            return;
+
+        string key = $"presence:{id}";
+        lock (_gate)
+        {
+            if (isPresent)
+            {
+                if (_items.TryGetValue(key, out var existing) && existing.IsLive)
+                {
+                    _items[key] = existing with { UpdatedAt = DateTimeOffset.Now };
+                }
+                else
+                {
+                    _items[key] = new AgentActivityItem(
+                        key, id, DisplayName(id), "Working", AgentActivityStatus.Working,
+                        DateTimeOffset.Now, DateTimeOffset.Now);
+                }
+            }
+            else if (_items.TryGetValue(key, out var previous) && previous.IsLive)
+            {
+                _items[key] = previous with
+                {
+                    Step = "Finished",
+                    Status = AgentActivityStatus.Completed,
+                    UpdatedAt = DateTimeOffset.Now,
+                };
+            }
+
+            Publish();
+        }
+    }
+
+    public void Report(string id, ProviderId provider, string title, string step,
+        AgentActivityStatus status, DateTimeOffset? startedAt = null, int subagentCount = 0, string? detail = null)
+    {
+        lock (_gate)
+        {
+            var now = DateTimeOffset.Now;
+            _items[id] = new AgentActivityItem(
+                id, provider, title, step, status, startedAt ?? now, now, subagentCount, detail);
+            if (status is AgentActivityStatus.Working or AgentActivityStatus.Waiting)
+                _acknowledged.Remove(id);
+            Publish();
+        }
+    }
+
+    public void Acknowledge(string id)
+    {
+        lock (_gate)
+        {
+            _acknowledged.Add(id);
+            Publish();
+        }
+    }
+
+    public void AcknowledgeAll()
+    {
+        lock (_gate)
+        {
+            foreach (var item in _items.Values)
+                if (!item.IsLive)
+                    _acknowledged.Add(item.Id);
+            Publish();
+        }
+    }
+
+    private AgentActivitySnapshot BuildSnapshot()
+    {
+        var items = _items.Values
+            .Where(item => item.IsLive || !_acknowledged.Contains(item.Id))
+            .OrderByDescending(item => item.IsLive)
+            .ThenByDescending(item => item.UpdatedAt)
+            .ToArray();
+        var runItems = items
+            .Where(item => _runIds.Contains(item.Id))
+            .OrderBy(item => item.StartedAt)
+            .ToArray();
+        return new AgentActivitySnapshot(items, runItems);
+    }
+
+    private void Publish() => Changed?.Invoke(BuildSnapshot());
+
+    private static string DisplayName(ProviderId provider) => provider switch
+    {
+        ProviderId.ClinePass => "Cline Pass",
+        ProviderId.OpenCodeGo => "OpenCode Go",
+        _ => provider.ToString(),
+    };
+}

--- a/src/TaskbarQuota.App/AgentActivity/CodexThreadNameResolver.cs
+++ b/src/TaskbarQuota.App/AgentActivity/CodexThreadNameResolver.cs
@@ -9,10 +9,15 @@ namespace TaskbarQuota.AgentActivity;
 internal sealed class CodexThreadNameResolver
 {
     private static readonly TimeSpan CacheLifetime = TimeSpan.FromSeconds(10);
-    private readonly string _indexPath = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".codex", "session_index.jsonl");
+    private readonly string _indexPath;
     private readonly Dictionary<string, string> _names = new(StringComparer.OrdinalIgnoreCase);
     private DateTimeOffset _loadedAt = DateTimeOffset.MinValue;
+
+    public CodexThreadNameResolver(string? indexPath = null)
+    {
+        _indexPath = indexPath ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".codex", "session_index.jsonl");
+    }
 
     public string? GetName(string? threadId)
     {
@@ -29,28 +34,44 @@ internal sealed class CodexThreadNameResolver
             return;
 
         _loadedAt = DateTimeOffset.Now;
-        _names.Clear();
         if (!File.Exists(_indexPath))
+        {
+            _names.Clear();
             return;
+        }
 
         try
         {
+            var refreshed = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (var line in File.ReadLines(_indexPath))
             {
                 if (string.IsNullOrWhiteSpace(line))
                     continue;
-                using var entry = JsonDocument.Parse(line);
-                var root = entry.RootElement;
-                if (!root.TryGetProperty("id", out var id) || !root.TryGetProperty("thread_name", out var name))
-                    continue;
-                var idValue = id.GetString();
-                var nameValue = name.GetString()?.Trim();
-                if (!string.IsNullOrWhiteSpace(idValue) && !string.IsNullOrWhiteSpace(nameValue))
-                    _names[idValue] = nameValue;
+                try
+                {
+                    using var entry = JsonDocument.Parse(line);
+                    var root = entry.RootElement;
+                    if (!root.TryGetProperty("id", out var id)
+                        || id.ValueKind != JsonValueKind.String
+                        || !root.TryGetProperty("thread_name", out var name)
+                        || name.ValueKind != JsonValueKind.String)
+                        continue;
+                    var idValue = id.GetString();
+                    var nameValue = name.GetString()?.Trim();
+                    if (!string.IsNullOrWhiteSpace(idValue) && !string.IsNullOrWhiteSpace(nameValue))
+                        refreshed[idValue] = nameValue;
+                }
+                catch (JsonException)
+                {
+                    // session_index.jsonl is append-only; the last line may be incomplete while Codex writes it.
+                }
             }
+
+            _names.Clear();
+            foreach (var (id, name) in refreshed)
+                _names[id] = name;
         }
         catch (IOException) { }
         catch (UnauthorizedAccessException) { }
-        catch (JsonException) { }
     }
 }

--- a/src/TaskbarQuota.App/AgentActivity/CodexThreadNameResolver.cs
+++ b/src/TaskbarQuota.App/AgentActivity/CodexThreadNameResolver.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace TaskbarQuota.AgentActivity;
+
+/// <summary>Reads Codex's own persisted thread names from its append-only session index.</summary>
+internal sealed class CodexThreadNameResolver
+{
+    private static readonly TimeSpan CacheLifetime = TimeSpan.FromSeconds(10);
+    private readonly string _indexPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".codex", "session_index.jsonl");
+    private readonly Dictionary<string, string> _names = new(StringComparer.OrdinalIgnoreCase);
+    private DateTimeOffset _loadedAt = DateTimeOffset.MinValue;
+
+    public string? GetName(string? threadId)
+    {
+        if (string.IsNullOrWhiteSpace(threadId))
+            return null;
+
+        RefreshIfNeeded();
+        return _names.TryGetValue(threadId, out var name) ? name : null;
+    }
+
+    private void RefreshIfNeeded()
+    {
+        if (DateTimeOffset.Now - _loadedAt < CacheLifetime)
+            return;
+
+        _loadedAt = DateTimeOffset.Now;
+        _names.Clear();
+        if (!File.Exists(_indexPath))
+            return;
+
+        try
+        {
+            foreach (var line in File.ReadLines(_indexPath))
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
+                using var entry = JsonDocument.Parse(line);
+                var root = entry.RootElement;
+                if (!root.TryGetProperty("id", out var id) || !root.TryGetProperty("thread_name", out var name))
+                    continue;
+                var idValue = id.GetString();
+                var nameValue = name.GetString()?.Trim();
+                if (!string.IsNullOrWhiteSpace(idValue) && !string.IsNullOrWhiteSpace(nameValue))
+                    _names[idValue] = nameValue;
+            }
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+        catch (JsonException) { }
+    }
+}

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
@@ -4,66 +4,77 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:TaskbarQuota.Controls">
-    <Grid x:Name="Root" Width="400" Padding="8,3" Background="Transparent" ColumnSpacing="8">
+    <Grid x:Name="Root" Width="400" Padding="4" Background="Transparent" ColumnSpacing="4">
         <Grid.RenderTransform>
             <CompositeTransform x:Name="RootTransform" />
         </Grid.RenderTransform>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="22"/>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
-        <Grid x:Name="AgentNavigator" Grid.Column="0" RowSpacing="0"
-              VerticalAlignment="Center" HorizontalAlignment="Center">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="12"/>
-                <RowDefinition Height="12"/>
-                <RowDefinition Height="12"/>
-            </Grid.RowDefinitions>
-            <Button x:Name="PreviousButton" Grid.Row="0" Width="20" Height="12"
-                    Padding="0" BorderThickness="0" Background="Transparent"
-                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                    Click="PreviousButton_Click" PointerPressed="NavigationButton_PointerPressed"
-                    Tapped="NavigationButton_Tapped"
-                    AutomationProperties.Name="Previous agent">
-                <FontIcon Glyph="&#xE70E;" FontSize="8"/>
+        <StackPanel x:Name="AgentNavigator"
+                    Grid.Column="0"
+                    Orientation="Horizontal"
+                    VerticalAlignment="Center">
+            <Button x:Name="PreviousButton"
+                    AutomationProperties.Name="Previous agent"
+                    AutomationProperties.AutomationId="AgentActivityPreviousButton"
+                    Width="40"
+                    Height="40"
+                    Click="PreviousButton_Click">
+                <FontIcon Glyph="&#xE76B;" FontSize="12"/>
             </Button>
-            <TextBlock x:Name="AgentPositionText" Grid.Row="1" FontSize="9"
-                       TextAlignment="Center" HorizontalAlignment="Center"
-                       VerticalAlignment="Center"/>
-            <Button x:Name="NextButton" Grid.Row="2" Width="20" Height="12"
-                    Padding="0" BorderThickness="0" Background="Transparent"
-                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                    Click="NextButton_Click" PointerPressed="NavigationButton_PointerPressed"
-                    Tapped="NavigationButton_Tapped"
-                    AutomationProperties.Name="Next agent">
-                <FontIcon Glyph="&#xE70D;" FontSize="8"/>
+            <TextBlock x:Name="AgentPositionText"
+                       MinWidth="28"
+                       TextAlignment="Center"
+                       VerticalAlignment="Center"
+                       Style="{StaticResource CaptionTextBlockStyle}"/>
+            <Button x:Name="NextButton"
+                    AutomationProperties.Name="Next agent"
+                    AutomationProperties.AutomationId="AgentActivityNextButton"
+                    Width="40"
+                    Height="40"
+                    Click="NextButton_Click">
+                <FontIcon Glyph="&#xE76C;" FontSize="12"/>
             </Button>
-        </Grid>
+        </StackPanel>
 
-        <controls:ProviderAvatar x:Name="ProviderIcon"
-                                 Grid.Column="1"
-                                 Width="30"
-                                 Height="30"
-                                 VerticalAlignment="Center"
-                                 ForegroundBrush="{ThemeResource TextFillColorPrimaryBrush}"
-                                 AutomationProperties.Name="Activity provider"/>
-
-        <!-- A StackPanel measures its children at their full desired width, which
-             prevents TextTrimming from engaging for long task/tool descriptions. -->
-        <Grid Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Stretch"
-              MinWidth="0" RowSpacing="0">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-            <TextBlock x:Name="TitleText" Grid.Row="0" HorizontalAlignment="Stretch"
-                       FontSize="12" FontWeight="SemiBold" TextWrapping="NoWrap"
-                       TextTrimming="CharacterEllipsis"/>
-            <TextBlock x:Name="StepText" Grid.Row="1" HorizontalAlignment="Stretch"
-                       FontSize="11" Opacity="0.72" TextWrapping="NoWrap"
-                       TextTrimming="CharacterEllipsis"/>
-        </Grid>
+        <Button x:Name="OpenActivityButton"
+                Grid.Column="1"
+                AutomationProperties.Name="Open agent activity"
+                AutomationProperties.AutomationId="AgentActivityOpenButton"
+                AutomationProperties.LiveSetting="Polite"
+                HorizontalAlignment="Stretch"
+                HorizontalContentAlignment="Stretch"
+                Click="OpenActivityButton_Click">
+            <Grid ColumnSpacing="8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <controls:ProviderAvatar x:Name="ProviderIcon"
+                                         Width="30"
+                                         Height="30"
+                                         VerticalAlignment="Center"
+                                         ForegroundBrush="{ThemeResource TextFillColorPrimaryBrush}"
+                                         AutomationProperties.Name="Activity provider"/>
+                <Grid Grid.Column="1" MinWidth="0" VerticalAlignment="Center">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock x:Name="TitleText"
+                               HorizontalAlignment="Stretch"
+                               TextTrimming="CharacterEllipsis"
+                               Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                    <TextBlock x:Name="StepText"
+                               Grid.Row="1"
+                               HorizontalAlignment="Stretch"
+                               TextTrimming="CharacterEllipsis"
+                               Style="{StaticResource CaptionTextBlockStyle}"/>
+                </Grid>
+            </Grid>
+        </Button>
     </Grid>
 </UserControl>

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
@@ -42,8 +42,8 @@
 
         <controls:ProviderAvatar x:Name="ProviderIcon"
                                  Grid.Column="1"
-                                 Width="24"
-                                 Height="24"
+                                 Width="30"
+                                 Height="30"
                                  VerticalAlignment="Center"
                                  ForegroundBrush="{ThemeResource TextFillColorPrimaryBrush}"
                                  AutomationProperties.Name="Activity provider"/>

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
@@ -13,17 +13,47 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
-        <controls:ProviderAvatar x:Name="ProviderIcon"
-                                 Grid.Column="0"
-                                 Width="24"
-                                 Height="24"
-                                 VerticalAlignment="Center"
-                                 ForegroundBrush="{ThemeResource TextFillColorPrimaryBrush}"
-                                 AutomationProperties.Name="Activity provider"/>
+        <Grid x:Name="ProviderMarker"
+              Grid.Column="0"
+              Width="28"
+              Height="28"
+              VerticalAlignment="Center">
+            <controls:ProviderAvatar x:Name="ProviderIcon"
+                                     Width="24"
+                                     Height="24"
+                                     VerticalAlignment="Center"
+                                     HorizontalAlignment="Center"
+                                     ForegroundBrush="{ThemeResource TextFillColorPrimaryBrush}"
+                                     AutomationProperties.Name="Activity provider"/>
+            <Border x:Name="AgentCountBadge"
+                    Width="15"
+                    Height="15"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    Margin="0,-1,-2,0"
+                    Background="{ThemeResource AccentFillColorDefaultBrush}"
+                    CornerRadius="8"
+                    Visibility="Collapsed">
+                <TextBlock x:Name="AgentCountText"
+                           FontSize="9"
+                           FontWeight="SemiBold"
+                           TextAlignment="Center"
+                           VerticalAlignment="Center"
+                           Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"/>
+            </Border>
+        </Grid>
 
         <StackPanel Grid.Column="1" VerticalAlignment="Center">
-            <TextBlock x:Name="TitleText" FontSize="12" FontWeight="SemiBold"
-                       TextTrimming="CharacterEllipsis"/>
+            <Grid ColumnSpacing="8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock x:Name="TitleText" Grid.Column="0" FontSize="12" FontWeight="SemiBold"
+                           TextTrimming="CharacterEllipsis"/>
+                <TextBlock x:Name="AgentStatusText" Grid.Column="1" FontSize="10" Opacity="0.72"
+                           TextTrimming="CharacterEllipsis" HorizontalAlignment="Right"/>
+            </Grid>
             <TextBlock x:Name="StepText" FontSize="11" Opacity="0.72"
                        TextTrimming="CharacterEllipsis"/>
         </StackPanel>

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
@@ -24,13 +24,13 @@
         <StackPanel Grid.Column="1" VerticalAlignment="Center">
             <Grid ColumnSpacing="8">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock x:Name="TitleText" Grid.Column="0" FontSize="12" FontWeight="SemiBold"
+                <TextBlock x:Name="AgentStatusText" Grid.Column="0" FontSize="10" Opacity="0.72"
+                           TextTrimming="CharacterEllipsis" VerticalAlignment="Center"/>
+                <TextBlock x:Name="TitleText" Grid.Column="1" FontSize="12" FontWeight="SemiBold"
                            TextTrimming="CharacterEllipsis"/>
-                <TextBlock x:Name="AgentStatusText" Grid.Column="1" FontSize="10" Opacity="0.72"
-                           TextTrimming="CharacterEllipsis" HorizontalAlignment="Right"/>
             </Grid>
             <TextBlock x:Name="StepText" FontSize="11" Opacity="0.72"
                        TextTrimming="CharacterEllipsis"/>

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
@@ -76,6 +76,9 @@
                 AutomationProperties.AutomationId="AgentActivityOpenButton"
                 AutomationProperties.LiveSetting="Polite"
                 Click="OpenActivityButton_Click">
+            <Button.Resources>
+                <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="Transparent" />
+            </Button.Resources>
             <Grid VerticalAlignment="Center" HorizontalAlignment="Stretch"
                   MinWidth="0" RowSpacing="0">
                 <Grid.RowDefinitions>

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
@@ -48,11 +48,20 @@
                                  ForegroundBrush="{ThemeResource TextFillColorPrimaryBrush}"
                                  AutomationProperties.Name="Activity provider"/>
 
-        <StackPanel Grid.Column="2" VerticalAlignment="Center">
-            <TextBlock x:Name="TitleText" FontSize="12" FontWeight="SemiBold"
+        <!-- A StackPanel measures its children at their full desired width, which
+             prevents TextTrimming from engaging for long task/tool descriptions. -->
+        <Grid Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Stretch"
+              MinWidth="0" RowSpacing="0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <TextBlock x:Name="TitleText" Grid.Row="0" HorizontalAlignment="Stretch"
+                       FontSize="12" FontWeight="SemiBold" TextWrapping="NoWrap"
                        TextTrimming="CharacterEllipsis"/>
-            <TextBlock x:Name="StepText" FontSize="11" Opacity="0.72"
+            <TextBlock x:Name="StepText" Grid.Row="1" HorizontalAlignment="Stretch"
+                       FontSize="11" Opacity="0.72" TextWrapping="NoWrap"
                        TextTrimming="CharacterEllipsis"/>
-        </StackPanel>
+        </Grid>
     </Grid>
 </UserControl>

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
@@ -9,66 +9,50 @@
             <CompositeTransform x:Name="RootTransform" />
         </Grid.RenderTransform>
         <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="22"/>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
+        <Grid x:Name="AgentNavigator" Grid.Column="0" RowSpacing="0"
+              VerticalAlignment="Center" HorizontalAlignment="Center">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="12"/>
+                <RowDefinition Height="12"/>
+                <RowDefinition Height="12"/>
+            </Grid.RowDefinitions>
+            <Button x:Name="PreviousButton" Grid.Row="0" Width="20" Height="12"
+                    Padding="0" BorderThickness="0" Background="Transparent"
+                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                    Click="PreviousButton_Click" PointerPressed="NavigationButton_PointerPressed"
+                    AutomationProperties.Name="Previous agent">
+                <FontIcon Glyph="&#xE70E;" FontSize="8"/>
+            </Button>
+            <TextBlock x:Name="AgentPositionText" Grid.Row="1" FontSize="9"
+                       TextAlignment="Center" HorizontalAlignment="Center"
+                       VerticalAlignment="Center"/>
+            <Button x:Name="NextButton" Grid.Row="2" Width="20" Height="12"
+                    Padding="0" BorderThickness="0" Background="Transparent"
+                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                    Click="NextButton_Click" PointerPressed="NavigationButton_PointerPressed"
+                    AutomationProperties.Name="Next agent">
+                <FontIcon Glyph="&#xE70D;" FontSize="8"/>
+            </Button>
+        </Grid>
+
         <controls:ProviderAvatar x:Name="ProviderIcon"
-                                 Grid.Column="0"
+                                 Grid.Column="1"
                                  Width="24"
                                  Height="24"
                                  VerticalAlignment="Center"
                                  ForegroundBrush="{ThemeResource TextFillColorPrimaryBrush}"
                                  AutomationProperties.Name="Activity provider"/>
 
-        <Grid Grid.Column="1" ColumnSpacing="6" VerticalAlignment="Center">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="22"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-
-            <Grid x:Name="AgentNavigator" Grid.Column="0" RowSpacing="0"
-                  VerticalAlignment="Center" HorizontalAlignment="Center">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="12"/>
-                    <RowDefinition Height="12"/>
-                    <RowDefinition Height="12"/>
-                </Grid.RowDefinitions>
-                <Button x:Name="PreviousButton" Grid.Row="0" Width="20" Height="12"
-                        Padding="0" BorderThickness="0" Background="Transparent"
-                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                        Click="PreviousButton_Click" PointerPressed="NavigationButton_PointerPressed"
-                        AutomationProperties.Name="Previous agent">
-                    <FontIcon Glyph="&#xE70E;" FontSize="8"/>
-                </Button>
-                <TextBlock x:Name="AgentPositionText" Grid.Row="1" FontSize="9"
-                           TextAlignment="Center" HorizontalAlignment="Center"
-                           VerticalAlignment="Center"/>
-                <Button x:Name="NextButton" Grid.Row="2" Width="20" Height="12"
-                        Padding="0" BorderThickness="0" Background="Transparent"
-                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                        Click="NextButton_Click" PointerPressed="NavigationButton_PointerPressed"
-                        AutomationProperties.Name="Next agent">
-                    <FontIcon Glyph="&#xE70D;" FontSize="8"/>
-                </Button>
-            </Grid>
-
-            <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                <TextBlock x:Name="TitleText" FontSize="12" FontWeight="SemiBold"
-                           TextTrimming="CharacterEllipsis"/>
-                <Grid ColumnSpacing="8">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBlock x:Name="StepText" Grid.Column="0" FontSize="11" Opacity="0.72"
-                               TextTrimming="CharacterEllipsis"/>
-                    <TextBlock x:Name="AgentStatusText" Grid.Column="1" FontSize="10" Opacity="0.72"
-                               TextTrimming="CharacterEllipsis" TextAlignment="Right"
-                               MaxWidth="155"
-                               VerticalAlignment="Center"/>
-                </Grid>
-            </StackPanel>
-        </Grid>
+        <StackPanel Grid.Column="2" VerticalAlignment="Center">
+            <TextBlock x:Name="TitleText" FontSize="12" FontWeight="SemiBold"
+                       TextTrimming="CharacterEllipsis"/>
+            <TextBlock x:Name="StepText" FontSize="11" Opacity="0.72"
+                       TextTrimming="CharacterEllipsis"/>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
@@ -13,35 +13,13 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
-        <Grid x:Name="ProviderMarker"
-              Grid.Column="0"
-              Width="28"
-              Height="28"
-              VerticalAlignment="Center">
-            <controls:ProviderAvatar x:Name="ProviderIcon"
-                                     Width="24"
-                                     Height="24"
-                                     VerticalAlignment="Center"
-                                     HorizontalAlignment="Center"
-                                     ForegroundBrush="{ThemeResource TextFillColorPrimaryBrush}"
-                                     AutomationProperties.Name="Activity provider"/>
-            <Border x:Name="AgentCountBadge"
-                    Width="15"
-                    Height="15"
-                    HorizontalAlignment="Right"
-                    VerticalAlignment="Top"
-                    Margin="0,-1,-2,0"
-                    Background="{ThemeResource AccentFillColorDefaultBrush}"
-                    CornerRadius="8"
-                    Visibility="Collapsed">
-                <TextBlock x:Name="AgentCountText"
-                           FontSize="9"
-                           FontWeight="SemiBold"
-                           TextAlignment="Center"
-                           VerticalAlignment="Center"
-                           Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"/>
-            </Border>
-        </Grid>
+        <controls:ProviderAvatar x:Name="ProviderIcon"
+                                 Grid.Column="0"
+                                 Width="24"
+                                 Height="24"
+                                 VerticalAlignment="Center"
+                                 ForegroundBrush="{ThemeResource TextFillColorPrimaryBrush}"
+                                 AutomationProperties.Name="Activity provider"/>
 
         <StackPanel Grid.Column="1" VerticalAlignment="Center">
             <Grid ColumnSpacing="8">

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
@@ -5,6 +5,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:TaskbarQuota.Controls">
     <Grid x:Name="Root" Width="400" Padding="8,3" Background="Transparent" ColumnSpacing="8">
+        <Grid.RenderTransform>
+            <CompositeTransform x:Name="RootTransform" />
+        </Grid.RenderTransform>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="*"/>

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
@@ -21,21 +21,54 @@
                                  ForegroundBrush="{ThemeResource TextFillColorPrimaryBrush}"
                                  AutomationProperties.Name="Activity provider"/>
 
-        <StackPanel Grid.Column="1" VerticalAlignment="Center">
-            <TextBlock x:Name="TitleText" FontSize="12" FontWeight="SemiBold"
-                       TextTrimming="CharacterEllipsis"/>
-            <Grid ColumnSpacing="8">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock x:Name="StepText" Grid.Column="0" FontSize="11" Opacity="0.72"
-                           TextTrimming="CharacterEllipsis"/>
-                <TextBlock x:Name="AgentStatusText" Grid.Column="1" FontSize="10" Opacity="0.72"
-                           TextTrimming="CharacterEllipsis" TextAlignment="Right"
-                           MaxWidth="155"
+        <Grid Grid.Column="1" ColumnSpacing="6" VerticalAlignment="Center">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="22"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <Grid x:Name="AgentNavigator" Grid.Column="0" RowSpacing="0"
+                  VerticalAlignment="Center" HorizontalAlignment="Center">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="12"/>
+                    <RowDefinition Height="12"/>
+                    <RowDefinition Height="12"/>
+                </Grid.RowDefinitions>
+                <Button x:Name="PreviousButton" Grid.Row="0" Width="20" Height="12"
+                        Padding="0" BorderThickness="0" Background="Transparent"
+                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                        Click="PreviousButton_Click" PointerPressed="NavigationButton_PointerPressed"
+                        AutomationProperties.Name="Previous agent">
+                    <FontIcon Glyph="&#xE70E;" FontSize="8"/>
+                </Button>
+                <TextBlock x:Name="AgentPositionText" Grid.Row="1" FontSize="9"
+                           TextAlignment="Center" HorizontalAlignment="Center"
                            VerticalAlignment="Center"/>
+                <Button x:Name="NextButton" Grid.Row="2" Width="20" Height="12"
+                        Padding="0" BorderThickness="0" Background="Transparent"
+                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                        Click="NextButton_Click" PointerPressed="NavigationButton_PointerPressed"
+                        AutomationProperties.Name="Next agent">
+                    <FontIcon Glyph="&#xE70D;" FontSize="8"/>
+                </Button>
             </Grid>
-        </StackPanel>
+
+            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                <TextBlock x:Name="TitleText" FontSize="12" FontWeight="SemiBold"
+                           TextTrimming="CharacterEllipsis"/>
+                <Grid ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock x:Name="StepText" Grid.Column="0" FontSize="11" Opacity="0.72"
+                               TextTrimming="CharacterEllipsis"/>
+                    <TextBlock x:Name="AgentStatusText" Grid.Column="1" FontSize="10" Opacity="0.72"
+                               TextTrimming="CharacterEllipsis" TextAlignment="Right"
+                               MaxWidth="155"
+                               VerticalAlignment="Center"/>
+                </Grid>
+            </StackPanel>
+        </Grid>
     </Grid>
 </UserControl>

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
@@ -25,6 +25,7 @@
                     Padding="0" BorderThickness="0" Background="Transparent"
                     HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                     Click="PreviousButton_Click" PointerPressed="NavigationButton_PointerPressed"
+                    Tapped="NavigationButton_Tapped"
                     AutomationProperties.Name="Previous agent">
                 <FontIcon Glyph="&#xE70E;" FontSize="8"/>
             </Button>
@@ -35,6 +36,7 @@
                     Padding="0" BorderThickness="0" Background="Transparent"
                     HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                     Click="NextButton_Click" PointerPressed="NavigationButton_PointerPressed"
+                    Tapped="NavigationButton_Tapped"
                     AutomationProperties.Name="Next agent">
                 <FontIcon Glyph="&#xE70D;" FontSize="8"/>
             </Button>

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="TaskbarQuota.Controls.AgentActivitySummary"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid x:Name="Root" Width="400" Padding="8,3" Background="Transparent">
+        <StackPanel VerticalAlignment="Center">
+            <TextBlock x:Name="TitleText" FontSize="12" FontWeight="SemiBold"
+                       TextTrimming="CharacterEllipsis"/>
+            <TextBlock x:Name="StepText" FontSize="11" Opacity="0.72"
+                       TextTrimming="CharacterEllipsis"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
@@ -2,9 +2,23 @@
 <UserControl
     x:Class="TaskbarQuota.Controls.AgentActivitySummary"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Grid x:Name="Root" Width="400" Padding="8,3" Background="Transparent">
-        <StackPanel VerticalAlignment="Center">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:TaskbarQuota.Controls">
+    <Grid x:Name="Root" Width="400" Padding="8,3" Background="Transparent" ColumnSpacing="8">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <controls:ProviderAvatar x:Name="ProviderIcon"
+                                 Grid.Column="0"
+                                 Width="24"
+                                 Height="24"
+                                 VerticalAlignment="Center"
+                                 ForegroundBrush="{ThemeResource TextFillColorPrimaryBrush}"
+                                 AutomationProperties.Name="Activity provider"/>
+
+        <StackPanel Grid.Column="1" VerticalAlignment="Center">
             <TextBlock x:Name="TitleText" FontSize="12" FontWeight="SemiBold"
                        TextTrimming="CharacterEllipsis"/>
             <TextBlock x:Name="StepText" FontSize="11" Opacity="0.72"

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
@@ -4,76 +4,90 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:TaskbarQuota.Controls">
-    <Grid x:Name="Root" Width="400" Padding="4" Background="Transparent" ColumnSpacing="4">
+    <Grid x:Name="Root" Width="400" Padding="8,3" Background="Transparent" ColumnSpacing="8">
         <Grid.RenderTransform>
             <CompositeTransform x:Name="RootTransform" />
         </Grid.RenderTransform>
         <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="22"/>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
-        <StackPanel x:Name="AgentNavigator"
-                    Grid.Column="0"
-                    Orientation="Horizontal"
-                    VerticalAlignment="Center">
+        <Grid x:Name="AgentNavigator" Grid.Column="0" RowSpacing="0"
+              VerticalAlignment="Center" HorizontalAlignment="Center">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="12"/>
+                <RowDefinition Height="12"/>
+                <RowDefinition Height="12"/>
+            </Grid.RowDefinitions>
             <Button x:Name="PreviousButton"
+                    Grid.Row="0"
                     AutomationProperties.Name="Previous agent"
                     AutomationProperties.AutomationId="AgentActivityPreviousButton"
-                    Width="40"
-                    Height="40"
+                    Width="20"
+                    Height="12"
+                    Padding="0"
+                    BorderThickness="0"
+                    Background="Transparent"
+                    HorizontalContentAlignment="Center"
+                    VerticalContentAlignment="Center"
                     Click="PreviousButton_Click">
-                <FontIcon Glyph="&#xE76B;" FontSize="12"/>
+                <FontIcon Glyph="&#xE70E;" FontSize="8"/>
             </Button>
             <TextBlock x:Name="AgentPositionText"
-                       MinWidth="28"
+                       Grid.Row="1"
+                       FontSize="9"
                        TextAlignment="Center"
-                       VerticalAlignment="Center"
-                       Style="{StaticResource CaptionTextBlockStyle}"/>
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"/>
             <Button x:Name="NextButton"
+                    Grid.Row="2"
                     AutomationProperties.Name="Next agent"
                     AutomationProperties.AutomationId="AgentActivityNextButton"
-                    Width="40"
-                    Height="40"
+                    Width="20"
+                    Height="12"
+                    Padding="0"
+                    BorderThickness="0"
+                    Background="Transparent"
+                    HorizontalContentAlignment="Center"
+                    VerticalContentAlignment="Center"
                     Click="NextButton_Click">
-                <FontIcon Glyph="&#xE76C;" FontSize="12"/>
+                <FontIcon Glyph="&#xE70D;" FontSize="8"/>
             </Button>
-        </StackPanel>
+        </Grid>
+
+        <controls:ProviderAvatar x:Name="ProviderIcon"
+                Grid.Column="1"
+                Width="30"
+                Height="30"
+                VerticalAlignment="Center"
+                ForegroundBrush="{ThemeResource TextFillColorPrimaryBrush}"
+                AutomationProperties.Name="Activity provider"/>
 
         <Button x:Name="OpenActivityButton"
-                Grid.Column="1"
+                Grid.Column="2"
+                Padding="0"
+                BorderThickness="0"
+                Background="Transparent"
+                HorizontalAlignment="Stretch"
+                HorizontalContentAlignment="Stretch"
                 AutomationProperties.Name="Open agent activity"
                 AutomationProperties.AutomationId="AgentActivityOpenButton"
                 AutomationProperties.LiveSetting="Polite"
-                HorizontalAlignment="Stretch"
-                HorizontalContentAlignment="Stretch"
                 Click="OpenActivityButton_Click">
-            <Grid ColumnSpacing="8">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <controls:ProviderAvatar x:Name="ProviderIcon"
-                                         Width="30"
-                                         Height="30"
-                                         VerticalAlignment="Center"
-                                         ForegroundBrush="{ThemeResource TextFillColorPrimaryBrush}"
-                                         AutomationProperties.Name="Activity provider"/>
-                <Grid Grid.Column="1" MinWidth="0" VerticalAlignment="Center">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <TextBlock x:Name="TitleText"
-                               HorizontalAlignment="Stretch"
-                               TextTrimming="CharacterEllipsis"
-                               Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                    <TextBlock x:Name="StepText"
-                               Grid.Row="1"
-                               HorizontalAlignment="Stretch"
-                               TextTrimming="CharacterEllipsis"
-                               Style="{StaticResource CaptionTextBlockStyle}"/>
-                </Grid>
+            <Grid VerticalAlignment="Center" HorizontalAlignment="Stretch"
+                  MinWidth="0" RowSpacing="0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <TextBlock x:Name="TitleText" Grid.Row="0" HorizontalAlignment="Stretch"
+                           FontSize="12" FontWeight="SemiBold" TextWrapping="NoWrap"
+                           TextTrimming="CharacterEllipsis"/>
+                <TextBlock x:Name="StepText" Grid.Row="1" HorizontalAlignment="Stretch"
+                           FontSize="11" Opacity="0.72" TextWrapping="NoWrap"
+                           TextTrimming="CharacterEllipsis"/>
             </Grid>
         </Button>
     </Grid>

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml
@@ -22,18 +22,20 @@
                                  AutomationProperties.Name="Activity provider"/>
 
         <StackPanel Grid.Column="1" VerticalAlignment="Center">
+            <TextBlock x:Name="TitleText" FontSize="12" FontWeight="SemiBold"
+                       TextTrimming="CharacterEllipsis"/>
             <Grid ColumnSpacing="8">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock x:Name="AgentStatusText" Grid.Column="0" FontSize="10" Opacity="0.72"
-                           TextTrimming="CharacterEllipsis" VerticalAlignment="Center"/>
-                <TextBlock x:Name="TitleText" Grid.Column="1" FontSize="12" FontWeight="SemiBold"
+                <TextBlock x:Name="StepText" Grid.Column="0" FontSize="11" Opacity="0.72"
                            TextTrimming="CharacterEllipsis"/>
+                <TextBlock x:Name="AgentStatusText" Grid.Column="1" FontSize="10" Opacity="0.72"
+                           TextTrimming="CharacterEllipsis" TextAlignment="Right"
+                           MaxWidth="155"
+                           VerticalAlignment="Center"/>
             </Grid>
-            <TextBlock x:Name="StepText" FontSize="11" Opacity="0.72"
-                       TextTrimming="CharacterEllipsis"/>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
@@ -56,18 +57,18 @@ public sealed partial class AgentActivitySummary : UserControl
             item.Status,
             ProviderIcon.ForegroundBrush ?? (Brush)Application.Current.Resources["TextFillColorPrimaryBrush"]);
         ProviderIcon.ForegroundBrush = statusBrush;
-        bool hasMultipleProviders = items.Select(candidate => candidate.Provider).Distinct().Count() > 1;
-        ProviderIcon.Visibility = hasMultipleProviders || item.Provider != activeProvider
-            ? Visibility.Visible
-            : Visibility.Collapsed;
-        ToolTipService.SetToolTip(ProviderIcon, $"Agent activity from {providerName}");
-        int total = items.Count;
-        int completed = items.Count(candidate => candidate.Status == AgentActivityStatus.Completed);
-        bool showProgress = total > 1;
-        bool allDone = showProgress && completed == total;
-        TitleText.Text = allDone ? "All agent tasks" : ActivityTitle(item);
-        var state = allDone ? $"{completed} / {total} completed" : SummaryText(item);
-        StepText.Text = showProgress && !allDone ? $"{state} · {completed} / {total} completed" : state;
+        bool showProviderMarker = items.Select(candidate => candidate.Provider).Distinct().Count() > 1
+            || item.Provider != activeProvider
+            || items.Count > 1;
+        ProviderMarker.Visibility = showProviderMarker ? Visibility.Visible : Visibility.Collapsed;
+        AgentCountBadge.Visibility = items.Count > 1 ? Visibility.Visible : Visibility.Collapsed;
+        AgentCountText.Text = items.Count > 9 ? "9+" : items.Count.ToString();
+        var activitySummary = ActivitySummary(items);
+        AgentStatusText.Text = activitySummary;
+        ToolTipService.SetToolTip(ProviderMarker,
+            $"{items.Count} agents · {activitySummary}. Use the mouse wheel to switch agents.");
+        TitleText.Text = ActivityTitle(item);
+        StepText.Text = SummaryText(item);
         ToolTipService.SetToolTip(this, $"{ActivityTitle(item)}: {item.Step}");
         ApplyForeground();
     }
@@ -144,6 +145,24 @@ public sealed partial class AgentActivitySummary : UserControl
         AgentActivityStatus.Failed => "Task needs attention",
         _ => Condense(item.Step),
     };
+
+    private static string ActivitySummary(IReadOnlyList<AgentActivityItem> items)
+    {
+        int working = items.Count(item => item.Status == AgentActivityStatus.Working);
+        int waiting = items.Count(item => item.Status == AgentActivityStatus.Waiting);
+        int idle = items.Count(item => item.Status == AgentActivityStatus.Idle);
+        int completed = items.Count(item => item.Status == AgentActivityStatus.Completed);
+        int failed = items.Count(item => item.Status == AgentActivityStatus.Failed);
+        var parts = new[]
+        {
+            working > 0 ? $"{working} working" : "",
+            waiting > 0 ? $"{waiting} waiting" : "",
+            idle > 0 ? $"{idle} idle" : "",
+            completed > 0 ? $"{completed} done" : "",
+            failed > 0 ? $"{failed} failed" : "",
+        }.Where(part => part.Length > 0);
+        return string.Join(" · ", parts);
+    }
 
     private static string Condense(string text)
     {

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Animation;
@@ -22,7 +23,7 @@ public sealed partial class AgentActivitySummary : UserControl
     public const int DefaultLogicalWidth = 240;
     // The navigator and provider glyph need to remain usable, but the text area may shrink below the
     // preferred width so the host never reserves more space than the taskbar gap actually provides.
-    public const int MinimumLogicalWidth = 160;
+    public const int MinimumLogicalWidth = 200;
     public event Action<AgentActivityItem?>? Clicked;
     public bool SuppressNextClick { get; set; }
     public AgentActivityItem? FollowedItem { get; private set; }
@@ -49,23 +50,17 @@ public sealed partial class AgentActivitySummary : UserControl
             _wheelGestureActive = false;
         };
         Loaded += (_, _) => ApplyForeground();
-        Tapped += AgentActivitySummary_Tapped;
         PointerWheelChanged += AgentActivitySummary_PointerWheelChanged;
     }
 
-    private void AgentActivitySummary_Tapped(object sender, TappedRoutedEventArgs e)
+    private void OpenActivityButton_Click(object sender, RoutedEventArgs e)
     {
         if (SuppressNextClick)
         {
             SuppressNextClick = false;
             return;
         }
-
-        if (!e.Handled)
-        {
-            e.Handled = true;
-            Clicked?.Invoke(FollowedItem);
-        }
+        Clicked?.Invoke(FollowedItem);
     }
 
     public void SetLogicalWidth(int logicalWidth)
@@ -104,7 +99,10 @@ public sealed partial class AgentActivitySummary : UserControl
         var activitySummary = ActivitySummary(items);
         UpdateNavigation(items, item.Id);
         TitleText.Text = ActivityTitle(item);
-        StepText.Text = SummaryText(item);
+        StepText.Text = $"{item.StatusText} · {SummaryText(item)}";
+        var accessibleSummary = $"{ActivityTitle(item)}, {providerName}, {item.StatusText}. {SummaryText(item)}";
+        AutomationProperties.SetName(OpenActivityButton, $"Open agent activity. {accessibleSummary}");
+        AutomationProperties.SetName(ProviderIcon, $"{providerName}, {item.StatusText}");
         ToolTipService.SetToolTip(this,
             $"{ActivityTitle(item)}: {item.Step}\n{items.Count} agents · {activitySummary}. Use the arrows or mouse wheel to switch agents.");
         ApplyForeground();
@@ -134,12 +132,6 @@ public sealed partial class AgentActivitySummary : UserControl
     private void PreviousButton_Click(object sender, RoutedEventArgs e) => MoveSelection(-1);
 
     private void NextButton_Click(object sender, RoutedEventArgs e) => MoveSelection(1);
-
-    private void NavigationButton_PointerPressed(object sender, PointerRoutedEventArgs e)
-        => e.Handled = true;
-
-    private void NavigationButton_Tapped(object sender, TappedRoutedEventArgs e)
-        => e.Handled = true;
 
     private bool MoveSelection(int direction)
     {

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -36,7 +36,7 @@ public sealed partial class AgentActivitySummary : UserControl
         _snapshot = snapshot;
         _activeProvider = activeProvider;
         var items = snapshot.TrackedItems;
-        var item = items.FirstOrDefault(candidate => candidate.Id == _followedId && candidate.IsLive)
+        var item = items.FirstOrDefault(candidate => candidate.Id == _followedId)
             ?? items.FirstOrDefault(candidate => candidate.IsLive)
             ?? items.OrderByDescending(candidate => candidate.UpdatedAt).FirstOrDefault();
         if (item is null)
@@ -61,7 +61,7 @@ public sealed partial class AgentActivitySummary : UserControl
         ProviderIcon.Visibility = showProviderMarker ? Visibility.Visible : Visibility.Collapsed;
         var activitySummary = ActivitySummary(items);
         AgentStatusText.Text = activitySummary;
-        AgentStatusText.Visibility = items.Count > 1 ? Visibility.Visible : Visibility.Collapsed;
+        UpdateNavigation(items, item.Id);
         ToolTipService.SetToolTip(ProviderIcon,
             $"{items.Count} agents · {activitySummary}. Use the mouse wheel to switch agents.");
         TitleText.Text = ActivityTitle(item);
@@ -72,34 +72,60 @@ public sealed partial class AgentActivitySummary : UserControl
 
     private void AgentActivitySummary_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
     {
-        var liveItems = _snapshot.TrackedItems
-            .Where(item => item.IsLive)
-            .OrderBy(item => item.StartedAt)
-            .ThenBy(item => item.Id, StringComparer.Ordinal)
-            .ToList();
-        if (liveItems.Count < 2)
-            return;
-
         int delta = e.GetCurrentPoint(this).Properties.MouseWheelDelta;
         if (delta == 0)
             return;
 
-        int currentIndex = liveItems.FindIndex(item => item.Id == _followedId);
-        if (currentIndex < 0)
-            currentIndex = 0;
-
         // Wheel-up moves toward the earlier agent; wheel-down moves toward the later agent.
         int direction = delta > 0 ? -1 : 1;
-        int nextIndex = (currentIndex + direction + liveItems.Count) % liveItems.Count;
-        var next = liveItems[nextIndex];
-        if (next.Id == _followedId)
-            return;
+        if (MoveSelection(direction))
+            e.Handled = true;
+    }
 
-        _followedId = next.Id;
+    private void PreviousButton_Click(object sender, RoutedEventArgs e) => MoveSelection(-1);
+
+    private void NextButton_Click(object sender, RoutedEventArgs e) => MoveSelection(1);
+
+    private void NavigationButton_PointerPressed(object sender, PointerRoutedEventArgs e)
+        => e.Handled = true;
+
+    private bool MoveSelection(int direction)
+    {
+        var items = NavigationItems(_snapshot.TrackedItems);
+        int currentIndex = items.FindIndex(item => item.Id == _followedId);
+        if (currentIndex < 0)
+            return false;
+
+        int nextIndex = currentIndex + direction;
+        if (nextIndex < 0 || nextIndex >= items.Count)
+            return false;
+
+        _followedId = items[nextIndex].Id;
         Apply(_snapshot, _activeProvider);
         AnimateSelection(direction);
-        e.Handled = true;
+        return true;
     }
+
+    private void UpdateNavigation(IReadOnlyList<AgentActivityItem> items, string selectedId)
+    {
+        var navigationItems = NavigationItems(items);
+        int index = navigationItems.FindIndex(item => item.Id == selectedId);
+        bool hasSelection = index >= 0;
+        AgentPositionText.Text = hasSelection ? $"{index + 1}/{navigationItems.Count}" : "—";
+        AgentPositionText.Visibility = navigationItems.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
+
+        PreviousButton.IsEnabled = hasSelection && index > 0;
+        NextButton.IsEnabled = hasSelection && index < navigationItems.Count - 1;
+        PreviousButton.Opacity = PreviousButton.IsEnabled ? 1 : 0.35;
+        NextButton.Opacity = NextButton.IsEnabled ? 1 : 0.35;
+    }
+
+    private static List<AgentActivityItem> NavigationItems(IReadOnlyList<AgentActivityItem> items)
+        => items
+            .OrderByDescending(item => item.IsLive)
+            .ThenBy(item => item.StartedAt)
+            .ThenBy(item => item.Id, StringComparer.Ordinal)
+            .ToList();
 
     private void AnimateSelection(int direction)
     {

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -52,9 +52,10 @@ public sealed partial class AgentActivitySummary : UserControl
         var providerName = ProviderDisplayName(item.Provider);
         ProviderIcon.ProviderId = item.Provider;
         ProviderIcon.Initial = providerName.Length > 0 ? providerName[0].ToString() : "?";
-        ProviderIcon.ForegroundBrush = AgentActivityVisuals.StatusBrush(
+        var statusBrush = AgentActivityVisuals.StatusBrush(
             item.Status,
             ProviderIcon.ForegroundBrush ?? (Brush)Application.Current.Resources["TextFillColorPrimaryBrush"]);
+        ProviderIcon.ForegroundBrush = statusBrush;
         bool hasMultipleProviders = items.Select(candidate => candidate.Provider).Distinct().Count() > 1;
         ProviderIcon.Visibility = hasMultipleProviders || item.Provider != activeProvider
             ? Visibility.Visible
@@ -68,7 +69,7 @@ public sealed partial class AgentActivitySummary : UserControl
         var state = allDone ? $"{completed} / {total} completed" : SummaryText(item);
         StepText.Text = showProgress && !allDone ? $"{state} · {completed} / {total} completed" : state;
         ToolTipService.SetToolTip(this, $"{ActivityTitle(item)}: {item.Step}");
-        ApplyForeground();
+        ApplyForeground(statusBrush);
     }
 
     private void AgentActivitySummary_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
@@ -170,11 +171,13 @@ public sealed partial class AgentActivitySummary : UserControl
             ? $"{ProviderDisplayName(item.Provider)} through {item.Host}"
             : item.Title;
 
-    private void ApplyForeground()
+    private void ApplyForeground(Brush? statusBrush = null)
     {
         bool light = Interop.SystemInfos.IsSystemLightThemeUsed() == true;
         var brush = new SolidColorBrush(light ? Color.FromArgb(255, 28, 28, 28) : Colors.White);
         StepText.Foreground = brush;
         TitleText.Foreground = brush;
+        if (statusBrush is not null)
+            StepText.Foreground = statusBrush;
     }
 }

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Xaml.Media;
 using TaskbarQuota.AgentActivity;
 using TaskbarQuota.Usage;
@@ -17,16 +18,22 @@ public sealed partial class AgentActivitySummary : UserControl
     public event Action? Clicked;
     public AgentActivityItem? FollowedItem { get; private set; }
     private string? _followedId;
+    private AgentActivitySnapshot _snapshot = new(Array.Empty<AgentActivityItem>());
+    private ProviderId? _activeProvider;
+    private Storyboard? _selectionStoryboard;
 
     public AgentActivitySummary()
     {
         InitializeComponent();
         Loaded += (_, _) => ApplyForeground();
         PointerPressed += (_, _) => Clicked?.Invoke();
+        PointerWheelChanged += AgentActivitySummary_PointerWheelChanged;
     }
 
     public void Apply(AgentActivitySnapshot snapshot, ProviderId? activeProvider = null)
     {
+        _snapshot = snapshot;
+        _activeProvider = activeProvider;
         var items = snapshot.TrackedItems;
         var item = items.FirstOrDefault(candidate => candidate.Id == _followedId && candidate.IsLive)
             ?? items.FirstOrDefault(candidate => candidate.IsLive)
@@ -62,6 +69,70 @@ public sealed partial class AgentActivitySummary : UserControl
         StepText.Text = showProgress && !allDone ? $"{state} · {completed} / {total} completed" : state;
         ToolTipService.SetToolTip(this, $"{ActivityTitle(item)}: {item.Step}");
         ApplyForeground();
+    }
+
+    private void AgentActivitySummary_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
+    {
+        var liveItems = _snapshot.TrackedItems
+            .Where(item => item.IsLive)
+            .OrderBy(item => item.StartedAt)
+            .ThenBy(item => item.Id, StringComparer.Ordinal)
+            .ToList();
+        if (liveItems.Count < 2)
+            return;
+
+        int delta = e.GetCurrentPoint(this).Properties.MouseWheelDelta;
+        if (delta == 0)
+            return;
+
+        int currentIndex = liveItems.FindIndex(item => item.Id == _followedId);
+        if (currentIndex < 0)
+            currentIndex = 0;
+
+        // Wheel-up moves toward the earlier agent; wheel-down moves toward the later agent.
+        int direction = delta > 0 ? -1 : 1;
+        int nextIndex = (currentIndex + direction + liveItems.Count) % liveItems.Count;
+        var next = liveItems[nextIndex];
+        if (next.Id == _followedId)
+            return;
+
+        _followedId = next.Id;
+        Apply(_snapshot, _activeProvider);
+        AnimateSelection(direction);
+        e.Handled = true;
+    }
+
+    private void AnimateSelection(int direction)
+    {
+        _selectionStoryboard?.Stop();
+
+        Root.Opacity = 0.55;
+        RootTransform.TranslateY = direction > 0 ? 8 : -8;
+
+        var storyboard = new Storyboard();
+        var fade = new DoubleAnimation
+        {
+            To = 1,
+            Duration = TimeSpan.FromMilliseconds(180),
+            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut },
+        };
+        Storyboard.SetTarget(fade, Root);
+        Storyboard.SetTargetProperty(fade, "Opacity");
+
+        var slide = new DoubleAnimation
+        {
+            To = 0,
+            Duration = TimeSpan.FromMilliseconds(220),
+            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut },
+            EnableDependentAnimation = true,
+        };
+        Storyboard.SetTarget(slide, RootTransform);
+        Storyboard.SetTargetProperty(slide, "TranslateY");
+
+        storyboard.Children.Add(fade);
+        storyboard.Children.Add(slide);
+        _selectionStoryboard = storyboard;
+        storyboard.Begin();
     }
 
     private static string SummaryText(AgentActivityItem item) => item.Status switch

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -20,7 +20,7 @@ public sealed partial class AgentActivitySummary : UserControl
     // A separate taskbar island should start compact. The wider value above remains the maximum when
     // space is abundant, but using it as the initial native-window width makes narrow drag lanes look
     // unavailable and causes a large resize the first time the activity island is moved.
-    public const int DefaultLogicalWidth = 240;
+    public const int DefaultLogicalWidth = MinimumLogicalWidth;
     // The navigator and provider glyph need to remain usable, but the text area may shrink below the
     // preferred width so the host never reserves more space than the taskbar gap actually provides.
     public const int MinimumLogicalWidth = 160;

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -19,7 +19,7 @@ public sealed partial class AgentActivitySummary : UserControl
     // The navigator and provider glyph need to remain usable, but the text area may shrink below the
     // preferred width so the host never reserves more space than the taskbar gap actually provides.
     public const int MinimumLogicalWidth = 160;
-    public event Action? Clicked;
+    public event Action<AgentActivityItem?>? Clicked;
     public AgentActivityItem? FollowedItem { get; private set; }
     private string? _followedId;
     private AgentActivitySnapshot _snapshot = new(Array.Empty<AgentActivityItem>());
@@ -37,7 +37,7 @@ public sealed partial class AgentActivitySummary : UserControl
     private void AgentActivitySummary_PointerPressed(object sender, PointerRoutedEventArgs e)
     {
         if (!e.Handled)
-            Clicked?.Invoke();
+            Clicked?.Invoke(FollowedItem);
     }
 
     public void SetLogicalWidth(int logicalWidth)

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -16,6 +16,10 @@ namespace TaskbarQuota.Controls;
 public sealed partial class AgentActivitySummary : UserControl
 {
     public const int DesiredLogicalWidth = 400;
+    // A separate taskbar island should start compact. The wider value above remains the maximum when
+    // space is abundant, but using it as the initial native-window width makes narrow drag lanes look
+    // unavailable and causes a large resize the first time the activity island is moved.
+    public const int DefaultLogicalWidth = 240;
     // The navigator and provider glyph need to remain usable, but the text area may shrink below the
     // preferred width so the host never reserves more space than the taskbar gap actually provides.
     public const int MinimumLogicalWidth = 160;
@@ -26,10 +30,24 @@ public sealed partial class AgentActivitySummary : UserControl
     private AgentActivitySnapshot _snapshot = new(Array.Empty<AgentActivityItem>());
     private ProviderId? _activeProvider;
     private Storyboard? _selectionStoryboard;
+    private readonly DispatcherTimer _wheelGestureEndTimer;
+    private bool _wheelGestureActive;
 
     public AgentActivitySummary()
     {
         InitializeComponent();
+        _wheelGestureEndTimer = new DispatcherTimer
+        {
+            // Precision touchpads keep emitting wheel events while momentum decays. A short fixed
+            // cooldown prevents a swipe from racing through agents without making the next swipe feel
+            // blocked.
+            Interval = TimeSpan.FromMilliseconds(140),
+        };
+        _wheelGestureEndTimer.Tick += (_, _) =>
+        {
+            _wheelGestureEndTimer.Stop();
+            _wheelGestureActive = false;
+        };
         Loaded += (_, _) => ApplyForeground();
         Tapped += AgentActivitySummary_Tapped;
         PointerWheelChanged += AgentActivitySummary_PointerWheelChanged;
@@ -94,14 +112,23 @@ public sealed partial class AgentActivitySummary : UserControl
 
     private void AgentActivitySummary_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
     {
-        int delta = e.GetCurrentPoint(this).Properties.MouseWheelDelta;
-        if (delta == 0)
+        var properties = e.GetCurrentPoint(this).Properties;
+        int delta = properties.MouseWheelDelta;
+        if (delta == 0 || properties.IsHorizontalMouseWheel)
             return;
 
+        // Consume every vertical wheel event over the widget, including momentum events and attempts at
+        // either end of the list. Letting those events bubble can scroll an enclosing surface instead.
+        e.Handled = true;
+        if (_wheelGestureActive)
+            return;
+
+        _wheelGestureActive = true;
+        _wheelGestureEndTimer.Stop();
+        _wheelGestureEndTimer.Start();
         // Wheel-up moves toward the earlier agent; wheel-down moves toward the later agent.
         int direction = delta > 0 ? -1 : 1;
-        if (MoveSelection(direction))
-            e.Handled = true;
+        MoveSelection(direction);
     }
 
     private void PreviousButton_Click(object sender, RoutedEventArgs e) => MoveSelection(-1);
@@ -229,6 +256,7 @@ public sealed partial class AgentActivitySummary : UserControl
     {
         ProviderId.ClinePass => "Cline Pass",
         ProviderId.OpenCodeGo => "OpenCode Go",
+        ProviderId.Copilot => "GitHub Copilot",
         _ => provider.ToString(),
     };
 

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -57,8 +57,7 @@ public sealed partial class AgentActivitySummary : UserControl
             item.Status,
             ProviderIcon.ForegroundBrush ?? (Brush)Application.Current.Resources["TextFillColorPrimaryBrush"]);
         ProviderIcon.ForegroundBrush = statusBrush;
-        bool showProviderMarker = items.Select(candidate => candidate.Provider).Distinct().Count() > 1
-            || item.Provider != activeProvider;
+        bool showProviderMarker = item.Provider != activeProvider;
         ProviderIcon.Visibility = showProviderMarker ? Visibility.Visible : Visibility.Collapsed;
         var activitySummary = ActivitySummary(items);
         AgentStatusText.Text = activitySummary;

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -23,7 +23,7 @@ public sealed partial class AgentActivitySummary : UserControl
     public const int DefaultLogicalWidth = 240;
     // The navigator and provider glyph need to remain usable, but the text area may shrink below the
     // preferred width so the host never reserves more space than the taskbar gap actually provides.
-    public const int MinimumLogicalWidth = 200;
+    public const int MinimumLogicalWidth = 160;
     public event Action<AgentActivityItem?>? Clicked;
     public bool SuppressNextClick { get; set; }
     public AgentActivityItem? FollowedItem { get; private set; }
@@ -99,7 +99,7 @@ public sealed partial class AgentActivitySummary : UserControl
         var activitySummary = ActivitySummary(items);
         UpdateNavigation(items, item.Id);
         TitleText.Text = ActivityTitle(item);
-        StepText.Text = $"{item.StatusText} · {SummaryText(item)}";
+        StepText.Text = SummaryText(item);
         var accessibleSummary = $"{ActivityTitle(item)}, {providerName}, {item.StatusText}. {SummaryText(item)}";
         AutomationProperties.SetName(OpenActivityButton, $"Open agent activity. {accessibleSummary}");
         AutomationProperties.SetName(ProviderIcon, $"{providerName}, {item.StatusText}");

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -60,13 +60,11 @@ public sealed partial class AgentActivitySummary : UserControl
         bool showProviderMarker = item.Provider != activeProvider;
         ProviderIcon.Visibility = showProviderMarker ? Visibility.Visible : Visibility.Collapsed;
         var activitySummary = ActivitySummary(items);
-        AgentStatusText.Text = activitySummary;
         UpdateNavigation(items, item.Id);
-        ToolTipService.SetToolTip(ProviderIcon,
-            $"{items.Count} agents · {activitySummary}. Use the mouse wheel to switch agents.");
         TitleText.Text = ActivityTitle(item);
         StepText.Text = SummaryText(item);
-        ToolTipService.SetToolTip(this, $"{ActivityTitle(item)}: {item.Step}");
+        ToolTipService.SetToolTip(this,
+            $"{ActivityTitle(item)}: {item.Step}\n{items.Count} agents · {activitySummary}. Use the arrows or mouse wheel to switch agents.");
         ApplyForeground();
     }
 

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -57,7 +57,7 @@ public sealed partial class AgentActivitySummary : UserControl
             item.Status,
             ProviderIcon.ForegroundBrush ?? (Brush)Application.Current.Resources["TextFillColorPrimaryBrush"]);
         ProviderIcon.ForegroundBrush = statusBrush;
-        bool showProviderMarker = item.Provider != activeProvider;
+        bool showProviderMarker = !IsSameProvider(item.Provider, activeProvider);
         ProviderIcon.Visibility = showProviderMarker ? Visibility.Visible : Visibility.Collapsed;
         var activitySummary = ActivitySummary(items);
         UpdateNavigation(items, item.Id);
@@ -204,6 +204,14 @@ public sealed partial class AgentActivitySummary : UserControl
         ProviderId.OpenCodeGo => "OpenCode Go",
         _ => provider.ToString(),
     };
+
+    private static bool IsSameProvider(ProviderId activityProvider, ProviderId? activeProvider)
+        => activeProvider is { } active
+            && (activityProvider == active
+                || (activityProvider is ProviderId.Cline && active is ProviderId.ClinePass)
+                || (activityProvider is ProviderId.ClinePass && active is ProviderId.Cline)
+                || (activityProvider is ProviderId.OpenCode && active is ProviderId.OpenCodeGo)
+                || (activityProvider is ProviderId.OpenCodeGo && active is ProviderId.OpenCode));
 
     private static string ActivityTitle(AgentActivityItem item)
         => !string.IsNullOrWhiteSpace(item.Host)

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -20,10 +20,10 @@ public sealed partial class AgentActivitySummary : UserControl
     // A separate taskbar island should start compact. The wider value above remains the maximum when
     // space is abundant, but using it as the initial native-window width makes narrow drag lanes look
     // unavailable and causes a large resize the first time the activity island is moved.
-    public const int DefaultLogicalWidth = MinimumLogicalWidth;
+    public const int DefaultLogicalWidth = 120;
     // The navigator and provider glyph need to remain usable, but the text area may shrink below the
     // preferred width so the host never reserves more space than the taskbar gap actually provides.
-    public const int MinimumLogicalWidth = 160;
+    public const int MinimumLogicalWidth = 120;
     public event Action<AgentActivityItem?>? Clicked;
     public bool SuppressNextClick { get; set; }
     public AgentActivityItem? FollowedItem { get; private set; }

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -20,6 +20,7 @@ public sealed partial class AgentActivitySummary : UserControl
     // preferred width so the host never reserves more space than the taskbar gap actually provides.
     public const int MinimumLogicalWidth = 160;
     public event Action<AgentActivityItem?>? Clicked;
+    public bool SuppressNextClick { get; set; }
     public AgentActivityItem? FollowedItem { get; private set; }
     private string? _followedId;
     private AgentActivitySnapshot _snapshot = new(Array.Empty<AgentActivityItem>());
@@ -30,14 +31,23 @@ public sealed partial class AgentActivitySummary : UserControl
     {
         InitializeComponent();
         Loaded += (_, _) => ApplyForeground();
-        PointerPressed += AgentActivitySummary_PointerPressed;
+        Tapped += AgentActivitySummary_Tapped;
         PointerWheelChanged += AgentActivitySummary_PointerWheelChanged;
     }
 
-    private void AgentActivitySummary_PointerPressed(object sender, PointerRoutedEventArgs e)
+    private void AgentActivitySummary_Tapped(object sender, TappedRoutedEventArgs e)
     {
+        if (SuppressNextClick)
+        {
+            SuppressNextClick = false;
+            return;
+        }
+
         if (!e.Handled)
+        {
+            e.Handled = true;
             Clicked?.Invoke(FollowedItem);
+        }
     }
 
     public void SetLogicalWidth(int logicalWidth)
@@ -99,6 +109,9 @@ public sealed partial class AgentActivitySummary : UserControl
     private void NextButton_Click(object sender, RoutedEventArgs e) => MoveSelection(1);
 
     private void NavigationButton_PointerPressed(object sender, PointerRoutedEventArgs e)
+        => e.Handled = true;
+
+    private void NavigationButton_Tapped(object sender, TappedRoutedEventArgs e)
         => e.Handled = true;
 
     private bool MoveSelection(int direction)

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -69,7 +69,7 @@ public sealed partial class AgentActivitySummary : UserControl
         var state = allDone ? $"{completed} / {total} completed" : SummaryText(item);
         StepText.Text = showProgress && !allDone ? $"{state} · {completed} / {total} completed" : state;
         ToolTipService.SetToolTip(this, $"{ActivityTitle(item)}: {item.Step}");
-        ApplyForeground(statusBrush);
+        ApplyForeground();
     }
 
     private void AgentActivitySummary_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
@@ -171,13 +171,11 @@ public sealed partial class AgentActivitySummary : UserControl
             ? $"{ProviderDisplayName(item.Provider)} through {item.Host}"
             : item.Title;
 
-    private void ApplyForeground(Brush? statusBrush = null)
+    private void ApplyForeground()
     {
         bool light = Interop.SystemInfos.IsSystemLightThemeUsed() == true;
         var brush = new SolidColorBrush(light ? Color.FromArgb(255, 28, 28, 28) : Colors.White);
         StepText.Foreground = brush;
         TitleText.Foreground = brush;
-        if (statusBrush is not null)
-            StepText.Foreground = statusBrush;
     }
 }

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using TaskbarQuota.AgentActivity;
+using TaskbarQuota.Usage;
 using Windows.UI;
 
 namespace TaskbarQuota.Controls;
@@ -24,7 +25,7 @@ public sealed partial class AgentActivitySummary : UserControl
         PointerPressed += (_, _) => Clicked?.Invoke();
     }
 
-    public void Apply(AgentActivitySnapshot snapshot)
+    public void Apply(AgentActivitySnapshot snapshot, ProviderId? activeProvider = null)
     {
         var items = snapshot.TrackedItems;
         var item = items.FirstOrDefault(candidate => candidate.Id == _followedId && candidate.IsLive)
@@ -41,14 +42,25 @@ public sealed partial class AgentActivitySummary : UserControl
         _followedId = item.Id;
         FollowedItem = item;
         Visibility = Visibility.Visible;
+        var providerName = ProviderDisplayName(item.Provider);
+        ProviderIcon.ProviderId = item.Provider;
+        ProviderIcon.Initial = providerName.Length > 0 ? providerName[0].ToString() : "?";
+        ProviderIcon.ForegroundBrush = AgentActivityVisuals.StatusBrush(
+            item.Status,
+            ProviderIcon.ForegroundBrush ?? (Brush)Application.Current.Resources["TextFillColorPrimaryBrush"]);
+        bool hasMultipleProviders = items.Select(candidate => candidate.Provider).Distinct().Count() > 1;
+        ProviderIcon.Visibility = hasMultipleProviders || item.Provider != activeProvider
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+        ToolTipService.SetToolTip(ProviderIcon, $"Agent activity from {providerName}");
         int total = items.Count;
         int completed = items.Count(candidate => candidate.Status == AgentActivityStatus.Completed);
         bool showProgress = total > 1;
         bool allDone = showProgress && completed == total;
-        TitleText.Text = allDone ? "All agent tasks" : item.Title;
+        TitleText.Text = allDone ? "All agent tasks" : ActivityTitle(item);
         var state = allDone ? $"{completed} / {total} completed" : SummaryText(item);
         StepText.Text = showProgress && !allDone ? $"{state} · {completed} / {total} completed" : state;
-        ToolTipService.SetToolTip(this, $"{item.Title}: {item.Step}");
+        ToolTipService.SetToolTip(this, $"{ActivityTitle(item)}: {item.Step}");
         ApplyForeground();
     }
 
@@ -73,6 +85,19 @@ public sealed partial class AgentActivitySummary : UserControl
 
         return compact[..95].TrimEnd() + "…";
     }
+
+    private static string ProviderDisplayName(ProviderId provider) => provider switch
+    {
+        ProviderId.ClinePass => "Cline Pass",
+        ProviderId.OpenCodeGo => "OpenCode Go",
+        _ => provider.ToString(),
+    };
+
+    private static string ActivityTitle(AgentActivityItem item)
+        => !string.IsNullOrWhiteSpace(item.Host)
+            && string.Equals(item.Title, ProviderDisplayName(item.Provider), StringComparison.OrdinalIgnoreCase)
+            ? $"{ProviderDisplayName(item.Provider)} through {item.Host}"
+            : item.Title;
 
     private void ApplyForeground()
     {

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -30,8 +30,14 @@ public sealed partial class AgentActivitySummary : UserControl
     {
         InitializeComponent();
         Loaded += (_, _) => ApplyForeground();
-        PointerPressed += (_, _) => Clicked?.Invoke();
+        PointerPressed += AgentActivitySummary_PointerPressed;
         PointerWheelChanged += AgentActivitySummary_PointerWheelChanged;
+    }
+
+    private void AgentActivitySummary_PointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        if (!e.Handled)
+            Clicked?.Invoke();
     }
 
     public void SetLogicalWidth(int logicalWidth)

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -57,9 +57,12 @@ public sealed partial class AgentActivitySummary : UserControl
             item.Status,
             ProviderIcon.ForegroundBrush ?? (Brush)Application.Current.Resources["TextFillColorPrimaryBrush"]);
         ProviderIcon.ForegroundBrush = statusBrush;
-        ProviderIcon.Visibility = Visibility.Visible;
+        bool showProviderMarker = items.Select(candidate => candidate.Provider).Distinct().Count() > 1
+            || item.Provider != activeProvider;
+        ProviderIcon.Visibility = showProviderMarker ? Visibility.Visible : Visibility.Collapsed;
         var activitySummary = ActivitySummary(items);
         AgentStatusText.Text = activitySummary;
+        AgentStatusText.Visibility = items.Count > 1 ? Visibility.Visible : Visibility.Collapsed;
         ToolTipService.SetToolTip(ProviderIcon,
             $"{items.Count} agents · {activitySummary}. Use the mouse wheel to switch agents.");
         TitleText.Text = ActivityTitle(item);

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -16,6 +16,9 @@ namespace TaskbarQuota.Controls;
 public sealed partial class AgentActivitySummary : UserControl
 {
     public const int DesiredLogicalWidth = 400;
+    // The navigator and provider glyph need to remain usable, but the text area may shrink below the
+    // preferred width so the host never reserves more space than the taskbar gap actually provides.
+    public const int MinimumLogicalWidth = 160;
     public event Action? Clicked;
     public AgentActivityItem? FollowedItem { get; private set; }
     private string? _followedId;
@@ -29,6 +32,11 @@ public sealed partial class AgentActivitySummary : UserControl
         Loaded += (_, _) => ApplyForeground();
         PointerPressed += (_, _) => Clicked?.Invoke();
         PointerWheelChanged += AgentActivitySummary_PointerWheelChanged;
+    }
+
+    public void SetLogicalWidth(int logicalWidth)
+    {
+        Root.Width = Math.Clamp(logicalWidth, 1, DesiredLogicalWidth);
     }
 
     public void Apply(AgentActivitySnapshot snapshot, ProviderId? activeProvider = null)

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -31,6 +31,8 @@ public sealed partial class AgentActivitySummary : UserControl
     private AgentActivitySnapshot _snapshot = new(Array.Empty<AgentActivityItem>());
     private ProviderId? _activeProvider;
     private Storyboard? _selectionStoryboard;
+    private Storyboard? _appearanceStoryboard;
+    private bool _hasAppeared;
     private readonly DispatcherTimer _wheelGestureEndTimer;
     private bool _wheelGestureActive;
 
@@ -81,9 +83,11 @@ public sealed partial class AgentActivitySummary : UserControl
             Visibility = Visibility.Collapsed;
             FollowedItem = null;
             _followedId = null;
+            _hasAppeared = false;
             return;
         }
 
+        bool shouldReveal = !_hasAppeared;
         _followedId = item.Id;
         FollowedItem = item;
         Visibility = Visibility.Visible;
@@ -96,16 +100,18 @@ public sealed partial class AgentActivitySummary : UserControl
         ProviderIcon.ForegroundBrush = statusBrush;
         bool showProviderMarker = !IsSameProvider(item.Provider, activeProvider);
         ProviderIcon.Visibility = showProviderMarker ? Visibility.Visible : Visibility.Collapsed;
-        var activitySummary = ActivitySummary(items);
         UpdateNavigation(items, item.Id);
         TitleText.Text = ActivityTitle(item);
         StepText.Text = SummaryText(item);
         var accessibleSummary = $"{ActivityTitle(item)}, {providerName}, {item.StatusText}. {SummaryText(item)}";
         AutomationProperties.SetName(OpenActivityButton, $"Open agent activity. {accessibleSummary}");
         AutomationProperties.SetName(ProviderIcon, $"{providerName}, {item.StatusText}");
-        ToolTipService.SetToolTip(this,
-            $"{ActivityTitle(item)}: {item.Step}\n{items.Count} agents · {activitySummary}. Use the arrows or mouse wheel to switch agents.");
         ApplyForeground();
+        if (shouldReveal)
+        {
+            _hasAppeared = true;
+            AnimateReveal();
+        }
     }
 
     private void AgentActivitySummary_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
@@ -201,6 +207,40 @@ public sealed partial class AgentActivitySummary : UserControl
         storyboard.Children.Add(fade);
         storyboard.Children.Add(slide);
         _selectionStoryboard = storyboard;
+        storyboard.Begin();
+    }
+
+    private void AnimateReveal()
+    {
+        _appearanceStoryboard?.Stop();
+        Root.Opacity = 1;
+        RootTransform.TranslateY = 0;
+
+        var fade = new DoubleAnimation
+        {
+            From = 0,
+            To = 1,
+            Duration = new Duration(TimeSpan.FromMilliseconds(240)),
+            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut },
+        };
+        Storyboard.SetTarget(fade, Root);
+        Storyboard.SetTargetProperty(fade, "Opacity");
+
+        var slide = new DoubleAnimation
+        {
+            From = 5,
+            To = 0,
+            Duration = new Duration(TimeSpan.FromMilliseconds(260)),
+            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut },
+            EnableDependentAnimation = true,
+        };
+        Storyboard.SetTarget(slide, RootTransform);
+        Storyboard.SetTargetProperty(slide, "TranslateY");
+
+        var storyboard = new Storyboard();
+        storyboard.Children.Add(fade);
+        storyboard.Children.Add(slide);
+        _appearanceStoryboard = storyboard;
         storyboard.Begin();
     }
 

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -102,7 +102,7 @@ public sealed partial class AgentActivitySummary : UserControl
         ProviderIcon.Visibility = showProviderMarker ? Visibility.Visible : Visibility.Collapsed;
         UpdateNavigation(items, item.Id);
         TitleText.Text = ActivityTitle(item);
-        StepText.Text = SummaryText(item);
+        StepText.Text = $"{item.StatusText} · {SummaryText(item)}";
         var accessibleSummary = $"{ActivityTitle(item)}, {providerName}, {item.StatusText}. {SummaryText(item)}";
         AutomationProperties.SetName(OpenActivityButton, $"Open agent activity. {accessibleSummary}");
         AutomationProperties.SetName(ProviderIcon, $"{providerName}, {item.StatusText}");

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using TaskbarQuota.AgentActivity;
+using Windows.UI;
+
+namespace TaskbarQuota.Controls;
+
+public sealed partial class AgentActivitySummary : UserControl
+{
+    public const int DesiredLogicalWidth = 400;
+    public event Action? Clicked;
+    public AgentActivityItem? FollowedItem { get; private set; }
+    private string? _followedId;
+
+    public AgentActivitySummary()
+    {
+        InitializeComponent();
+        Loaded += (_, _) => ApplyForeground();
+        PointerPressed += (_, _) => Clicked?.Invoke();
+    }
+
+    public void Apply(AgentActivitySnapshot snapshot)
+    {
+        var items = snapshot.TrackedItems;
+        var item = items.FirstOrDefault(candidate => candidate.Id == _followedId && candidate.IsLive)
+            ?? items.FirstOrDefault(candidate => candidate.IsLive)
+            ?? items.OrderByDescending(candidate => candidate.UpdatedAt).FirstOrDefault();
+        if (item is null)
+        {
+            Visibility = Visibility.Collapsed;
+            FollowedItem = null;
+            _followedId = null;
+            return;
+        }
+
+        _followedId = item.Id;
+        FollowedItem = item;
+        Visibility = Visibility.Visible;
+        int total = items.Count;
+        int completed = items.Count(candidate => candidate.Status == AgentActivityStatus.Completed);
+        bool showProgress = total > 1;
+        bool allDone = showProgress && completed == total;
+        TitleText.Text = allDone ? "All agent tasks" : item.Title;
+        var state = allDone ? $"{completed} / {total} completed" : SummaryText(item);
+        StepText.Text = showProgress && !allDone ? $"{state} · {completed} / {total} completed" : state;
+        ToolTipService.SetToolTip(this, $"{item.Title}: {item.Step}");
+        ApplyForeground();
+    }
+
+    private static string SummaryText(AgentActivityItem item) => item.Status switch
+    {
+        AgentActivityStatus.Completed => string.IsNullOrWhiteSpace(item.Step) || item.Step == "Completed"
+            ? "Task completed"
+            : Condense(item.Step),
+        AgentActivityStatus.Failed => "Task needs attention",
+        _ => Condense(item.Step),
+    };
+
+    private static string Condense(string text)
+    {
+        var compact = string.Join(' ', text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+        if (compact.Length <= 96)
+            return compact;
+
+        int sentenceEnd = compact.IndexOfAny(['.', '!', '?']);
+        if (sentenceEnd is > 12 and <= 96)
+            return compact[..(sentenceEnd + 1)];
+
+        return compact[..95].TrimEnd() + "…";
+    }
+
+    private void ApplyForeground()
+    {
+        bool light = Interop.SystemInfos.IsSystemLightThemeUsed() == true;
+        var brush = new SolidColorBrush(light ? Color.FromArgb(255, 28, 28, 28) : Colors.White);
+        StepText.Foreground = brush;
+        TitleText.Foreground = brush;
+    }
+}

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -57,15 +57,10 @@ public sealed partial class AgentActivitySummary : UserControl
             item.Status,
             ProviderIcon.ForegroundBrush ?? (Brush)Application.Current.Resources["TextFillColorPrimaryBrush"]);
         ProviderIcon.ForegroundBrush = statusBrush;
-        bool showProviderMarker = items.Select(candidate => candidate.Provider).Distinct().Count() > 1
-            || item.Provider != activeProvider
-            || items.Count > 1;
-        ProviderMarker.Visibility = showProviderMarker ? Visibility.Visible : Visibility.Collapsed;
-        AgentCountBadge.Visibility = items.Count > 1 ? Visibility.Visible : Visibility.Collapsed;
-        AgentCountText.Text = items.Count > 9 ? "9+" : items.Count.ToString();
+        ProviderIcon.Visibility = Visibility.Visible;
         var activitySummary = ActivitySummary(items);
         AgentStatusText.Text = activitySummary;
-        ToolTipService.SetToolTip(ProviderMarker,
+        ToolTipService.SetToolTip(ProviderIcon,
             $"{items.Count} agents · {activitySummary}. Use the mouse wheel to switch agents.");
         TitleText.Text = ActivityTitle(item);
         StepText.Text = SummaryText(item);

--- a/src/TaskbarQuota.App/Controls/AgentActivityVisuals.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivityVisuals.cs
@@ -1,0 +1,28 @@
+using Microsoft.UI.Xaml.Media;
+using TaskbarQuota.AgentActivity;
+using Windows.UI;
+
+namespace TaskbarQuota.Controls;
+
+internal static class AgentActivityVisuals
+{
+    public static Brush StatusBrush(AgentActivityStatus? status, Brush fallback) => status switch
+    {
+        AgentActivityStatus.Working => StatusGradient(Color.FromArgb(255, 82, 196, 255), Color.FromArgb(255, 45, 94, 232)),
+        AgentActivityStatus.Waiting => StatusGradient(Color.FromArgb(255, 255, 202, 92), Color.FromArgb(255, 224, 141, 33)),
+        AgentActivityStatus.Completed => StatusGradient(Color.FromArgb(255, 100, 222, 130), Color.FromArgb(255, 20, 142, 73)),
+        AgentActivityStatus.Failed => StatusGradient(Color.FromArgb(255, 255, 130, 130), Color.FromArgb(255, 207, 55, 62)),
+        _ => fallback,
+    };
+
+    private static LinearGradientBrush StatusGradient(Color start, Color end) => new()
+    {
+        StartPoint = new Windows.Foundation.Point(0, 0),
+        EndPoint = new Windows.Foundation.Point(1, 1),
+        GradientStops =
+        {
+            new GradientStop { Color = start, Offset = 0 },
+            new GradientStop { Color = end, Offset = 1 },
+        },
+    };
+}

--- a/src/TaskbarQuota.App/Controls/AgentActivityVisuals.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivityVisuals.cs
@@ -10,6 +10,7 @@ internal static class AgentActivityVisuals
     {
         AgentActivityStatus.Working => StatusGradient(Color.FromArgb(255, 82, 196, 255), Color.FromArgb(255, 45, 94, 232)),
         AgentActivityStatus.Waiting => StatusGradient(Color.FromArgb(255, 255, 202, 92), Color.FromArgb(255, 224, 141, 33)),
+        AgentActivityStatus.Idle => StatusGradient(Color.FromArgb(255, 174, 184, 198), Color.FromArgb(255, 92, 105, 126)),
         AgentActivityStatus.Completed => StatusGradient(Color.FromArgb(255, 100, 222, 130), Color.FromArgb(255, 20, 142, 73)),
         AgentActivityStatus.Failed => StatusGradient(Color.FromArgb(255, 255, 130, 130), Color.FromArgb(255, 207, 55, 62)),
         _ => fallback,

--- a/src/TaskbarQuota.App/Controls/ProviderGlyphRenderer.cs
+++ b/src/TaskbarQuota.App/Controls/ProviderGlyphRenderer.cs
@@ -23,11 +23,11 @@ namespace TaskbarQuota.Controls
 
             path.Data = glyph;
             path.Fill = foreground;
-            ApplyTransform(path, providerId);
+            ApplyTransform(path);
             return true;
         }
 
-        public static void ApplyTransform(Path path, ProviderId? providerId = null)
+        public static void ApplyTransform(Path path)
         {
             var bounds = path.Data?.Bounds ?? Rect.Empty;
             if (bounds.IsEmpty || bounds.Width <= 0 || bounds.Height <= 0)
@@ -37,18 +37,14 @@ namespace TaskbarQuota.Controls
             }
 
             double scale = NormalizedExtent / Math.Max(bounds.Width, bounds.Height);
-            double scaleX = scale * OpticalScaleX(providerId);
             path.RenderTransform = new CompositeTransform
             {
-                ScaleX = scaleX,
+                ScaleX = scale,
                 ScaleY = scale,
-                TranslateX = (ViewportSize / 2) - ((bounds.X + bounds.Width / 2) * scaleX),
+                TranslateX = (ViewportSize / 2) - ((bounds.X + bounds.Width / 2) * scale),
                 TranslateY = (ViewportSize / 2) - ((bounds.Y + bounds.Height / 2) * scale),
             };
         }
-
-        internal static double OpticalScaleX(ProviderId? providerId)
-            => providerId is ProviderId.OpenCode or ProviderId.OpenCodeGo ? 1.24 : 1;
 
         public static double Viewport => ViewportSize;
     }

--- a/src/TaskbarQuota.App/Controls/ProviderGlyphRenderer.cs
+++ b/src/TaskbarQuota.App/Controls/ProviderGlyphRenderer.cs
@@ -23,11 +23,11 @@ namespace TaskbarQuota.Controls
 
             path.Data = glyph;
             path.Fill = foreground;
-            ApplyTransform(path);
+            ApplyTransform(path, providerId);
             return true;
         }
 
-        public static void ApplyTransform(Path path)
+        public static void ApplyTransform(Path path, ProviderId? providerId = null)
         {
             var bounds = path.Data?.Bounds ?? Rect.Empty;
             if (bounds.IsEmpty || bounds.Width <= 0 || bounds.Height <= 0)
@@ -37,14 +37,18 @@ namespace TaskbarQuota.Controls
             }
 
             double scale = NormalizedExtent / Math.Max(bounds.Width, bounds.Height);
+            double scaleX = scale * OpticalScaleX(providerId);
             path.RenderTransform = new CompositeTransform
             {
-                ScaleX = scale,
+                ScaleX = scaleX,
                 ScaleY = scale,
-                TranslateX = (ViewportSize / 2) - ((bounds.X + bounds.Width / 2) * scale),
+                TranslateX = (ViewportSize / 2) - ((bounds.X + bounds.Width / 2) * scaleX),
                 TranslateY = (ViewportSize / 2) - ((bounds.Y + bounds.Height / 2) * scale),
             };
         }
+
+        internal static double OpticalScaleX(ProviderId? providerId)
+            => providerId is ProviderId.OpenCode or ProviderId.OpenCodeGo ? 1.24 : 1;
 
         public static double Viewport => ViewportSize;
     }

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -963,13 +963,11 @@ namespace TaskbarQuota.Controls
 
         private void AnimateSoftRefresh()
         {
-            // Start below the resting value so the refresh still reads as a pulse, but never brighten
-            // past it — a stale snapshot must stay dimmed once the animation settles.
-            double targetOpacity = RestingPanelOpacity;
-            double startOpacity = Math.Min(0.72, targetOpacity);
-            Panel.Opacity = startOpacity;
-
-            AnimatePanelOpacity(startOpacity, targetOpacity, 180);
+            // A refresh replaces the row elements in-place. Dimming the entire panel here made every
+            // quota poll flash, especially when providers publish a stale snapshot followed by a live
+            // result a moment later. Keep the resting opacity stable; first reveal and provider switches
+            // still use their dedicated transitions.
+            Panel.Opacity = RestingPanelOpacity;
         }
 
         /// <summary>

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -189,7 +189,7 @@ namespace TaskbarQuota.Controls
             var glyph = TaskbarQuota.ViewModels.Ui.Glyph(result.Id);
             if (glyph != null)
             {
-                SetNormalizedGlyph(BadgeGlyph, glyph, BadgeGlyph.Fill as Brush ?? Foreground);
+                SetNormalizedGlyph(BadgeGlyph, glyph, BadgeGlyph.Fill as Brush ?? Foreground, result.Id);
                 BadgeGlyphBox.Visibility = Visibility.Visible;
                 BadgeText.Visibility = Visibility.Collapsed;
             }
@@ -1356,14 +1356,15 @@ namespace TaskbarQuota.Controls
             };
         }
 
-        private static void SetNormalizedGlyph(Path path, Geometry glyph, Brush foreground)
+        private static void SetNormalizedGlyph(
+            Path path, Geometry glyph, Brush foreground, ProviderId? providerId = null)
         {
             path.Data = glyph;
             path.Fill = foreground;
-            SetNormalizedGlyphTransform(path);
+            SetNormalizedGlyphTransform(path, providerId);
         }
 
-        private static void SetNormalizedGlyphTransform(Path path)
+        private static void SetNormalizedGlyphTransform(Path path, ProviderId? providerId = null)
         {
             var bounds = path.Data?.Bounds ?? Rect.Empty;
             if (bounds.IsEmpty || bounds.Width <= 0 || bounds.Height <= 0)
@@ -1373,11 +1374,12 @@ namespace TaskbarQuota.Controls
             }
 
             double scale = NormalizedGlyphExtent / Math.Max(bounds.Width, bounds.Height);
+            double scaleX = scale * ProviderGlyphRenderer.OpticalScaleX(providerId);
             path.RenderTransform = new CompositeTransform
             {
-                ScaleX = scale,
+                ScaleX = scaleX,
                 ScaleY = scale,
-                TranslateX = (GlyphViewportSize / 2) - ((bounds.X + bounds.Width / 2) * scale),
+                TranslateX = (GlyphViewportSize / 2) - ((bounds.X + bounds.Width / 2) * scaleX),
                 TranslateY = (GlyphViewportSize / 2) - ((bounds.Y + bounds.Height / 2) * scale),
             };
         }

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -11,6 +11,7 @@ using Microsoft.UI.Xaml.Shapes;
 using Windows.Foundation;
 using Windows.UI;
 using TaskbarQuota.ActiveApp;
+using TaskbarQuota.AgentActivity;
 using TaskbarQuota.Services;
 using TaskbarQuota.Usage;
 using TaskbarQuota.Usage.Providers;
@@ -73,6 +74,7 @@ namespace TaskbarQuota.Controls
         private bool _forcePercentagesOnly;
         private UsageResult? _lastResult;
         private ProviderId? _lastAppliedProvider;
+        private AgentActivityStatus? _agentStatus;
         private string? _lastRenderSignature;
         private bool _hasRevealed;
         private bool _isActiveToolVisible = true;
@@ -156,7 +158,7 @@ namespace TaskbarQuota.Controls
                 row.Track.Background = track;
                 row.Value.Foreground = Foreground;
             }
-            BadgeGlyph.Fill = Foreground;
+            UpdateBadgeFill();
         }
 
         public void Apply(UsageResult result, bool force = false)
@@ -187,7 +189,7 @@ namespace TaskbarQuota.Controls
             var glyph = TaskbarQuota.ViewModels.Ui.Glyph(result.Id);
             if (glyph != null)
             {
-                SetNormalizedGlyph(BadgeGlyph, glyph, Foreground);
+                SetNormalizedGlyph(BadgeGlyph, glyph, BadgeGlyph.Fill as Brush ?? Foreground);
                 BadgeGlyphBox.Visibility = Visibility.Visible;
                 BadgeText.Visibility = Visibility.Collapsed;
             }
@@ -282,6 +284,34 @@ namespace TaskbarQuota.Controls
                     ? $"{WidgetTooltipTitle(widgetName, result.Source)}\n{string.Join("\n", tooltipLines)}{costTooltip}{resetCreditsTooltip}{staleTooltip}"
                     : $"{WidgetTooltipTitle(widgetName, result.Source)} · {plan}\n{string.Join("\n", tooltipLines)}{costTooltip}{resetCreditsTooltip}{staleTooltip}");
         }
+
+        /// <summary>Colors the provider glyph to match its latest independently-discovered agent task.</summary>
+        public void SetAgentActivity(AgentActivityItem? activity)
+        {
+            _agentStatus = activity is not null && activity.Provider == _lastAppliedProvider
+                ? activity.Status
+                : null;
+            UpdateBadgeFill();
+        }
+
+        private void UpdateBadgeFill()
+        {
+            BadgeGlyph.Fill = _agentStatus switch
+            {
+                AgentActivityStatus.Working => StatusGradient(Color.FromArgb(255, 82, 196, 255), Color.FromArgb(255, 45, 94, 232)),
+                AgentActivityStatus.Waiting => StatusGradient(Color.FromArgb(255, 255, 202, 92), Color.FromArgb(255, 224, 141, 33)),
+                AgentActivityStatus.Completed => StatusGradient(Color.FromArgb(255, 100, 222, 130), Color.FromArgb(255, 20, 142, 73)),
+                AgentActivityStatus.Failed => StatusGradient(Color.FromArgb(255, 255, 130, 130), Color.FromArgb(255, 207, 55, 62)),
+                _ => Foreground,
+            };
+        }
+
+        private static LinearGradientBrush StatusGradient(Color start, Color end) => new()
+        {
+            StartPoint = new Point(0, 0),
+            EndPoint = new Point(1, 1),
+            GradientStops = { new GradientStop { Color = start, Offset = 0 }, new GradientStop { Color = end, Offset = 1 } },
+        };
 
         /// <summary>
         /// Badge the provider glyph with its active source (browser, host app, terminal, desktop app).

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -299,14 +299,30 @@ namespace TaskbarQuota.Controls
                     : $"{WidgetTooltipTitle(widgetName, result.Source)} · {plan}\n{string.Join("\n", tooltipLines)}{costTooltip}{resetCreditsTooltip}{staleTooltip}");
         }
 
-        /// <summary>Colors the provider glyph to match its latest independently-discovered agent task.</summary>
-        public void SetAgentActivity(AgentActivityItem? activity)
+        /// <summary>Colors this provider glyph from its own independently-discovered agent tasks.</summary>
+        public void SetAgentActivity(AgentActivitySnapshot snapshot)
         {
-            _agentStatus = activity is not null && activity.Provider == _lastAppliedProvider
-                ? activity.Status
+            var activity = _lastAppliedProvider is { } provider
+                ? snapshot.TrackedItems
+                    .Where(item => item.Provider == provider)
+                    .OrderByDescending(item => item.IsLive)
+                    .ThenByDescending(item => ActivityStatusPriority(item.Status))
+                    .ThenByDescending(item => item.UpdatedAt)
+                    .FirstOrDefault()
                 : null;
+            _agentStatus = activity?.Status;
             UpdateBadgeFill();
         }
+
+        private static int ActivityStatusPriority(AgentActivityStatus status) => status switch
+        {
+            AgentActivityStatus.Working => 5,
+            AgentActivityStatus.Waiting => 4,
+            AgentActivityStatus.Idle => 3,
+            AgentActivityStatus.Failed => 2,
+            AgentActivityStatus.Completed => 1,
+            _ => 0,
+        };
 
         private void UpdateBadgeFill()
             => BadgeGlyph.Fill = AgentActivityVisuals.StatusBrush(_agentStatus, Foreground);

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -295,23 +295,7 @@ namespace TaskbarQuota.Controls
         }
 
         private void UpdateBadgeFill()
-        {
-            BadgeGlyph.Fill = _agentStatus switch
-            {
-                AgentActivityStatus.Working => StatusGradient(Color.FromArgb(255, 82, 196, 255), Color.FromArgb(255, 45, 94, 232)),
-                AgentActivityStatus.Waiting => StatusGradient(Color.FromArgb(255, 255, 202, 92), Color.FromArgb(255, 224, 141, 33)),
-                AgentActivityStatus.Completed => StatusGradient(Color.FromArgb(255, 100, 222, 130), Color.FromArgb(255, 20, 142, 73)),
-                AgentActivityStatus.Failed => StatusGradient(Color.FromArgb(255, 255, 130, 130), Color.FromArgb(255, 207, 55, 62)),
-                _ => Foreground,
-            };
-        }
-
-        private static LinearGradientBrush StatusGradient(Color start, Color end) => new()
-        {
-            StartPoint = new Point(0, 0),
-            EndPoint = new Point(1, 1),
-            GradientStops = { new GradientStop { Color = start, Offset = 0 }, new GradientStop { Color = end, Offset = 1 } },
-        };
+            => BadgeGlyph.Fill = AgentActivityVisuals.StatusBrush(_agentStatus, Foreground);
 
         /// <summary>
         /// Badge the provider glyph with its active source (browser, host app, terminal, desktop app).

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -189,7 +189,7 @@ namespace TaskbarQuota.Controls
             var glyph = TaskbarQuota.ViewModels.Ui.Glyph(result.Id);
             if (glyph != null)
             {
-                SetNormalizedGlyph(BadgeGlyph, glyph, BadgeGlyph.Fill as Brush ?? Foreground, result.Id);
+                SetNormalizedGlyph(BadgeGlyph, glyph, BadgeGlyph.Fill as Brush ?? Foreground);
                 BadgeGlyphBox.Visibility = Visibility.Visible;
                 BadgeText.Visibility = Visibility.Collapsed;
             }
@@ -1356,15 +1356,14 @@ namespace TaskbarQuota.Controls
             };
         }
 
-        private static void SetNormalizedGlyph(
-            Path path, Geometry glyph, Brush foreground, ProviderId? providerId = null)
+        private static void SetNormalizedGlyph(Path path, Geometry glyph, Brush foreground)
         {
             path.Data = glyph;
             path.Fill = foreground;
-            SetNormalizedGlyphTransform(path, providerId);
+            SetNormalizedGlyphTransform(path);
         }
 
-        private static void SetNormalizedGlyphTransform(Path path, ProviderId? providerId = null)
+        private static void SetNormalizedGlyphTransform(Path path)
         {
             var bounds = path.Data?.Bounds ?? Rect.Empty;
             if (bounds.IsEmpty || bounds.Width <= 0 || bounds.Height <= 0)
@@ -1374,12 +1373,11 @@ namespace TaskbarQuota.Controls
             }
 
             double scale = NormalizedGlyphExtent / Math.Max(bounds.Width, bounds.Height);
-            double scaleX = scale * ProviderGlyphRenderer.OpticalScaleX(providerId);
             path.RenderTransform = new CompositeTransform
             {
-                ScaleX = scaleX,
+                ScaleX = scale,
                 ScaleY = scale,
-                TranslateX = (GlyphViewportSize / 2) - ((bounds.X + bounds.Width / 2) * scaleX),
+                TranslateX = (GlyphViewportSize / 2) - ((bounds.X + bounds.Width / 2) * scale),
                 TranslateY = (GlyphViewportSize / 2) - ((bounds.Y + bounds.Height / 2) * scale),
             };
         }

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -75,6 +75,7 @@ namespace TaskbarQuota.Controls
         private UsageResult? _lastResult;
         private ProviderId? _lastAppliedProvider;
         private AgentActivityStatus? _agentStatus;
+        private AgentActivitySnapshot _lastActivitySnapshot = new(Array.Empty<AgentActivityItem>());
         private string? _lastRenderSignature;
         private bool _hasRevealed;
         private bool _isActiveToolVisible = true;
@@ -176,6 +177,7 @@ namespace TaskbarQuota.Controls
             var isFirstReveal = !_hasRevealed;
             var providerChanged = _lastAppliedProvider != result.Id;
             _lastAppliedProvider = result.Id;
+            UpdateActivityStatus();
             _lastRenderSignature = signature;
             _lastResult = result;
             ApplyTaskbarForeground();
@@ -302,9 +304,15 @@ namespace TaskbarQuota.Controls
         /// <summary>Colors this provider glyph from its own independently-discovered agent tasks.</summary>
         public void SetAgentActivity(AgentActivitySnapshot snapshot)
         {
+            _lastActivitySnapshot = snapshot;
+            UpdateActivityStatus();
+        }
+
+        private void UpdateActivityStatus()
+        {
             var activity = _lastAppliedProvider is { } provider
-                ? snapshot.TrackedItems
-                    .Where(item => item.Provider == provider)
+                ? _lastActivitySnapshot.TrackedItems
+                    .Where(item => AreActivityProvidersEquivalent(item.Provider, provider))
                     .OrderByDescending(item => item.IsLive)
                     .ThenByDescending(item => ActivityStatusPriority(item.Status))
                     .ThenByDescending(item => item.UpdatedAt)
@@ -313,6 +321,13 @@ namespace TaskbarQuota.Controls
             _agentStatus = activity?.Status;
             UpdateBadgeFill();
         }
+
+        private static bool AreActivityProvidersEquivalent(ProviderId left, ProviderId right)
+            => left == right
+                || left is ProviderId.Cline or ProviderId.ClinePass
+                    && right is ProviderId.Cline or ProviderId.ClinePass
+                || left is ProviderId.OpenCode or ProviderId.OpenCodeGo
+                    && right is ProviderId.OpenCode or ProviderId.OpenCodeGo;
 
         private static int ActivityStatusPriority(AgentActivityStatus status) => status switch
         {

--- a/src/TaskbarQuota.App/FlyoutLayout.cs
+++ b/src/TaskbarQuota.App/FlyoutLayout.cs
@@ -21,11 +21,11 @@ namespace TaskbarQuota
         public const int MinLogicalWidth = BaseLogicalWidth;
 
         /// <summary>
-        /// Chrome beyond the provider icons, so the strip + settings button fit without clipping the
-        /// gear: bottom-chrome margins (12+12) + strip border &amp; padding (1+4+4+1) + strip/settings
-        /// gap (8) + settings border &amp; button (1+48+1) = 92, plus a few px of slack for rounding.
+        /// Chrome beyond the provider icons, so the strip + activity + settings buttons fit without
+        /// clipping the settings gear: bottom-chrome margins (12+12) + strip border &amp; padding
+        /// (1+4+4+1) + two gaps (8+8) + two utility buttons (1+48+1 each) = 150.
         /// </summary>
-        public const int StripChromeLogicalWidth = 100;
+        public const int StripChromeLogicalWidth = 150;
 
         /// <summary>Extra width reserved for the dashboard detail card inside the frame.</summary>
         public const int DetailContentPadding = 40;

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml
@@ -26,14 +26,25 @@
               Visibility="Collapsed">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
-            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
                 <TextBlock Text="Agent activity"
                            Style="{StaticResource SubtitleTextBlockStyle}"
                            VerticalAlignment="Center"/>
-                <ToggleButton x:Name="ActivityWidgetButton"
+                <ToggleButton x:Name="ActivityMonitoringButton"
                               Grid.Column="1"
+                              MinWidth="88"
+                              VerticalAlignment="Center"
+                              Click="ActivityMonitoringButton_Click"
+                              AutomationProperties.Name="Monitor local agent activity"
+                              AutomationProperties.AutomationId="FlyoutActivityMonitoringButton"
+                              ToolTipService.ToolTip="Monitor local agent activity">
+                    <TextBlock Text="Monitoring"/>
+                </ToggleButton>
+                <ToggleButton x:Name="ActivityWidgetButton"
+                              Grid.Column="2"
                               MinWidth="76"
                               VerticalAlignment="Center"
                               Click="ActivityWidgetButton_Click"
@@ -43,7 +54,25 @@
                     <TextBlock Text="Activity Widget"/>
                 </ToggleButton>
             </Grid>
-            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="0,12,0,0">
+            <TextBlock Grid.Row="1"
+                       Margin="0,8,0,0"
+                       Text="Activity is read and displayed locally on this PC. It is not uploaded to TaskbarQuota."
+                       TextWrapping="Wrap"
+                       Style="{StaticResource CaptionTextBlockStyle}"/>
+            <TextBlock x:Name="ActivityEmptyState"
+                       Grid.Row="2"
+                       Margin="0,24,0,0"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Top"
+                       Text="No recent agent activity"
+                       Style="{StaticResource BodyTextBlockStyle}"/>
+            <ScrollViewer x:Name="ActivityScrollViewer"
+                          Grid.Row="2"
+                          Margin="0,12,0,0"
+                          AutomationProperties.Name="Agent activity list"
+                          AutomationProperties.AutomationId="FlyoutActivityList"
+                          AutomationProperties.LiveSetting="Polite"
+                          VerticalScrollBarVisibility="Auto">
                 <StackPanel x:Name="ActivityList" Spacing="8"/>
             </ScrollViewer>
         </Grid>

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml
@@ -54,11 +54,6 @@
                     <TextBlock Text="Activity Widget"/>
                 </ToggleButton>
             </Grid>
-            <TextBlock Grid.Row="1"
-                       Margin="0,8,0,0"
-                       Text="Activity is read and displayed locally on this PC. It is not uploaded to TaskbarQuota."
-                       TextWrapping="Wrap"
-                       Style="{StaticResource CaptionTextBlockStyle}"/>
             <TextBlock x:Name="ActivityEmptyState"
                        Grid.Row="2"
                        Margin="0,24,0,0"

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml
@@ -28,7 +28,21 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
-            <TextBlock Text="Agent activity" Style="{StaticResource SubtitleTextBlockStyle}"/>
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <TextBlock Text="Agent activity"
+                           Style="{StaticResource SubtitleTextBlockStyle}"
+                           VerticalAlignment="Center"/>
+                <ToggleButton x:Name="ActivityWidgetButton"
+                              Grid.Column="1"
+                              MinWidth="76"
+                              VerticalAlignment="Center"
+                              Click="ActivityWidgetButton_Click"
+                              AutomationProperties.Name="Show agent activity in taskbar widget"
+                              AutomationProperties.AutomationId="FlyoutActivityWidgetButton"
+                              ToolTipService.ToolTip="Show agent activity in taskbar widget">
+                    <TextBlock Text="Activity Widget"/>
+                </ToggleButton>
+            </Grid>
             <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="0,12,0,0">
                 <StackPanel x:Name="ActivityList" Spacing="8"/>
             </ScrollViewer>

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml
@@ -30,6 +30,18 @@
             </Grid.RowDefinitions>
             <StackPanel Orientation="Horizontal" Spacing="8">
                 <TextBlock Text="Agent activity" Style="{StaticResource SubtitleTextBlockStyle}"/>
+                <controls:ProviderAvatar x:Name="ActivityProviderAvatar"
+                                         Width="20"
+                                         Height="20"
+                                         VerticalAlignment="Center"
+                                         ForegroundBrush="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                         Visibility="Collapsed"
+                                         AutomationProperties.Name="Activity provider"/>
+                <TextBlock x:Name="ActivityProviderText"
+                           VerticalAlignment="Center"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           Style="{StaticResource CaptionTextBlockStyle}"
+                           Visibility="Collapsed"/>
                 <TextBlock x:Name="ActivityCountText" VerticalAlignment="Center"
                            Style="{StaticResource CaptionTextBlockStyle}"/>
             </StackPanel>

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml
@@ -28,23 +28,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
-            <StackPanel Orientation="Horizontal" Spacing="8">
-                <TextBlock Text="Agent activity" Style="{StaticResource SubtitleTextBlockStyle}"/>
-                <controls:ProviderAvatar x:Name="ActivityProviderAvatar"
-                                         Width="20"
-                                         Height="20"
-                                         VerticalAlignment="Center"
-                                         ForegroundBrush="{ThemeResource AccentTextFillColorPrimaryBrush}"
-                                         Visibility="Collapsed"
-                                         AutomationProperties.Name="Activity provider"/>
-                <TextBlock x:Name="ActivityProviderText"
-                           VerticalAlignment="Center"
-                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                           Style="{StaticResource CaptionTextBlockStyle}"
-                           Visibility="Collapsed"/>
-                <TextBlock x:Name="ActivityCountText" VerticalAlignment="Center"
-                           Style="{StaticResource CaptionTextBlockStyle}"/>
-            </StackPanel>
+            <TextBlock Text="Agent activity" Style="{StaticResource SubtitleTextBlockStyle}"/>
             <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="0,12,0,0">
                 <StackPanel x:Name="ActivityList" Spacing="8"/>
             </ScrollViewer>

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml
@@ -20,6 +20,24 @@
                VerticalAlignment="Stretch"
                VerticalContentAlignment="Stretch"/>
 
+        <Grid x:Name="ActivityPanel"
+              Grid.Row="0"
+              Padding="16,12,16,8"
+              Visibility="Collapsed">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock Text="Agent activity" Style="{StaticResource SubtitleTextBlockStyle}"/>
+                <TextBlock x:Name="ActivityCountText" VerticalAlignment="Center"
+                           Style="{StaticResource CaptionTextBlockStyle}"/>
+            </StackPanel>
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="0,12,0,0">
+                <StackPanel x:Name="ActivityList" Spacing="8"/>
+            </ScrollViewer>
+        </Grid>
+
         <controls:UpdateActionBar x:Name="UpdateBar"
                                   Grid.Row="1"
                                   Margin="12,0,12,8"/>
@@ -39,6 +57,28 @@
                 <StackPanel x:Name="ProviderStrip"
                             MinHeight="48"
                             Orientation="Horizontal"/>
+            </Border>
+
+            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8">
+                <Button x:Name="ActivityButton"
+                        Width="48"
+                        Height="48"
+                        MinWidth="0"
+                        MinHeight="0"
+                        Padding="0"
+                        BorderThickness="0"
+                        Background="Transparent"
+                        AutomationProperties.Name="Agent activity"
+                        AutomationProperties.AutomationId="FlyoutActivityButton"
+                        Click="ActivityButton_Click"
+                        ToolTipService.ToolTip="Agent activity">
+                    <FontIcon Glyph="&#xE7F4;"
+                              FontSize="16"
+                              Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                </Button>
             </Border>
 
             <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -51,6 +51,7 @@ namespace TaskbarQuota
         public FlyoutWindow()
         {
             InitializeComponent();
+            UpdateActivityWidgetButton();
             _dashboardViewModel = DashboardPage.SharedViewModel ?? new DashboardViewModel(DispatcherQueue);
             DashboardPage.SharedViewModel = _dashboardViewModel;
             _dashboardViewModel.Cards.CollectionChanged += DashboardCards_CollectionChanged;
@@ -106,7 +107,11 @@ namespace TaskbarQuota
         }
 
         private void OnWidgetSettingsChanged(object? sender, EventArgs e)
-            => DispatcherQueue.TryEnqueue(SyncProviderStripPins);
+            => DispatcherQueue.TryEnqueue(() =>
+            {
+                SyncProviderStripPins();
+                UpdateActivityWidgetButton();
+            });
 
         private void OnActivated(object sender, WindowActivatedEventArgs args)
         {
@@ -247,6 +252,17 @@ namespace TaskbarQuota
             _showingActivity = true;
             ActivityPanel.Visibility = Visibility.Visible;
             ContentFrame.Visibility = Visibility.Collapsed;
+            UpdateActivityWidgetButton();
+        }
+
+        private void UpdateActivityWidgetButton()
+        {
+            bool enabled = WidgetSettingsService.ShowAgentActivityInWidget;
+            ActivityWidgetButton.IsChecked = enabled;
+            ToolTipService.SetToolTip(ActivityWidgetButton,
+                enabled ? "Hide agent activity from taskbar widget" : "Show agent activity in taskbar widget");
+            AutomationProperties.SetName(ActivityWidgetButton,
+                enabled ? "Hide agent activity from taskbar widget" : "Show agent activity in taskbar widget");
         }
 
         private void OnActivityChanged(AgentActivitySnapshot snapshot)
@@ -294,6 +310,7 @@ namespace TaskbarQuota
         {
             ProviderId.ClinePass => "Cline Pass",
             ProviderId.OpenCodeGo => "OpenCode Go",
+            ProviderId.Copilot => "GitHub Copilot",
             _ => provider.ToString(),
         };
 
@@ -365,6 +382,13 @@ namespace TaskbarQuota
                 ShowProviderDashboard();
             else
                 ShowActivityPanel();
+        }
+
+        private void ActivityWidgetButton_Click(object sender, RoutedEventArgs e)
+        {
+            WidgetSettingsService.ApplyShowAgentActivityInWidget(
+                !WidgetSettingsService.ShowAgentActivityInWidget);
+            UpdateActivityWidgetButton();
         }
 
         private void RegisterWindowSizeHooks()

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -119,6 +119,17 @@ namespace TaskbarQuota
             ShowAbove(widgetHandle);
         }
 
+        public void ToggleActivityAbove(IntPtr widgetHandle, string? selectedActivityId = null)
+        {
+            if (_shown)
+            {
+                Hide();
+                return;
+            }
+
+            ShowActivityAbove(widgetHandle, selectedActivityId);
+        }
+
         /// <summary>
         /// Compose the first XAML frame and spin up the acrylic backdrop off-screen once, so the first
         /// real open doesn't flash a black slab while WinUI warms up composition.

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -200,8 +200,13 @@ namespace TaskbarQuota
             // Quota normally gets this transfer as a side effect of its provider interaction, so make it
             // explicit for the shared path instead.
             var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            if (hwnd != IntPtr.Zero && User32.GetForegroundWindow() != hwnd)
+            if (hwnd == IntPtr.Zero)
+                return;
+
+            if (User32.GetForegroundWindow() != hwnd)
                 User32.SetForegroundWindow(hwnd);
+            User32.SetActiveWindow(hwnd);
+            User32.SetFocus(hwnd);
         }
 
         private void ShowProviderDashboard()

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -14,6 +14,7 @@ using Microsoft.UI.Xaml.Media.Animation;
 using Windows.Foundation;
 using Windows.Graphics;
 using TaskbarQuota.Controls;
+using TaskbarQuota.AgentActivity;
 using TaskbarQuota.Interop;
 using TaskbarQuota.Services;
 using TaskbarQuota.Usage;
@@ -55,6 +56,7 @@ namespace TaskbarQuota
             _dashboardViewModel.DetailContentHeightChanged += DashboardDetailContentHeightChanged;
             ProviderStrip.Loaded += (_, _) => RebuildProviderStrip();
             WidgetSettingsService.Changed += OnWidgetSettingsChanged;
+            AgentActivityService.Instance.Changed += OnActivityChanged;
 
             SystemBackdrop = new DesktopAcrylicBackdrop();
             ThemeService.Register(Root);
@@ -86,6 +88,7 @@ namespace TaskbarQuota
             Closed -= OnClosed;
             Activated -= OnActivated;
             WidgetSettingsService.Changed -= OnWidgetSettingsChanged;
+            AgentActivityService.Instance.Changed -= OnActivityChanged;
             _dashboardViewModel.Cards.CollectionChanged -= DashboardCards_CollectionChanged;
             _dashboardViewModel.SelectedCardChanged -= DashboardSelectedCardChanged;
             _dashboardViewModel.DetailContentWidthChanged -= DashboardDetailContentWidthChanged;
@@ -146,6 +149,7 @@ namespace TaskbarQuota
         {
             _widgetHandle = widgetHandle;
             EnsureDashboardLoaded();
+            RenderActivity(AgentActivityService.Instance.Snapshot);
 
             // Sync the strip selection to the provider the taskbar widget is currently showing,
             // so opening the tray highlights/details that provider rather than a stale selection.
@@ -159,6 +163,66 @@ namespace TaskbarQuota
             ScheduleFlyoutBoundsUpdate();
 
             _ = UpdateAvailabilityService.Instance.CheckSilentlyAsync();
+        }
+
+        private void OnActivityChanged(AgentActivitySnapshot snapshot)
+            => DispatcherQueue.TryEnqueue(() => RenderActivity(snapshot));
+
+        private void RenderActivity(AgentActivitySnapshot snapshot)
+        {
+            ActivityList.Children.Clear();
+            ActivityCountText.Text = snapshot.Items.Count == 0 ? "" : snapshot.Items.Count.ToString();
+            foreach (var item in snapshot.Items)
+            {
+                var card = new Border
+                {
+                    Padding = new Thickness(12, 8, 12, 8),
+                    CornerRadius = new CornerRadius(8),
+                    Background = (Brush)Application.Current.Resources["CardBackgroundFillColorDefaultBrush"],
+                    BorderBrush = (Brush)Application.Current.Resources["CardStrokeColorDefaultBrush"],
+                    BorderThickness = new Thickness(1),
+                };
+                var row = new Grid { ColumnSpacing = 10 };
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(8) });
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                var dot = new Border
+                {
+                    Width = 8,
+                    Height = 8,
+                    CornerRadius = new CornerRadius(4),
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Background = new SolidColorBrush(item.Status switch
+                    {
+                        AgentActivityStatus.Failed => Colors.Red,
+                        AgentActivityStatus.Waiting => Colors.Orange,
+                        _ => Colors.Green,
+                    }),
+                };
+                Grid.SetColumn(dot, 0);
+                row.Children.Add(dot);
+                var text = new StackPanel { Spacing = 2 };
+                text.Children.Add(new TextBlock { Text = item.Title, Style = (Style)Application.Current.Resources["BodyStrongTextBlockStyle"] });
+                var metadata = string.IsNullOrWhiteSpace(item.Model)
+                    ? $"{item.Provider} · {item.StatusText}"
+                    : $"{item.Provider} · {item.Model} · {item.StatusText}";
+                text.Children.Add(new TextBlock { Text = metadata, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
+                text.Children.Add(new TextBlock { Text = item.Step, TextTrimming = TextTrimming.CharacterEllipsis, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
+                if (item.SubagentCount > 0)
+                    text.Children.Add(new TextBlock { Text = $"▸ {item.SubagentCount} subagents", Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
+                Grid.SetColumn(text, 1);
+                row.Children.Add(text);
+                card.Child = row;
+                ActivityList.Children.Add(card);
+            }
+            ActivityPanel.Visibility = snapshot.Items.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
+            ContentFrame.Visibility = snapshot.Items.Count > 0 ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        private void ActivityButton_Click(object sender, RoutedEventArgs e)
+        {
+            var showActivity = ActivityPanel.Visibility != Visibility.Visible;
+            ActivityPanel.Visibility = showActivity ? Visibility.Visible : Visibility.Collapsed;
+            ContentFrame.Visibility = showActivity ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void RegisterWindowSizeHooks()

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -115,13 +115,18 @@ namespace TaskbarQuota
 
         public void ToggleAbove(IntPtr widgetHandle)
         {
-            if (_shown) { Hide(); return; }
+            if (_shown && !_showingActivity)
+            {
+                Hide();
+                return;
+            }
+
             ShowAbove(widgetHandle);
         }
 
         public void ToggleActivityAbove(IntPtr widgetHandle, string? selectedActivityId = null)
         {
-            if (_shown)
+            if (_shown && _showingActivity && _selectedActivityId == selectedActivityId)
             {
                 Hide();
                 return;
@@ -245,52 +250,6 @@ namespace TaskbarQuota
         private void RenderActivity(AgentActivitySnapshot snapshot)
         {
             ActivityList.Children.Clear();
-            ActivityCountText.Text = snapshot.Items.Count == 0 ? "" : snapshot.Items.Count.ToString();
-
-            var primary = snapshot.Primary;
-            var selected = _selectedActivityId is { Length: > 0 } selectedId
-                ? snapshot.TrackedItems.FirstOrDefault(item => item.Id == selectedId)
-                : null;
-            var headerItem = selected ?? primary;
-            if (headerItem is { } primaryItem)
-            {
-                var providerName = ActivityProviderDisplayName(primaryItem.Provider);
-                var providerCount = snapshot.Items
-                    .Select(item => item.Provider)
-                    .Distinct()
-                    .Count();
-                // The activity panel is keyed to the selected agent, not the foreground quota provider.
-                // Keep its glyph visible even when both happen to use the same provider.
-                bool showProviderMarker = true;
-
-                ActivityProviderAvatar.ProviderId = primaryItem.Provider;
-                ActivityProviderAvatar.Initial = providerName.Length > 0 ? providerName[0].ToString() : "?";
-                ActivityProviderAvatar.ForegroundBrush =
-                    (Brush)Application.Current.Resources["AccentTextFillColorPrimaryBrush"];
-                ActivityProviderAvatar.Visibility = showProviderMarker
-                    ? Visibility.Visible
-                    : Visibility.Collapsed;
-                var primaryLabel = ActivityProviderLabel(primaryItem);
-                ActivityProviderText.Text = providerCount > 1
-                    ? $"{primaryLabel} + {providerCount - 1}"
-                    : primaryLabel;
-                ActivityProviderText.Visibility = showProviderMarker
-                    ? Visibility.Visible
-                    : Visibility.Collapsed;
-                ToolTipService.SetToolTip(
-                    ActivityProviderAvatar,
-                    !showProviderMarker
-                        ? null
-                        : providerCount > 1
-                        ? $"Agent activity from multiple providers; most recent: {primaryLabel}"
-                        : $"Agent activity from {primaryLabel}");
-            }
-            else
-            {
-                ActivityProviderAvatar.Visibility = Visibility.Collapsed;
-                ActivityProviderText.Visibility = Visibility.Collapsed;
-                ToolTipService.SetToolTip(ActivityProviderAvatar, null);
-            }
 
             foreach (var item in snapshot.Items)
             {

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -253,8 +253,9 @@ namespace TaskbarQuota
                 var metadata = string.IsNullOrWhiteSpace(item.Model)
                     ? $"{ActivityProviderLabel(item)} · {item.StatusText}"
                     : $"{ActivityProviderLabel(item)} · {item.Model} · {item.StatusText}";
-                text.Children.Add(new TextBlock { Text = metadata, Foreground = statusBrush, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
-                text.Children.Add(new TextBlock { Text = item.Step, Foreground = statusBrush, TextTrimming = TextTrimming.CharacterEllipsis, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
+                var mutedTextBrush = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"];
+                text.Children.Add(new TextBlock { Text = metadata, Foreground = mutedTextBrush, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
+                text.Children.Add(new TextBlock { Text = item.Step, Foreground = mutedTextBrush, TextTrimming = TextTrimming.CharacterEllipsis, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
                 if (item.SubagentCount > 0)
                     text.Children.Add(new TextBlock { Text = $"▸ {item.SubagentCount} subagents", Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
                 Grid.SetColumn(text, 1);

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -203,10 +203,26 @@ namespace TaskbarQuota
             if (hwnd == IntPtr.Zero)
                 return;
 
-            if (User32.GetForegroundWindow() != hwnd)
-                User32.SetForegroundWindow(hwnd);
-            User32.SetActiveWindow(hwnd);
-            User32.SetFocus(hwnd);
+            var foreground = User32.GetForegroundWindow();
+            var foregroundThread = foreground == IntPtr.Zero
+                ? 0u
+                : User32.GetWindowThreadProcessId(foreground, out _);
+            var currentThread = User32.GetCurrentThreadId();
+            bool attached = foregroundThread != 0
+                && foregroundThread != currentThread
+                && User32.AttachThreadInput(foregroundThread, currentThread, true);
+            try
+            {
+                if (User32.GetForegroundWindow() != hwnd)
+                    User32.SetForegroundWindow(hwnd);
+                User32.SetActiveWindow(hwnd);
+                User32.SetFocus(hwnd);
+            }
+            finally
+            {
+                if (attached)
+                    User32.AttachThreadInput(foregroundThread, currentThread, false);
+            }
         }
 
         private void ShowProviderDashboard()

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -233,6 +233,9 @@ namespace TaskbarQuota
 
             foreach (var item in snapshot.Items)
             {
+                var statusBrush = AgentActivityVisuals.StatusBrush(
+                    item.Status,
+                    (Brush)Application.Current.Resources["TextFillColorPrimaryBrush"]);
                 var card = new Border
                 {
                     Padding = new Thickness(12, 8, 12, 8),
@@ -250,8 +253,8 @@ namespace TaskbarQuota
                 var metadata = string.IsNullOrWhiteSpace(item.Model)
                     ? $"{ActivityProviderLabel(item)} · {item.StatusText}"
                     : $"{ActivityProviderLabel(item)} · {item.Model} · {item.StatusText}";
-                text.Children.Add(new TextBlock { Text = metadata, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
-                text.Children.Add(new TextBlock { Text = item.Step, TextTrimming = TextTrimming.CharacterEllipsis, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
+                text.Children.Add(new TextBlock { Text = metadata, Foreground = statusBrush, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
+                text.Children.Add(new TextBlock { Text = item.Step, Foreground = statusBrush, TextTrimming = TextTrimming.CharacterEllipsis, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
                 if (item.SubagentCount > 0)
                     text.Children.Add(new TextBlock { Text = $"▸ {item.SubagentCount} subagents", Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
                 Grid.SetColumn(text, 1);
@@ -305,13 +308,7 @@ namespace TaskbarQuota
                 CornerRadius = new CornerRadius(3),
                 HorizontalAlignment = HorizontalAlignment.Left,
                 VerticalAlignment = VerticalAlignment.Bottom,
-                Background = new SolidColorBrush(item.Status switch
-                {
-                    AgentActivityStatus.Failed => Colors.Red,
-                    AgentActivityStatus.Waiting => Colors.Orange,
-                    AgentActivityStatus.Completed => Colors.LimeGreen,
-                    _ => Colors.DodgerBlue,
-                }),
+                Background = foreground,
             };
             visual.Children.Add(dot);
 

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -148,10 +148,19 @@ namespace TaskbarQuota
         }
 
         public void ShowAbove(IntPtr widgetHandle)
+            => ShowAbove(widgetHandle, showActivity: false);
+
+        public void ShowActivityAbove(IntPtr widgetHandle)
+            => ShowAbove(widgetHandle, showActivity: true);
+
+        private void ShowAbove(IntPtr widgetHandle, bool showActivity)
         {
             _widgetHandle = widgetHandle;
             EnsureDashboardLoaded();
-            ShowProviderDashboard();
+            if (showActivity)
+                ShowActivityPanel();
+            else
+                ShowProviderDashboard();
             RenderActivity(AgentActivityService.Instance.Snapshot);
 
             // Sync the strip selection to the provider the taskbar widget is currently showing,

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -74,7 +74,12 @@ namespace TaskbarQuota
 
             var presenter = OverlappedPresenter.CreateForContextMenu();
             presenter.IsAlwaysOnTop = true;
-            GetAppWindow().SetPresenter(presenter);
+            var appWindow = GetAppWindow();
+            // The flyout is transient taskbar UI, not an application window. Keep it out of the
+            // taskbar/Alt+Tab representation; the main window opts in only when Settings or the app
+            // itself is explicitly opened.
+            appWindow.IsShownInSwitchers = false;
+            appWindow.SetPresenter(presenter);
 
             Activated += OnActivated;
             Closed += OnClosed;

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -157,7 +157,14 @@ namespace TaskbarQuota
         public void ShowActivityAbove(IntPtr widgetHandle, string? selectedActivityId = null)
         {
             _selectedActivityId = selectedActivityId;
-            ShowAbove(widgetHandle, showActivity: true);
+            // Present the same initialized surface as a normal provider open before switching to the
+            // activity layer. This primes DesktopAcrylic on a first open; showing ActivityPanel as the
+            // first-ever surface can otherwise produce a blank, non-composited window until the user
+            // opens the provider dashboard once.
+            ShowAbove(widgetHandle, showActivity: false);
+            ShowActivityPanel();
+            RenderActivity(AgentActivityService.Instance.Snapshot);
+            ScheduleFlyoutBoundsUpdate();
         }
 
         private void ShowAbove(IntPtr widgetHandle, bool showActivity)

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -184,10 +184,24 @@ namespace TaskbarQuota
             _shown = true;
             ApplyFlyoutBounds();
             GetAppWindow().Show();
-            Activate();
+            ActivateFlyout();
             ScheduleFlyoutBoundsUpdate();
 
             _ = UpdateAvailabilityService.Instance.CheckSilentlyAsync();
+        }
+
+        private void ActivateFlyout()
+        {
+            Activate();
+
+            // Activity can be opened directly from the injected taskbar island. In that path WinUI's
+            // Activate() is not always enough to transfer foreground ownership from Explorer, leaving
+            // DesktopAcrylic in its inactive/transparent state until the user clicks the flyout again.
+            // Quota normally gets this transfer as a side effect of its provider interaction, so make it
+            // explicit for the shared path instead.
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            if (hwnd != IntPtr.Zero && User32.GetForegroundWindow() != hwnd)
+                User32.SetForegroundWindow(hwnd);
         }
 
         private void ShowProviderDashboard()

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -51,7 +51,7 @@ namespace TaskbarQuota
         public FlyoutWindow()
         {
             InitializeComponent();
-            UpdateActivityWidgetButton();
+            UpdateActivityControls();
             _dashboardViewModel = DashboardPage.SharedViewModel ?? new DashboardViewModel(DispatcherQueue);
             DashboardPage.SharedViewModel = _dashboardViewModel;
             _dashboardViewModel.Cards.CollectionChanged += DashboardCards_CollectionChanged;
@@ -102,7 +102,7 @@ namespace TaskbarQuota
             _dashboardViewModel.SelectedCardChanged -= DashboardSelectedCardChanged;
             _dashboardViewModel.DetailContentWidthChanged -= DashboardDetailContentWidthChanged;
             _dashboardViewModel.DetailContentHeightChanged -= DashboardDetailContentHeightChanged;
-            _boundsUpdateTimer.Stop();
+            _boundsUpdateTimer?.Stop();
             _providerStripItems.Clear();
         }
 
@@ -110,7 +110,7 @@ namespace TaskbarQuota
             => DispatcherQueue.TryEnqueue(() =>
             {
                 SyncProviderStripPins();
-                UpdateActivityWidgetButton();
+                UpdateActivityControls();
             });
 
         private void OnActivated(object sender, WindowActivatedEventArgs args)
@@ -242,6 +242,8 @@ namespace TaskbarQuota
 
         private void ShowProviderDashboard()
         {
+            if (_showingActivity)
+                AgentActivityService.Instance.AcknowledgeAll();
             _showingActivity = false;
             ActivityPanel.Visibility = Visibility.Collapsed;
             ContentFrame.Visibility = Visibility.Visible;
@@ -252,17 +254,24 @@ namespace TaskbarQuota
             _showingActivity = true;
             ActivityPanel.Visibility = Visibility.Visible;
             ContentFrame.Visibility = Visibility.Collapsed;
-            UpdateActivityWidgetButton();
+            UpdateActivityControls();
         }
 
-        private void UpdateActivityWidgetButton()
+        private void UpdateActivityControls()
         {
-            bool enabled = WidgetSettingsService.ShowAgentActivityInWidget;
-            ActivityWidgetButton.IsChecked = enabled;
+            bool widgetEnabled = WidgetSettingsService.ShowAgentActivityInWidget;
+            bool monitoringEnabled = WidgetSettingsService.EnableAgentActivityMonitoring;
+            ActivityWidgetButton.IsChecked = widgetEnabled;
+            ActivityWidgetButton.IsEnabled = monitoringEnabled;
+            ActivityMonitoringButton.IsChecked = monitoringEnabled;
             ToolTipService.SetToolTip(ActivityWidgetButton,
-                enabled ? "Hide agent activity from taskbar widget" : "Show agent activity in taskbar widget");
+                widgetEnabled ? "Hide agent activity from taskbar widget" : "Show agent activity in taskbar widget");
             AutomationProperties.SetName(ActivityWidgetButton,
-                enabled ? "Hide agent activity from taskbar widget" : "Show agent activity in taskbar widget");
+                widgetEnabled ? "Hide agent activity from taskbar widget" : "Show agent activity in taskbar widget");
+            ToolTipService.SetToolTip(ActivityMonitoringButton,
+                monitoringEnabled ? "Stop monitoring local agent activity" : "Start monitoring local agent activity");
+            AutomationProperties.SetName(ActivityMonitoringButton,
+                monitoringEnabled ? "Stop monitoring local agent activity" : "Start monitoring local agent activity");
         }
 
         private void OnActivityChanged(AgentActivitySnapshot snapshot)
@@ -271,8 +280,14 @@ namespace TaskbarQuota
         private void RenderActivity(AgentActivitySnapshot snapshot)
         {
             ActivityList.Children.Clear();
+            var items = snapshot.ItemsForDisplay(_selectedActivityId);
+            bool monitoringEnabled = WidgetSettingsService.EnableAgentActivityMonitoring;
+            ActivityEmptyState.Text = monitoringEnabled ? "No recent agent activity" : "Agent activity monitoring is off";
+            ActivityEmptyState.Visibility = items.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            ActivityScrollViewer.Visibility = items.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
+            FrameworkElement? selectedCard = null;
 
-            foreach (var item in snapshot.Items)
+            foreach (var item in items)
             {
                 var statusBrush = AgentActivityVisuals.StatusBrush(
                     item.Status,
@@ -285,6 +300,16 @@ namespace TaskbarQuota
                     BorderBrush = (Brush)Application.Current.Resources["CardStrokeColorDefaultBrush"],
                     BorderThickness = new Thickness(1),
                 };
+                var accessibleName = $"{ActivityTitle(item)}, {ActivityProviderLabel(item)}, {item.StatusText}. {item.Step}";
+                AutomationProperties.SetName(card, accessibleName);
+                AutomationProperties.SetAutomationId(card, $"AgentActivityCard_{ActivityList.Children.Count}");
+                if (item.Id == _selectedActivityId)
+                {
+                    card.BorderBrush = (Brush)Application.Current.Resources["AccentFillColorDefaultBrush"];
+                    card.BorderThickness = new Thickness(2);
+                    selectedCard = card;
+                    AutomationProperties.SetName(ActivityScrollViewer, $"Selected agent activity. {accessibleName}");
+                }
                 var row = new Grid { ColumnSpacing = 10 };
                 row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(32) });
                 row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
@@ -303,6 +328,15 @@ namespace TaskbarQuota
                 row.Children.Add(text);
                 card.Child = row;
                 ActivityList.Children.Add(card);
+            }
+
+            if (_showingActivity && selectedCard is not null)
+            {
+                DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () =>
+                {
+                    selectedCard.StartBringIntoView(new BringIntoViewOptions { AnimationDesired = true });
+                    ActivityScrollViewer.Focus(FocusState.Programmatic);
+                });
             }
         }
 
@@ -388,7 +422,15 @@ namespace TaskbarQuota
         {
             WidgetSettingsService.ApplyShowAgentActivityInWidget(
                 !WidgetSettingsService.ShowAgentActivityInWidget);
-            UpdateActivityWidgetButton();
+            UpdateActivityControls();
+        }
+
+        private void ActivityMonitoringButton_Click(object sender, RoutedEventArgs e)
+        {
+            WidgetSettingsService.ApplyEnableAgentActivityMonitoring(
+                !WidgetSettingsService.EnableAgentActivityMonitoring);
+            UpdateActivityControls();
+            RenderActivity(AgentActivityService.Instance.Snapshot);
         }
 
         private void RegisterWindowSizeHooks()
@@ -519,6 +561,8 @@ namespace TaskbarQuota
             _shown = false;
             _lastAppliedBounds = null;
             GetAppWindow().Hide();
+            if (_showingActivity)
+                AgentActivityService.Instance.AcknowledgeAll();
         }
 
         private void DashboardCards_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -160,27 +160,15 @@ namespace TaskbarQuota
         }
 
         public void ShowAbove(IntPtr widgetHandle)
-        {
-            _selectedActivityId = null;
-            ShowAbove(widgetHandle, showActivity: false);
-        }
+            => ShowSurfaceAbove(widgetHandle, showActivity: false, selectedActivityId: null);
 
         public void ShowActivityAbove(IntPtr widgetHandle, string? selectedActivityId = null)
-        {
-            _selectedActivityId = selectedActivityId;
-            // Present the same initialized surface as a normal provider open before switching to the
-            // activity layer. This primes DesktopAcrylic on a first open; showing ActivityPanel as the
-            // first-ever surface can otherwise produce a blank, non-composited window until the user
-            // opens the provider dashboard once.
-            ShowAbove(widgetHandle, showActivity: false);
-            ShowActivityPanel();
-            RenderActivity(AgentActivityService.Instance.Snapshot);
-            ScheduleFlyoutBoundsUpdate();
-        }
+            => ShowSurfaceAbove(widgetHandle, showActivity: true, selectedActivityId);
 
-        private void ShowAbove(IntPtr widgetHandle, bool showActivity)
+        private void ShowSurfaceAbove(IntPtr widgetHandle, bool showActivity, string? selectedActivityId)
         {
             _widgetHandle = widgetHandle;
+            _selectedActivityId = showActivity ? selectedActivityId : null;
             EnsureDashboardLoaded();
             if (showActivity)
                 ShowActivityPanel();

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -8,6 +8,7 @@ using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Shapes;
 
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
@@ -33,6 +34,7 @@ namespace TaskbarQuota
         private bool _shown;
         private bool _prewarmed;
         private bool _dashboardLoaded;
+        private bool _showingActivity;
         private bool _sizeHooksRegistered;
         private bool _applyingBounds;
         private DispatcherQueueTimer? _boundsUpdateTimer;
@@ -149,6 +151,7 @@ namespace TaskbarQuota
         {
             _widgetHandle = widgetHandle;
             EnsureDashboardLoaded();
+            ShowProviderDashboard();
             RenderActivity(AgentActivityService.Instance.Snapshot);
 
             // Sync the strip selection to the provider the taskbar widget is currently showing,
@@ -165,6 +168,20 @@ namespace TaskbarQuota
             _ = UpdateAvailabilityService.Instance.CheckSilentlyAsync();
         }
 
+        private void ShowProviderDashboard()
+        {
+            _showingActivity = false;
+            ActivityPanel.Visibility = Visibility.Collapsed;
+            ContentFrame.Visibility = Visibility.Visible;
+        }
+
+        private void ShowActivityPanel()
+        {
+            _showingActivity = true;
+            ActivityPanel.Visibility = Visibility.Visible;
+            ContentFrame.Visibility = Visibility.Collapsed;
+        }
+
         private void OnActivityChanged(AgentActivitySnapshot snapshot)
             => DispatcherQueue.TryEnqueue(() => RenderActivity(snapshot));
 
@@ -172,6 +189,48 @@ namespace TaskbarQuota
         {
             ActivityList.Children.Clear();
             ActivityCountText.Text = snapshot.Items.Count == 0 ? "" : snapshot.Items.Count.ToString();
+
+            var primary = snapshot.Primary;
+            if (primary is { } primaryItem)
+            {
+                var providerName = ActivityProviderDisplayName(primaryItem.Provider);
+                var providerCount = snapshot.Items
+                    .Select(item => item.Provider)
+                    .Distinct()
+                    .Count();
+                bool showProviderMarker = providerCount > 1
+                    || primaryItem.Provider != UsageCoordinator.Instance.ActiveProvider;
+
+                ActivityProviderAvatar.ProviderId = primaryItem.Provider;
+                ActivityProviderAvatar.Initial = providerName.Length > 0 ? providerName[0].ToString() : "?";
+                ActivityProviderAvatar.ForegroundBrush = AgentActivityVisuals.StatusBrush(
+                    primaryItem.Status,
+                    ActivityProviderAvatar.ForegroundBrush ?? (Brush)Application.Current.Resources["AccentTextFillColorPrimaryBrush"]);
+                ActivityProviderAvatar.Visibility = showProviderMarker
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
+                var primaryLabel = ActivityProviderLabel(primaryItem);
+                ActivityProviderText.Text = providerCount > 1
+                    ? $"{primaryLabel} + {providerCount - 1}"
+                    : primaryLabel;
+                ActivityProviderText.Visibility = showProviderMarker
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
+                ToolTipService.SetToolTip(
+                    ActivityProviderAvatar,
+                    !showProviderMarker
+                        ? null
+                        : providerCount > 1
+                        ? $"Agent activity from multiple providers; most recent: {primaryLabel}"
+                        : $"Agent activity from {primaryLabel}");
+            }
+            else
+            {
+                ActivityProviderAvatar.Visibility = Visibility.Collapsed;
+                ActivityProviderText.Visibility = Visibility.Collapsed;
+                ToolTipService.SetToolTip(ActivityProviderAvatar, null);
+            }
+
             foreach (var item in snapshot.Items)
             {
                 var card = new Border
@@ -183,28 +242,14 @@ namespace TaskbarQuota
                     BorderThickness = new Thickness(1),
                 };
                 var row = new Grid { ColumnSpacing = 10 };
-                row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(8) });
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(32) });
                 row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-                var dot = new Border
-                {
-                    Width = 8,
-                    Height = 8,
-                    CornerRadius = new CornerRadius(4),
-                    VerticalAlignment = VerticalAlignment.Center,
-                    Background = new SolidColorBrush(item.Status switch
-                    {
-                        AgentActivityStatus.Failed => Colors.Red,
-                        AgentActivityStatus.Waiting => Colors.Orange,
-                        _ => Colors.Green,
-                    }),
-                };
-                Grid.SetColumn(dot, 0);
-                row.Children.Add(dot);
+                row.Children.Add(CreateActivityProviderVisual(item));
                 var text = new StackPanel { Spacing = 2 };
-                text.Children.Add(new TextBlock { Text = item.Title, Style = (Style)Application.Current.Resources["BodyStrongTextBlockStyle"] });
+                text.Children.Add(new TextBlock { Text = ActivityTitle(item), Style = (Style)Application.Current.Resources["BodyStrongTextBlockStyle"] });
                 var metadata = string.IsNullOrWhiteSpace(item.Model)
-                    ? $"{item.Provider} · {item.StatusText}"
-                    : $"{item.Provider} · {item.Model} · {item.StatusText}";
+                    ? $"{ActivityProviderLabel(item)} · {item.StatusText}"
+                    : $"{ActivityProviderLabel(item)} · {item.Model} · {item.StatusText}";
                 text.Children.Add(new TextBlock { Text = metadata, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
                 text.Children.Add(new TextBlock { Text = item.Step, TextTrimming = TextTrimming.CharacterEllipsis, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
                 if (item.SubagentCount > 0)
@@ -214,15 +259,89 @@ namespace TaskbarQuota
                 card.Child = row;
                 ActivityList.Children.Add(card);
             }
-            ActivityPanel.Visibility = snapshot.Items.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
-            ContentFrame.Visibility = snapshot.Items.Count > 0 ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        private static string ActivityProviderDisplayName(ProviderId provider) => provider switch
+        {
+            ProviderId.ClinePass => "Cline Pass",
+            ProviderId.OpenCodeGo => "OpenCode Go",
+            _ => provider.ToString(),
+        };
+
+        private static string ActivityProviderLabel(AgentActivityItem item)
+        {
+            var provider = ActivityProviderDisplayName(item.Provider);
+            return string.IsNullOrWhiteSpace(item.Host) ? provider : $"{provider} through {item.Host}";
+        }
+
+        private static string ActivityTitle(AgentActivityItem item)
+            => !string.IsNullOrWhiteSpace(item.Host)
+                && string.Equals(item.Title, ActivityProviderDisplayName(item.Provider), StringComparison.OrdinalIgnoreCase)
+                ? ActivityProviderLabel(item)
+                : item.Title;
+
+        private static FrameworkElement CreateActivityProviderVisual(AgentActivityItem item)
+        {
+            var visual = new Grid { Width = 30, Height = 24 };
+            var foreground = AgentActivityVisuals.StatusBrush(
+                item.Status,
+                (Brush)Application.Current.Resources["TextFillColorPrimaryBrush"]);
+            var avatar = new ProviderAvatar
+            {
+                Width = 22,
+                Height = 22,
+                ProviderId = item.Provider,
+                Initial = ActivityProviderDisplayName(item.Provider) is { Length: > 0 } name ? name[0].ToString() : "?",
+                ForegroundBrush = foreground,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            visual.Children.Add(avatar);
+
+            var dot = new Border
+            {
+                Width = 6,
+                Height = 6,
+                CornerRadius = new CornerRadius(3),
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Bottom,
+                Background = new SolidColorBrush(item.Status switch
+                {
+                    AgentActivityStatus.Failed => Colors.Red,
+                    AgentActivityStatus.Waiting => Colors.Orange,
+                    AgentActivityStatus.Completed => Colors.LimeGreen,
+                    _ => Colors.DodgerBlue,
+                }),
+            };
+            visual.Children.Add(dot);
+
+            if (string.Equals(item.Host, "T3 Code", StringComparison.OrdinalIgnoreCase)
+                && Ui.ParseFreshGeometry(ProviderGlyphs.T3Code) is { } t3Glyph)
+            {
+                var hostMark = new Path
+                {
+                    Width = 11,
+                    Height = 11,
+                    Data = t3Glyph,
+                    Stretch = Stretch.Uniform,
+                    Fill = new SolidColorBrush(Colors.White),
+                    HorizontalAlignment = HorizontalAlignment.Right,
+                    VerticalAlignment = VerticalAlignment.Bottom,
+                };
+                visual.Children.Add(hostMark);
+            }
+
+            ToolTipService.SetToolTip(visual, ActivityProviderLabel(item));
+            Grid.SetColumn(visual, 0);
+            return visual;
         }
 
         private void ActivityButton_Click(object sender, RoutedEventArgs e)
         {
-            var showActivity = ActivityPanel.Visibility != Visibility.Visible;
-            ActivityPanel.Visibility = showActivity ? Visibility.Visible : Visibility.Collapsed;
-            ContentFrame.Visibility = showActivity ? Visibility.Collapsed : Visibility.Visible;
+            if (_showingActivity)
+                ShowProviderDashboard();
+            else
+                ShowActivityPanel();
         }
 
         private void RegisterWindowSizeHooks()
@@ -497,7 +616,10 @@ namespace TaskbarQuota
         private void ProviderStripButton_Click(object sender, RoutedEventArgs e)
         {
             if (sender is Button { Tag: ProviderId providerId })
+            {
+                ShowProviderDashboard();
                 _dashboardViewModel.SelectProvider(providerId);
+            }
         }
 
         private void SettingsButton_Click(object sender, RoutedEventArgs e)

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -34,6 +34,7 @@ namespace TaskbarQuota
         private bool _shown;
         private bool _prewarmed;
         private bool _dashboardLoaded;
+        private string? _selectedActivityId;
         private bool _showingActivity;
         private bool _sizeHooksRegistered;
         private bool _applyingBounds;
@@ -148,10 +149,16 @@ namespace TaskbarQuota
         }
 
         public void ShowAbove(IntPtr widgetHandle)
-            => ShowAbove(widgetHandle, showActivity: false);
+        {
+            _selectedActivityId = null;
+            ShowAbove(widgetHandle, showActivity: false);
+        }
 
-        public void ShowActivityAbove(IntPtr widgetHandle)
-            => ShowAbove(widgetHandle, showActivity: true);
+        public void ShowActivityAbove(IntPtr widgetHandle, string? selectedActivityId = null)
+        {
+            _selectedActivityId = selectedActivityId;
+            ShowAbove(widgetHandle, showActivity: true);
+        }
 
         private void ShowAbove(IntPtr widgetHandle, bool showActivity)
         {
@@ -200,21 +207,25 @@ namespace TaskbarQuota
             ActivityCountText.Text = snapshot.Items.Count == 0 ? "" : snapshot.Items.Count.ToString();
 
             var primary = snapshot.Primary;
-            if (primary is { } primaryItem)
+            var selected = _selectedActivityId is { Length: > 0 } selectedId
+                ? snapshot.TrackedItems.FirstOrDefault(item => item.Id == selectedId)
+                : null;
+            var headerItem = selected ?? primary;
+            if (headerItem is { } primaryItem)
             {
                 var providerName = ActivityProviderDisplayName(primaryItem.Provider);
                 var providerCount = snapshot.Items
                     .Select(item => item.Provider)
                     .Distinct()
                     .Count();
-                bool showProviderMarker = providerCount > 1
-                    || primaryItem.Provider != UsageCoordinator.Instance.ActiveProvider;
+                // The activity panel is keyed to the selected agent, not the foreground quota provider.
+                // Keep its glyph visible even when both happen to use the same provider.
+                bool showProviderMarker = true;
 
                 ActivityProviderAvatar.ProviderId = primaryItem.Provider;
                 ActivityProviderAvatar.Initial = providerName.Length > 0 ? providerName[0].ToString() : "?";
-                ActivityProviderAvatar.ForegroundBrush = AgentActivityVisuals.StatusBrush(
-                    primaryItem.Status,
-                    ActivityProviderAvatar.ForegroundBrush ?? (Brush)Application.Current.Resources["AccentTextFillColorPrimaryBrush"]);
+                ActivityProviderAvatar.ForegroundBrush =
+                    (Brush)Application.Current.Resources["AccentTextFillColorPrimaryBrush"];
                 ActivityProviderAvatar.Visibility = showProviderMarker
                     ? Visibility.Visible
                     : Visibility.Collapsed;

--- a/src/TaskbarQuota.App/Interop/Native.cs
+++ b/src/TaskbarQuota.App/Interop/Native.cs
@@ -121,6 +121,13 @@ namespace TaskbarQuota.Interop
         [DllImport("user32.dll", SetLastError = true)]
         public static extern IntPtr SetFocus([In] IntPtr hWnd);
 
+        [DllImport("kernel32.dll")]
+        public static extern uint GetCurrentThreadId();
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, [MarshalAs(UnmanagedType.Bool)] bool fAttach);
+
         [DllImport("user32.dll", SetLastError = true)]
         public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 

--- a/src/TaskbarQuota.App/Interop/Native.cs
+++ b/src/TaskbarQuota.App/Interop/Native.cs
@@ -116,6 +116,12 @@ namespace TaskbarQuota.Interop
         public static extern bool SetForegroundWindow([In] IntPtr hWnd);
 
         [DllImport("user32.dll", SetLastError = true)]
+        public static extern IntPtr SetActiveWindow([In] IntPtr hWnd);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern IntPtr SetFocus([In] IntPtr hWnd);
+
+        [DllImport("user32.dll", SetLastError = true)]
         public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 
         [DllImport("user32.dll")]

--- a/src/TaskbarQuota.App/Interop/Native.cs
+++ b/src/TaskbarQuota.App/Interop/Native.cs
@@ -109,6 +109,9 @@ namespace TaskbarQuota.Interop
         [DllImport("user32.dll", SetLastError = true)]
         public static extern bool GetCursorPos([Out] out POINT lpPoint);
 
+        [DllImport("user32.dll")]
+        public static extern short GetAsyncKeyState(int vKey);
+
         [DllImport("user32.dll", SetLastError = true)]
         public static extern IntPtr GetForegroundWindow();
 

--- a/src/TaskbarQuota.App/Services/PinBudgetService.cs
+++ b/src/TaskbarQuota.App/Services/PinBudgetService.cs
@@ -107,9 +107,9 @@ public static class PinBudgetService
         var pinned = PinnedProviders();
         string name = ProviderName(provider);
 
-        if (pinned.Count >= UsageCoordinator.MaxWidgetTiles)
+        if (pinned.Count >= UsageCoordinator.MaxDisplayedWidgetTiles)
         {
-            reason = $"The taskbar can show at most {UsageCoordinator.MaxWidgetTiles} providers at once, and you already "
+            reason = $"The taskbar can show at most {UsageCoordinator.MaxDisplayedWidgetTiles} quota providers at once, and you already "
                 + $"have {string.Join(", ", pinned.Select(ProviderName))} pinned. Unpin one of those to make room for {name}.";
             return false;
         }
@@ -180,7 +180,7 @@ public static class PinBudgetService
         var dropped = new List<ProviderId>();
         foreach (var provider in order)
         {
-            if (keeping.Count <= UsageCoordinator.MaxWidgetTiles
+            if (keeping.Count <= UsageCoordinator.MaxDisplayedWidgetTiles
                 && FitsTaskbar(keeping, Taskbar.TaskbarSpace.AvailableLogicalWidth))
             {
                 break;
@@ -216,6 +216,7 @@ public static class PinBudgetService
     {
         var hash = new HashCode();
         hash.Add(Taskbar.TaskbarSpace.AvailableLogicalWidth);
+        hash.Add(UsageCoordinator.MaxDisplayedWidgetTiles);
         foreach (var provider in AllProviders)
         {
             if (!WidgetSettingsService.IsProviderPinned(provider))

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -62,6 +62,8 @@ public static class WidgetSettingsService
 
     private static readonly string ShowAgentActivityInWidgetPath =
         Path.Combine(AppStorage.AppDataDirectory, "show-agent-activity-in-widget.txt");
+    private static readonly string EnableAgentActivityMonitoringPath =
+        Path.Combine(AppStorage.AppDataDirectory, "enable-agent-activity-monitoring.txt");
 
     private static readonly Dictionary<string, bool> RowVisibility = LoadRowVisibility();
     private static readonly Dictionary<string, bool> ProviderVisibility = LoadProviderVisibility();
@@ -80,6 +82,8 @@ public static class WidgetSettingsService
     public static bool HideWhenProviderUnfocused { get; private set; } = LoadHideWhenUnfocused();
     /// <summary>Whether the separate Agent Activity island is shown on the taskbar. Enabled by default.</summary>
     public static bool ShowAgentActivityInWidget { get; private set; } = LoadShowAgentActivityInWidget();
+    /// <summary>Whether local agent processes and transcript stores are inspected for activity visualization.</summary>
+    public static bool EnableAgentActivityMonitoring { get; private set; } = LoadEnableAgentActivityMonitoring();
     public static event EventHandler? Changed;
     public static event EventHandler? DashboardCompositionChanged;
     public static event EventHandler? PercentageModeChanged;
@@ -259,6 +263,16 @@ public static class WidgetSettingsService
 
         ShowAgentActivityInWidget = enabled;
         Save(ShowAgentActivityInWidgetPath, enabled ? 1 : 0);
+        Changed?.Invoke(null, EventArgs.Empty);
+    }
+
+    public static void ApplyEnableAgentActivityMonitoring(bool enabled)
+    {
+        if (EnableAgentActivityMonitoring == enabled)
+            return;
+
+        EnableAgentActivityMonitoring = enabled;
+        Save(EnableAgentActivityMonitoringPath, enabled ? 1 : 0);
         Changed?.Invoke(null, EventArgs.Empty);
     }
 
@@ -664,6 +678,23 @@ public static class WidgetSettingsService
                 return true;
 
             string raw = File.ReadAllText(ShowAgentActivityInWidgetPath);
+            return !int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value)
+                || value != 0;
+        }
+        catch
+        {
+            return true;
+        }
+    }
+
+    private static bool LoadEnableAgentActivityMonitoring()
+    {
+        try
+        {
+            if (!File.Exists(EnableAgentActivityMonitoringPath))
+                return true;
+
+            string raw = File.ReadAllText(EnableAgentActivityMonitoringPath);
             return !int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value)
                 || value != 0;
         }

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -60,6 +60,9 @@ public static class WidgetSettingsService
     private static readonly string HideWhenUnfocusedPath =
         Path.Combine(AppStorage.AppDataDirectory, "hide-when-unfocused.txt");
 
+    private static readonly string ShowAgentActivityInWidgetPath =
+        Path.Combine(AppStorage.AppDataDirectory, "show-agent-activity-in-widget.txt");
+
     private static readonly Dictionary<string, bool> RowVisibility = LoadRowVisibility();
     private static readonly Dictionary<string, bool> ProviderVisibility = LoadProviderVisibility();
     private static readonly Dictionary<string, bool> DashboardProviderVisibility = LoadDashboardProviderVisibility();
@@ -75,6 +78,8 @@ public static class WidgetSettingsService
     /// are never affected — a pin is an explicit "always show this" request.
     /// </summary>
     public static bool HideWhenProviderUnfocused { get; private set; } = LoadHideWhenUnfocused();
+    /// <summary>Whether the separate Agent Activity island is shown on the taskbar. Enabled by default.</summary>
+    public static bool ShowAgentActivityInWidget { get; private set; } = LoadShowAgentActivityInWidget();
     public static event EventHandler? Changed;
     public static event EventHandler? DashboardCompositionChanged;
     public static event EventHandler? PercentageModeChanged;
@@ -244,6 +249,16 @@ public static class WidgetSettingsService
 
         HideWhenProviderUnfocused = enabled;
         Save(HideWhenUnfocusedPath, enabled ? 1 : 0);
+        Changed?.Invoke(null, EventArgs.Empty);
+    }
+
+    public static void ApplyShowAgentActivityInWidget(bool enabled)
+    {
+        if (ShowAgentActivityInWidget == enabled)
+            return;
+
+        ShowAgentActivityInWidget = enabled;
+        Save(ShowAgentActivityInWidgetPath, enabled ? 1 : 0);
         Changed?.Invoke(null, EventArgs.Empty);
     }
 
@@ -638,6 +653,23 @@ public static class WidgetSettingsService
         catch
         {
             return false;
+        }
+    }
+
+    private static bool LoadShowAgentActivityInWidget()
+    {
+        try
+        {
+            if (!File.Exists(ShowAgentActivityInWidgetPath))
+                return true;
+
+            string raw = File.ReadAllText(ShowAgentActivityInWidgetPath);
+            return !int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value)
+                || value != 0;
+        }
+        catch
+        {
+            return true;
         }
     }
 

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -263,6 +263,9 @@ public static class WidgetSettingsService
 
         ShowAgentActivityInWidget = enabled;
         Save(ShowAgentActivityInWidgetPath, enabled ? 1 : 0);
+        // Activity shares the taskbar area with quota tiles. Rebalance pins immediately so enabling it
+        // leaves room for the active quota tile plus one pinned tile (the normal cap is three quota tiles).
+        Services.PinBudgetService.EnforceBudget(notify: false);
         Changed?.Invoke(null, EventArgs.Empty);
     }
 

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -84,7 +84,7 @@ namespace TaskbarQuota.Taskbar
         private static void CreateTrayIcon()
         {
             var open = new PopupMenuItem("Open TaskbarQuota", (_, _) => _dispatcher?.TryEnqueue(() => _showMainWindow?.Invoke()));
-            var activity = new PopupMenuItem("Open agent activity", (_, _) => _dispatcher?.TryEnqueue(OpenActivityFlyout));
+            var activity = new PopupMenuItem("Open agent activity", (_, _) => _dispatcher?.TryEnqueue(() => OpenActivityFlyout()));
             var move = new PopupMenuItem("Move primary taskbar widget", (_, _) => _dispatcher?.TryEnqueue(
                 () => PrimaryWidget()?.StartDragging()));
             var reset = new PopupMenuItem("Reset widget positions", (_, _) => _dispatcher?.TryEnqueue(
@@ -213,6 +213,7 @@ namespace TaskbarQuota.Taskbar
                 };
                 widget.HydrateProvider = provider => HydrateResult(UsageCoordinator.Instance, provider);
                 widget.Clicked += () => _dispatcher?.TryEnqueue(() => ToggleFlyout(widget));
+                widget.ActivityClicked += () => _dispatcher?.TryEnqueue(() => OpenActivityFlyout(widget));
                 Widgets[target.Handle] = widget;
                 SyncWidgetState(widget);
                 PrewarmFlyout();
@@ -446,9 +447,9 @@ namespace TaskbarQuota.Taskbar
             }
         }
 
-        private static void OpenActivityFlyout()
+        private static void OpenActivityFlyout(TaskBarWidget? sourceWidget = null)
         {
-            var widget = PrimaryWidget();
+            var widget = sourceWidget ?? PrimaryWidget();
             if (widget is null)
             {
                 Log.Warning("Cannot open agent activity: no taskbar widget is available");
@@ -458,7 +459,7 @@ namespace TaskbarQuota.Taskbar
             try
             {
                 _flyout ??= new FlyoutWindow();
-                _flyout.ShowAbove(widget.Handle);
+                _flyout.ShowActivityAbove(widget.Handle);
             }
             catch (Exception ex)
             {

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -263,7 +263,7 @@ namespace TaskbarQuota.Taskbar
             // back in either — the set below runs first on show.
             if (providers.Count == 0)
             {
-                widget.SetVisible(activity.Primary is not null);
+                widget.SetVisible(WidgetSettingsService.ShowAgentActivityInWidget && activity.Primary is not null);
                 return;
             }
 
@@ -353,7 +353,7 @@ namespace TaskbarQuota.Taskbar
             try
             {
                 _flyout ??= new FlyoutWindow();
-                _flyout.ToggleActivityAbove(widget.Handle, selectedActivityId);
+                _flyout.ToggleActivityAbove(widget.ActivityHandle, selectedActivityId);
             }
             catch (Exception ex)
             {
@@ -403,7 +403,7 @@ namespace TaskbarQuota.Taskbar
                 // the tiles mid-fade.
                 if (providers.Count == 0)
                 {
-                    widget.SetVisible(activity.Primary is not null);
+                    widget.SetVisible(WidgetSettingsService.ShowAgentActivityInWidget && activity.Primary is not null);
                     continue;
                 }
 
@@ -480,7 +480,8 @@ namespace TaskbarQuota.Taskbar
                         continue;
 
                     widget.SetActivitySnapshot(snapshot);
-                    widget.SetVisible(snapshot.Primary is not null || UsageCoordinator.Instance.WidgetDisplayProviders.Count > 0);
+                    widget.SetVisible((WidgetSettingsService.ShowAgentActivityInWidget && snapshot.Primary is not null)
+                        || UsageCoordinator.Instance.WidgetDisplayProviders.Count > 0);
                 }
             });
 

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -27,6 +27,8 @@ namespace TaskbarQuota.Taskbar
         private static Action? _showMainWindow;
         private static DispatcherTimer? _widgetHealthTimer;
         private static DispatcherTimer? _activityTimer;
+        private static readonly TimeSpan ActiveActivityInterval = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan IdleActivityInterval = TimeSpan.FromSeconds(10);
         private static bool _initialized;
         private static bool _isReconcilingWidgets;
         private static ProviderId? _lastLoggedWidgetApplyProvider;
@@ -65,20 +67,39 @@ namespace TaskbarQuota.Taskbar
             }
 
             StartWidgetHealthTimer();
-            Log.Information("[activity] starting activity monitor");
-            StartActivityTimer();
+            ConfigureActivityTimer();
             OnActiveToolPresenceChanged(UsageCoordinator.Instance.IsActiveToolPresent);
         }
 
         private static void StartActivityTimer()
         {
-            if (_activityTimer != null)
+            if (_activityTimer != null || !WidgetSettingsService.EnableAgentActivityMonitoring)
                 return;
 
-            _activityTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
-            _activityTimer.Tick += async (_, _) => await AgentActivityService.Instance.RefreshFromTranscriptsAsync();
+            _activityTimer = new DispatcherTimer { Interval = IdleActivityInterval };
+            _activityTimer.Tick += async (_, _) =>
+            {
+                await AgentActivityService.Instance.RefreshFromTranscriptsAsync();
+                if (_activityTimer is { } timer)
+                    timer.Interval = AgentActivityService.Instance.Snapshot.HasLiveItems
+                        ? ActiveActivityInterval
+                        : IdleActivityInterval;
+            };
             _activityTimer.Start();
             _ = Task.Run(AgentActivityService.Instance.RefreshFromTranscriptsAsync);
+        }
+
+        private static void ConfigureActivityTimer()
+        {
+            if (WidgetSettingsService.EnableAgentActivityMonitoring)
+            {
+                StartActivityTimer();
+                return;
+            }
+
+            _activityTimer?.Stop();
+            _activityTimer = null;
+            AgentActivityService.Instance.Clear();
         }
 
         private static void CreateTrayIcon()
@@ -328,14 +349,17 @@ namespace TaskbarQuota.Taskbar
         private static void ToggleFlyout(TaskBarWidget widget)
         {
             if (!widget.IsAlive) return;
+            FlyoutWindow? flyout = null;
             try
             {
-                _flyout ??= new FlyoutWindow();
-                _flyout.ToggleAbove(widget.Handle);
+                flyout = _flyout ?? new FlyoutWindow();
+                _flyout = flyout;
+                flyout.ToggleAbove(widget.Handle);
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to toggle flyout");
+                try { flyout?.Close(); } catch { }
                 _flyout = null;
             }
         }
@@ -350,14 +374,17 @@ namespace TaskbarQuota.Taskbar
             }
 
             if (!widget.IsAlive) return;
+            FlyoutWindow? flyout = null;
             try
             {
-                _flyout ??= new FlyoutWindow();
-                _flyout.ToggleActivityAbove(widget.ActivityHandle, selectedActivityId);
+                flyout = _flyout ?? new FlyoutWindow();
+                _flyout = flyout;
+                flyout.ToggleActivityAbove(widget.ActivityHandle, selectedActivityId);
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to toggle agent activity flyout");
+                try { flyout?.Close(); } catch { }
                 _flyout = null;
             }
         }
@@ -366,14 +393,17 @@ namespace TaskbarQuota.Taskbar
         {
             _dispatcher?.TryEnqueue(DispatcherQueuePriority.Low, () =>
             {
+                FlyoutWindow? flyout = null;
                 try
                 {
-                    _flyout ??= new FlyoutWindow();
-                    _flyout.Prewarm();
+                    flyout = _flyout ?? new FlyoutWindow();
+                    _flyout = flyout;
+                    flyout.Prewarm();
                 }
                 catch (Exception ex)
                 {
                     Log.Warning(ex, "Failed to prewarm flyout");
+                    try { flyout?.Close(); } catch { }
                     _flyout = null;
                 }
             });
@@ -487,7 +517,11 @@ namespace TaskbarQuota.Taskbar
 
         private static void OnWidgetSettingsChanged(object? sender, EventArgs e)
         {
-            _dispatcher?.TryEnqueue(SyncWidgetState);
+            _dispatcher?.TryEnqueue(() =>
+            {
+                ConfigureActivityTimer();
+                SyncWidgetState();
+            });
         }
 
         private static void OnQuitting()

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -214,7 +214,7 @@ namespace TaskbarQuota.Taskbar
                 widget.HydrateProvider = provider => HydrateResult(UsageCoordinator.Instance, provider);
                 widget.Clicked += () => _dispatcher?.TryEnqueue(() => ToggleFlyout(widget));
                 widget.ActivityClicked += item => _dispatcher?.TryEnqueue(
-                    () => OpenActivityFlyout(widget, item?.Id));
+                    () => ToggleActivityFlyout(widget, item?.Id));
                 Widgets[target.Handle] = widget;
                 SyncWidgetState(widget);
                 PrewarmFlyout();
@@ -335,6 +335,22 @@ namespace TaskbarQuota.Taskbar
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to toggle flyout");
+                _flyout = null;
+            }
+        }
+
+        private static void ToggleActivityFlyout(TaskBarWidget widget, string? selectedActivityId)
+        {
+            if (!widget.IsAlive) return;
+            try
+            {
+                _flyout ??= new FlyoutWindow();
+                _flyout.Prewarm();
+                _flyout.ToggleActivityAbove(widget.Handle, selectedActivityId);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to toggle agent activity flyout");
                 _flyout = null;
             }
         }

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -213,7 +213,8 @@ namespace TaskbarQuota.Taskbar
                 };
                 widget.HydrateProvider = provider => HydrateResult(UsageCoordinator.Instance, provider);
                 widget.Clicked += () => _dispatcher?.TryEnqueue(() => ToggleFlyout(widget));
-                widget.ActivityClicked += () => _dispatcher?.TryEnqueue(() => OpenActivityFlyout(widget));
+                widget.ActivityClicked += item => _dispatcher?.TryEnqueue(
+                    () => OpenActivityFlyout(widget, item?.Id));
                 Widgets[target.Handle] = widget;
                 SyncWidgetState(widget);
                 PrewarmFlyout();
@@ -447,7 +448,7 @@ namespace TaskbarQuota.Taskbar
             }
         }
 
-        private static void OpenActivityFlyout(TaskBarWidget? sourceWidget = null)
+        private static void OpenActivityFlyout(TaskBarWidget? sourceWidget = null, string? selectedActivityId = null)
         {
             var widget = sourceWidget ?? PrimaryWidget();
             if (widget is null)
@@ -459,7 +460,7 @@ namespace TaskbarQuota.Taskbar
             try
             {
                 _flyout ??= new FlyoutWindow();
-                _flyout.ShowActivityAbove(widget.Handle);
+                _flyout.ShowActivityAbove(widget.Handle, selectedActivityId);
             }
             catch (Exception ex)
             {

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -460,6 +460,10 @@ namespace TaskbarQuota.Taskbar
             try
             {
                 _flyout ??= new FlyoutWindow();
+                // The taskbar activity section can be clicked before the low-priority startup prewarm
+                // runs. Prime this exact flyout synchronously so DesktopAcrylic is already attached to
+                // a composed window before the activity panel is shown.
+                _flyout.Prewarm();
                 _flyout.ShowActivityAbove(widget.Handle, selectedActivityId);
             }
             catch (Exception ex)

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using H.NotifyIcon.Core;
 using Microsoft.UI.Dispatching;
@@ -27,6 +28,7 @@ namespace TaskbarQuota.Taskbar
         private static Action? _showMainWindow;
         private static DispatcherTimer? _widgetHealthTimer;
         private static DispatcherTimer? _activityTimer;
+        private static CancellationTokenSource? _activityCts;
         private static readonly TimeSpan ActiveActivityInterval = TimeSpan.FromSeconds(2);
         private static readonly TimeSpan IdleActivityInterval = TimeSpan.FromSeconds(10);
         private static bool _initialized;
@@ -76,17 +78,19 @@ namespace TaskbarQuota.Taskbar
             if (_activityTimer != null || !WidgetSettingsService.EnableAgentActivityMonitoring)
                 return;
 
+            _activityCts = new CancellationTokenSource();
+            var cancellationToken = _activityCts.Token;
             _activityTimer = new DispatcherTimer { Interval = IdleActivityInterval };
             _activityTimer.Tick += async (_, _) =>
             {
-                await AgentActivityService.Instance.RefreshFromTranscriptsAsync();
+                await AgentActivityService.Instance.RefreshFromTranscriptsAsync(cancellationToken);
                 if (_activityTimer is { } timer)
                     timer.Interval = AgentActivityService.Instance.Snapshot.HasLiveItems
                         ? ActiveActivityInterval
                         : IdleActivityInterval;
             };
             _activityTimer.Start();
-            _ = Task.Run(AgentActivityService.Instance.RefreshFromTranscriptsAsync);
+            _ = AgentActivityService.Instance.RefreshFromTranscriptsAsync(cancellationToken);
         }
 
         private static void ConfigureActivityTimer()
@@ -99,6 +103,9 @@ namespace TaskbarQuota.Taskbar
 
             _activityTimer?.Stop();
             _activityTimer = null;
+            _activityCts?.Cancel();
+            _activityCts?.Dispose();
+            _activityCts = null;
             AgentActivityService.Instance.Clear();
         }
 
@@ -558,6 +565,9 @@ namespace TaskbarQuota.Taskbar
             _widgetHealthTimer = null;
             _activityTimer?.Stop();
             _activityTimer = null;
+            _activityCts?.Cancel();
+            _activityCts?.Dispose();
+            _activityCts = null;
             if (_foregroundWatcher is { } watcher)
             {
                 watcher.ForegroundChanged -= OnForegroundChanged;

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -284,7 +284,11 @@ namespace TaskbarQuota.Taskbar
             // back in either — the set below runs first on show.
             if (providers.Count == 0)
             {
-                widget.SetVisible(WidgetSettingsService.ShowAgentActivityInWidget && activity.Primary is not null);
+                widget.SetDisplayProviders(Array.Empty<ProviderId>(), coordinator.ActiveProvider);
+                if (WidgetSettingsService.ShowAgentActivityInWidget && activity.Primary is not null)
+                    widget.SetQuotaVisible(false);
+                else
+                    widget.SetVisible(false);
                 return;
             }
 
@@ -429,11 +433,15 @@ namespace TaskbarQuota.Taskbar
                 // Reconcile the tile set first, so a provider that just became active already owns a slot
                 // before its result is routed. SetDisplayProviders is a cheap no-op when nothing changed.
                 widget.SetActivitySnapshot(activity);
-                // As in SyncWidgetState, an empty set only hides — rebinding the slots here would collapse
-                // the tiles mid-fade.
+                // As in SyncWidgetState, clear the quota slots before hiding the quota host so a later
+                // provider return cannot reveal stale tiles.
                 if (providers.Count == 0)
                 {
-                    widget.SetVisible(WidgetSettingsService.ShowAgentActivityInWidget && activity.Primary is not null);
+                    widget.SetDisplayProviders(Array.Empty<ProviderId>(), coordinator.ActiveProvider);
+                    if (WidgetSettingsService.ShowAgentActivityInWidget && activity.Primary is not null)
+                        widget.SetQuotaVisible(false);
+                    else
+                        widget.SetVisible(false);
                     continue;
                 }
 
@@ -510,8 +518,20 @@ namespace TaskbarQuota.Taskbar
                         continue;
 
                     widget.SetActivitySnapshot(snapshot);
-                    widget.SetVisible((WidgetSettingsService.ShowAgentActivityInWidget && snapshot.Primary is not null)
-                        || UsageCoordinator.Instance.WidgetDisplayProviders.Count > 0);
+                    var providers = UsageCoordinator.Instance.WidgetDisplayProviders;
+                    if (providers.Count == 0)
+                    {
+                        widget.SetDisplayProviders(Array.Empty<ProviderId>(), UsageCoordinator.Instance.ActiveProvider);
+                        if (WidgetSettingsService.ShowAgentActivityInWidget && snapshot.Primary is not null)
+                            widget.SetQuotaVisible(false);
+                        else
+                            widget.SetVisible(false);
+                    }
+                    else
+                    {
+                        widget.SetDisplayProviders(providers, UsageCoordinator.Instance.ActiveProvider);
+                        widget.SetVisible(true);
+                    }
                 }
             });
 

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -2,12 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using H.NotifyIcon.Core;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
 using TaskbarQuota.Diagnostics;
 using TaskbarQuota.Usage;
+using TaskbarQuota.AgentActivity;
 
 namespace TaskbarQuota.Taskbar
 {
@@ -24,6 +26,7 @@ namespace TaskbarQuota.Taskbar
         private static DispatcherQueue? _dispatcher;
         private static Action? _showMainWindow;
         private static DispatcherTimer? _widgetHealthTimer;
+        private static DispatcherTimer? _activityTimer;
         private static bool _initialized;
         private static bool _isReconcilingWidgets;
         private static ProviderId? _lastLoggedWidgetApplyProvider;
@@ -41,18 +44,33 @@ namespace TaskbarQuota.Taskbar
                 UsageCoordinator.Instance.StateChanged += OnStateChanged;
                 UsageCoordinator.Instance.ActiveProviderChanged += OnActiveProviderChanged;
                 UsageCoordinator.Instance.ActiveToolPresenceChanged += OnActiveToolPresenceChanged;
+                AgentActivityService.Instance.Changed += OnActivityChanged;
                 WidgetSettingsService.Changed += OnWidgetSettingsChanged;
                 App.Quitting += OnQuitting;
                 _initialized = true;
             }
 
             StartWidgetHealthTimer();
+            Log.Information("[activity] starting activity monitor");
+            StartActivityTimer();
             OnActiveToolPresenceChanged(UsageCoordinator.Instance.IsActiveToolPresent);
+        }
+
+        private static void StartActivityTimer()
+        {
+            if (_activityTimer != null)
+                return;
+
+            _activityTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+            _activityTimer.Tick += async (_, _) => await AgentActivityService.Instance.RefreshFromTranscriptsAsync();
+            _activityTimer.Start();
+            _ = Task.Run(AgentActivityService.Instance.RefreshFromTranscriptsAsync);
         }
 
         private static void CreateTrayIcon()
         {
             var open = new PopupMenuItem("Open TaskbarQuota", (_, _) => _dispatcher?.TryEnqueue(() => _showMainWindow?.Invoke()));
+            var activity = new PopupMenuItem("Open agent activity", (_, _) => _dispatcher?.TryEnqueue(OpenActivityFlyout));
             var move = new PopupMenuItem("Move primary taskbar widget", (_, _) => _dispatcher?.TryEnqueue(
                 () => PrimaryWidget()?.StartDragging()));
             var reset = new PopupMenuItem("Reset widget positions", (_, _) => _dispatcher?.TryEnqueue(
@@ -76,7 +94,7 @@ namespace TaskbarQuota.Taskbar
 
             _trayIcon = new TrayIconWithContextMenu
             {
-                ContextMenu = new PopupMenu { Items = { open, new PopupMenuSeparator(), move, reset, new PopupMenuSeparator(), quit } },
+                ContextMenu = new PopupMenu { Items = { open, activity, new PopupMenuSeparator(), move, reset, new PopupMenuSeparator(), quit } },
                 ToolTip = "TaskbarQuota",
             };
             _trayIcon.Create();
@@ -219,10 +237,12 @@ namespace TaskbarQuota.Taskbar
 
             var coordinator = UsageCoordinator.Instance;
             var providers = coordinator.WidgetDisplayProviders;
+            var activity = AgentActivityService.Instance.Snapshot;
 
             // No provider to show -> hide the native host instead of leaving a transparent taskbar child
             // window over the notification area (#10).
-            widget.SetVisible(providers.Count > 0);
+            widget.SetVisible(providers.Count > 0 || activity.Primary is not null);
+            widget.SetActivitySnapshot(activity);
             widget.SetDisplayProviders(providers, coordinator.ActiveProvider);
             if (providers.Count == 0)
                 return;
@@ -318,6 +338,7 @@ namespace TaskbarQuota.Taskbar
         {
             var coordinator = UsageCoordinator.Instance;
             var providers = coordinator.WidgetDisplayProviders;
+            var activity = AgentActivityService.Instance.Snapshot;
             bool isDisplayed = providers.Contains(result.Id);
 
             // Reused buffer: this runs on every usage publish, so a fresh array per publish was pure waste.
@@ -329,7 +350,8 @@ namespace TaskbarQuota.Taskbar
 
                 // Reconcile the tile set first, so a provider that just became active already owns a slot
                 // before its result is routed. SetDisplayProviders is a cheap no-op when nothing changed.
-                widget.SetVisible(providers.Count > 0);
+                widget.SetVisible(providers.Count > 0 || activity.Primary is not null);
+                widget.SetActivitySnapshot(activity);
                 widget.SetDisplayProviders(providers, coordinator.ActiveProvider);
                 if (!isDisplayed)
                     continue;
@@ -361,9 +383,10 @@ namespace TaskbarQuota.Taskbar
             Log.Debug($"[synara] widget {source} applied provider={provider}");
         }
 
-        // Provider switches always publish StateChanged immediately after ActiveProviderChanged,
-        // so updating the widget here would only duplicate dispatcher work and add latency.
-        private static void OnActiveProviderChanged(ProviderId? _) { }
+        // Foreground provider detection is strictly for quota context. Agent activity is refreshed by
+        // its own desktop-app and terminal-command scans, even when another app has the focus.
+        private static void OnActiveProviderChanged(ProviderId? _)
+            => _dispatcher?.TryEnqueue(SyncWidgetState);
 
         private static void OnActiveToolPresenceChanged(bool isPresent)
             => _dispatcher?.TryEnqueue(() => ApplyActiveToolPresenceChanged(isPresent));
@@ -379,6 +402,40 @@ namespace TaskbarQuota.Taskbar
             }
         }
 
+        private static void OpenActivityFlyout()
+        {
+            var widget = PrimaryWidget();
+            if (widget is null)
+            {
+                Log.Warning("Cannot open agent activity: no taskbar widget is available");
+                return;
+            }
+
+            try
+            {
+                _flyout ??= new FlyoutWindow();
+                _flyout.ShowAbove(widget.Handle);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to open agent activity from tray");
+                _flyout = null;
+            }
+        }
+
+        private static void OnActivityChanged(AgentActivitySnapshot snapshot)
+            => _dispatcher?.TryEnqueue(() =>
+            {
+                foreach (var widget in Widgets.Values.ToArray())
+                {
+                    if (!widget.IsAlive)
+                        continue;
+
+                    widget.SetActivitySnapshot(snapshot);
+                    widget.SetVisible(snapshot.Primary is not null || UsageCoordinator.Instance.WidgetDisplayProviders.Count > 0);
+                }
+            });
+
         private static void OnWidgetSettingsChanged(object? sender, EventArgs e)
         {
             _dispatcher?.TryEnqueue(SyncWidgetState);
@@ -389,10 +446,13 @@ namespace TaskbarQuota.Taskbar
             UsageCoordinator.Instance.StateChanged -= OnStateChanged;
             UsageCoordinator.Instance.ActiveProviderChanged -= OnActiveProviderChanged;
             UsageCoordinator.Instance.ActiveToolPresenceChanged -= OnActiveToolPresenceChanged;
+            AgentActivityService.Instance.Changed -= OnActivityChanged;
             WidgetSettingsService.Changed -= OnWidgetSettingsChanged;
             _initialized = false;
             _widgetHealthTimer?.Stop();
             _widgetHealthTimer = null;
+            _activityTimer?.Stop();
+            _activityTimer = null;
             if (_trayIcon != null) { _trayIcon.TryRemove(); _trayIcon.Dispose(); _trayIcon = null; }
             try { _flyout?.Close(); } catch { }
             _flyout = null;

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -84,7 +84,8 @@ namespace TaskbarQuota.Taskbar
         private static void CreateTrayIcon()
         {
             var open = new PopupMenuItem("Open TaskbarQuota", (_, _) => _dispatcher?.TryEnqueue(() => _showMainWindow?.Invoke()));
-            var activity = new PopupMenuItem("Open agent activity", (_, _) => _dispatcher?.TryEnqueue(() => OpenActivityFlyout()));
+            var activity = new PopupMenuItem("Open agent activity", (_, _) => _dispatcher?.TryEnqueue(
+                () => ToggleActivityFlyout(sourceWidget: null, selectedActivityId: null)));
             var move = new PopupMenuItem("Move primary taskbar widget", (_, _) => _dispatcher?.TryEnqueue(
                 () => PrimaryWidget()?.StartDragging()));
             var reset = new PopupMenuItem("Reset widget positions", (_, _) => _dispatcher?.TryEnqueue(
@@ -339,13 +340,19 @@ namespace TaskbarQuota.Taskbar
             }
         }
 
-        private static void ToggleActivityFlyout(TaskBarWidget widget, string? selectedActivityId)
+        private static void ToggleActivityFlyout(TaskBarWidget? sourceWidget, string? selectedActivityId)
         {
+            var widget = sourceWidget ?? PrimaryWidget();
+            if (widget is null)
+            {
+                Log.Warning("Cannot toggle agent activity: no taskbar widget is available");
+                return;
+            }
+
             if (!widget.IsAlive) return;
             try
             {
                 _flyout ??= new FlyoutWindow();
-                _flyout.Prewarm();
                 _flyout.ToggleActivityAbove(widget.Handle, selectedActivityId);
             }
             catch (Exception ex)
@@ -461,31 +468,6 @@ namespace TaskbarQuota.Taskbar
             {
                 if (widget.IsAlive)
                     SyncWidgetState(widget);
-            }
-        }
-
-        private static void OpenActivityFlyout(TaskBarWidget? sourceWidget = null, string? selectedActivityId = null)
-        {
-            var widget = sourceWidget ?? PrimaryWidget();
-            if (widget is null)
-            {
-                Log.Warning("Cannot open agent activity: no taskbar widget is available");
-                return;
-            }
-
-            try
-            {
-                _flyout ??= new FlyoutWindow();
-                // The taskbar activity section can be clicked before the low-priority startup prewarm
-                // runs. Prime this exact flyout synchronously so DesktopAcrylic is already attached to
-                // a composed window before the activity panel is shown.
-                _flyout.Prewarm();
-                _flyout.ShowActivityAbove(widget.Handle, selectedActivityId);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to open agent activity from tray");
-                _flyout = null;
             }
         }
 

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -522,6 +522,11 @@ namespace TaskbarQuota.Taskbar
         /// </summary>
         public void SetDisplayProviders(IReadOnlyList<ProviderId> providers, ProviderId? activeProvider)
         {
+            // A stale reconciliation callback must never bind the same provider into two slots. The
+            // coordinator normally guarantees uniqueness, but normalizing at the widget boundary keeps
+            // an out-of-order foreground update from briefly rendering duplicate quota tiles.
+            providers = providers.Distinct().Take(UsageCoordinator.MaxWidgetTiles).ToArray();
+
             // Before Initialize() there are no tiles to bind. Hold the set instead of dropping it — the
             // manager re-sends only on a change, so a dropped first set never came back and the widget
             // stayed empty forever.

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -206,7 +206,7 @@ namespace TaskbarQuota.Taskbar
         /// <summary>Raised when any quota tile is clicked; provider-agnostic, it opens the provider flyout.</summary>
         public event Action? Clicked;
         /// <summary>Raised when the agent activity summary is clicked, so its activity panel can open.</summary>
-        public event Action? ActivityClicked;
+        public event Action<AgentActivityItem?>? ActivityClicked;
         public event EventHandler? Destroying;
 
         public TaskBarWidget(TaskbarWindowTarget target)
@@ -508,7 +508,7 @@ namespace TaskbarQuota.Taskbar
 
         private void OnTileClicked() => Clicked?.Invoke();
 
-        private void OnActivityClicked() => ActivityClicked?.Invoke();
+        private void OnActivityClicked(AgentActivityItem? item) => ActivityClicked?.Invoke(item);
 
         private void WidgetSummary_DesiredHostWidthChanged(int logicalWidth) => RecomputeLayout();
 

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -560,6 +560,25 @@ namespace TaskbarQuota.Taskbar
             QueuePositionUpdate(TaskbarChangeReason.None);
         }
 
+        /// <summary>Shows or hides only the quota host, leaving the independent activity host untouched.</summary>
+        public void SetQuotaVisible(bool visible)
+        {
+            if (appWindow is null || isVisible == visible && appWindow.IsVisible == visible)
+                return;
+
+            isVisible = visible;
+            if (visible)
+            {
+                QueuePositionUpdate(TaskbarChangeReason.None);
+                appWindow.Show(false);
+            }
+            else
+            {
+                classicTaskbarReservation.Restore();
+                appWindow.Hide();
+            }
+        }
+
         private Microsoft.UI.Xaml.Controls.StackPanel BuildSummaryPanel()
         {
             var panel = new Microsoft.UI.Xaml.Controls.StackPanel

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -1331,8 +1331,18 @@ namespace TaskbarQuota.Taskbar
                     }
                     else
                     {
-                        activityX = PlaceInFittingGap(activityPreferred, activityGaps, ActivityHostWidth)
-                            ?? (activityOffsetX != int.MinValue ? activityOffsetX : activityPreferred);
+                        var fittedActivityX = PlaceInFittingGap(activityPreferred, activityGaps, ActivityHostWidth);
+                        if (fittedActivityX is not { } fittingX)
+                        {
+                            // There is no free lane for the activity host. Keeping the old preferred
+                            // position here would place the transparent activity window on top of quota
+                            // values, which is worse than temporarily hiding the optional activity view.
+                            Log.Debug("activity hidden: no taskbar gap can fit the activity host without overlap");
+                            SetActivityHostVisible(false);
+                            return;
+                        }
+
+                        activityX = fittingX;
                     }
                     activityX = ClampToTaskbarMonitor(
                         activityX,

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -1294,9 +1294,16 @@ namespace TaskbarQuota.Taskbar
 
                 if (isActivityVisible && activityAppWindow is not null)
                 {
-                    int activityPreferred = activityOffsetX != int.MinValue
-                        ? activityOffsetX
-                        : offsetX + WidgetHostWidth + (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale);
+                    int quotaRightAnchor = offsetX + WidgetHostWidth
+                        + (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale);
+                    // In the normal quota-first order, keep the activity island to the quota's
+                    // right even when a previously saved activity position is stale or too far left.
+                    // This lets a wider quota widget push the optional activity view outward.
+                    int activityPreferred = widgetOrder == TaskbarWidgetOrder.QuotaFirst
+                        ? Math.Max(activityOffsetX, quotaRightAnchor)
+                        : activityOffsetX != int.MinValue
+                            ? activityOffsetX
+                            : quotaRightAnchor;
                     var quotaRect = new RECT
                     {
                         left = offsetX - (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale),

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -43,6 +43,8 @@ namespace TaskbarQuota.Taskbar
         // Fixed width of the "|" divider drawn between adjacent tiles. Fixed rather than measured so the
         // fit math stays exact and doesn't depend on a layout pass having run.
         private const int TileSeparatorLogicalPx = 7;
+        // The activity summary is separated from the quota row by its own left margin.
+        private const int ActivitySummaryMarginLogicalPx = 8;
         // Space assumed available before the first position pass has measured the real taskbar gap. Wide
         // enough for three tiles; the first pass corrects it either way.
         private const int DefaultAvailableLogicalWidth = 640;
@@ -446,7 +448,7 @@ namespace TaskbarQuota.Taskbar
 
             activitySummary = new AgentActivitySummary
             {
-                Margin = new Microsoft.UI.Xaml.Thickness(8, 0, 0, 0),
+                Margin = new Microsoft.UI.Xaml.Thickness(ActivitySummaryMarginLogicalPx, 0, 0, 0),
                 Visibility = Microsoft.UI.Xaml.Visibility.Collapsed,
                 HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
                 VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Stretch,
@@ -642,14 +644,16 @@ namespace TaskbarQuota.Taskbar
                         layoutSlots[count++] = i;
                 }
 
-                int activityWidth = showActivity ? AgentActivitySummary.DesiredLogicalWidth + 8 : 0;
-                count = HoldBackTilesThatDoNotFit(layoutSlots, count, activityWidth);
+                int minimumActivityWidth = showActivity
+                    ? AgentActivitySummary.MinimumLogicalWidth + ActivitySummaryMarginLogicalPx
+                    : 0;
+                count = HoldBackTilesThatDoNotFit(layoutSlots, count, minimumActivityWidth);
 
                 // Widths are measured, never rendered — MeasureDesiredWidth is a pure calculation.
                 // Rendering to measure made the tile restart its refresh animation on every usage publish,
                 // which read as a tile flashing about once a second.
                 var brush = TaskbarForegroundBrush();
-                int total = activityWidth;
+                int total = 0;
                 for (int n = 0; n < count; n++)
                 {
                     int i = layoutSlots[n];
@@ -659,6 +663,23 @@ namespace TaskbarQuota.Taskbar
                         TaskbarSpace.RecordTileWidth(measuredProvider, width);
                     total += width + TileHorizontalMarginLogicalPx + (n > 0 ? TileSeparatorLogicalPx : 0);
                 }
+
+                // Give the activity panel exactly the remaining taskbar budget. Its title and action
+                // TextBlocks can then trim against a real width instead of painting into the shell buttons.
+                int quotaWidth = total;
+                int activityWidth = 0;
+                if (showActivity && activitySummary is not null)
+                {
+                    int remainingWidth = availableLogicalWidth - quotaWidth;
+                    int activityOuterWidth = Math.Clamp(
+                        remainingWidth,
+                        ActivitySummaryMarginLogicalPx + 1,
+                        AgentActivitySummary.DesiredLogicalWidth + ActivitySummaryMarginLogicalPx);
+                    activitySummary.SetLogicalWidth(activityOuterWidth - ActivitySummaryMarginLogicalPx);
+                    activityWidth = activityOuterWidth;
+                }
+
+                total += activityWidth;
 
                 for (int i = 0; i < tiles.Length; i++)
                 {

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -45,6 +45,11 @@ namespace TaskbarQuota.Taskbar
         private const int TileSeparatorLogicalPx = 7;
         // The activity summary is separated from the quota row by its own left margin.
         private const int ActivitySummaryMarginLogicalPx = 8;
+        // Keep enough text visible to recognize the activity while dragging, while still fitting beside a
+        // wide two-column quota tile in the normal left taskbar lane.
+        private const int ActivityDragLogicalWidth = 240;
+        private const int PartnerSnapLogicalPx = 32;
+        private const int LayoutTransitionMilliseconds = 190;
         // Space assumed available before the first position pass has measured the real taskbar gap. Wide
         // enough for three tiles; the first pass corrects it either way.
         private const int DefaultAvailableLogicalWidth = 640;
@@ -85,6 +90,7 @@ namespace TaskbarQuota.Taskbar
         private readonly string positionPath;
         private readonly string orderPath;
         private readonly string activityPositionPath;
+        private readonly string activityManualPositionPath;
         private readonly CancellationTokenSource positionUpdateCancellation = new();
         private readonly SemaphoreSlim positionUpdateGate = new(1, 1);
         private readonly object positionRequestLock = new();
@@ -100,6 +106,8 @@ namespace TaskbarQuota.Taskbar
         private readonly WidgetSummary[] tiles = new WidgetSummary[UsageCoordinator.MaxWidgetTiles];
         private AgentActivitySummary? activitySummary;
         private AgentActivitySnapshot activitySnapshot = new(Array.Empty<AgentActivityItem>());
+        private AgentActivitySnapshot? pendingEmptyActivitySnapshot;
+        private readonly Microsoft.UI.Xaml.DispatcherTimer activityEmptySnapshotTimer;
         // separators[i] is the "|" divider between slot i and slot i+1.
         private readonly Microsoft.UI.Xaml.Controls.TextBlock[] separators =
             new Microsoft.UI.Xaml.Controls.TextBlock[UsageCoordinator.MaxWidgetTiles - 1];
@@ -140,11 +148,18 @@ namespace TaskbarQuota.Taskbar
         // slower reads as lag rather than as a transition.
         private const int HostFadeMilliseconds = 100;
         private Anim.Storyboard? hostFadeStoryboard;
+        private Anim.Storyboard? activityFadeStoryboard;
+        private Anim.Storyboard? quotaLayoutStoryboard;
+        private Anim.Storyboard? activityLayoutStoryboard;
         private int hostFadeGeneration;
+        private int activityFadeGeneration;
         private int WidgetHostWidth;
         private int ActivityHostWidth;
         private int currentOffsetX = int.MinValue;
         private int activityOffsetX = int.MinValue;
+        // Runtime placement updates activityOffsetX on every adaptive pass. Only a coordinate loaded from
+        // disk or committed by an Activity drag is user-owned and must survive later quota width changes.
+        private bool hasManualActivityPosition;
         private int currentOffsetY = 0;
         // Last known Widgets/weather pill bounds in taskbar-client coords, captured during the resting
         // reposition so the synchronous drag path can avoid it without an async UIA read.
@@ -237,6 +252,12 @@ namespace TaskbarQuota.Taskbar
 
         public TaskBarWidget(TaskbarWindowTarget target)
         {
+            activityEmptySnapshotTimer = new Microsoft.UI.Xaml.DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(650),
+            };
+            activityEmptySnapshotTimer.Tick += ActivityEmptySnapshotTimer_Tick;
+
             hwndShell = target.Handle;
             isPrimaryTaskbar = target.IsPrimary;
             displayKey = target.DisplayKey;
@@ -257,6 +278,7 @@ namespace TaskbarQuota.Taskbar
             positionPath = target.GetPositionPath();
             orderPath = positionPath + ".order";
             activityPositionPath = positionPath + ".activity";
+            activityManualPositionPath = positionPath + ".activity.manual";
 
             taskbarWatcher = new TaskbarStructureWatcher(hwndShell, hwndReBar);
             classicTaskbarReservation = new ClassicTaskbarSpaceReservation(hwndShell);
@@ -348,7 +370,13 @@ namespace TaskbarQuota.Taskbar
                 HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
                 VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Stretch,
             };
-            summary.PointerPressed += WidgetSummary_PointerPressed;
+            // Listen even when a child button marks the press handled. Dragging starts only after the
+            // movement threshold, so a normal click still activates the button while the whole surface
+            // remains draggable.
+            summary.AddHandler(
+                Microsoft.UI.Xaml.UIElement.PointerPressedEvent,
+                new Microsoft.UI.Xaml.Input.PointerEventHandler(WidgetSummary_PointerPressed),
+                true);
             summary.PointerMoved += WidgetSummary_PointerMoved;
             summary.PointerReleased += WidgetSummary_PointerReleased;
             summary.PointerCanceled += WidgetSummary_PointerCanceled;
@@ -523,8 +551,11 @@ namespace TaskbarQuota.Taskbar
                 widgetOrder = TaskbarWidgetOrder.QuotaFirst;
                 SaveWidgetOrder();
                 activityOffsetX = int.MinValue;
+                hasManualActivityPosition = false;
                 try { if (File.Exists(activityPositionPath)) File.Delete(activityPositionPath); }
                 catch (Exception ex) { Log.Warning(ex, "Could not clear detached activity position"); }
+                try { if (File.Exists(activityManualPositionPath)) File.Delete(activityManualPositionPath); }
+                catch (Exception ex) { Log.Warning(ex, "Could not clear manual activity position marker"); }
             }
             QueuePositionUpdate(TaskbarChangeReason.None);
         }
@@ -593,6 +624,36 @@ namespace TaskbarQuota.Taskbar
         private void WidgetSummary_DesiredHostWidthChanged(int logicalWidth) => RecomputeLayout();
 
         public void SetActivitySnapshot(AgentActivitySnapshot snapshot)
+        {
+            if (snapshot.Primary is null && activitySnapshot.Primary is not null)
+            {
+                // Discovery can publish an empty intermediate snapshot while transcript sources are being
+                // rescanned. Keep the visible activity island for a short grace period instead of hiding
+                // and recreating the native host on the next non-empty publish.
+                pendingEmptyActivitySnapshot = snapshot;
+                activityEmptySnapshotTimer.Stop();
+                activityEmptySnapshotTimer.Start();
+                return;
+            }
+
+            activityEmptySnapshotTimer.Stop();
+            pendingEmptyActivitySnapshot = null;
+            ApplyActivitySnapshot(snapshot);
+        }
+
+        private void ActivityEmptySnapshotTimer_Tick(object? sender, object e)
+        {
+            activityEmptySnapshotTimer.Stop();
+            if (pendingEmptyActivitySnapshot is not { } snapshot)
+                return;
+            if (IsUserRepositioning)
+                return;
+
+            pendingEmptyActivitySnapshot = null;
+            ApplyActivitySnapshot(snapshot);
+        }
+
+        private void ApplyActivitySnapshot(AgentActivitySnapshot snapshot)
         {
             activitySnapshot = snapshot;
             // Transcript discovery publishes about once per second. Rebuilding and resizing the separate
@@ -770,10 +831,8 @@ namespace TaskbarQuota.Taskbar
                     }
                 }
 
-                if (activitySummary is not null)
-                    activitySummary.Visibility = showActivity
-                        ? Microsoft.UI.Xaml.Visibility.Visible
-                        : Microsoft.UI.Xaml.Visibility.Collapsed;
+                if (activitySummary is not null && showActivity)
+                    activitySummary.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
                 bool activityVisibilityChanged = SetActivityHostVisible(showActivity);
 
                 for (int i = 0; i < tiles.Length; i++)
@@ -1030,6 +1089,7 @@ namespace TaskbarQuota.Taskbar
 
             WidgetHostWidth = width;
             appWindow.ResizeClient(new SizeInt32(WidgetHostWidth, appWindow.Size.Height));
+            AnimateLayoutSurface(hostContent, ref quotaLayoutStoryboard, 0);
             return true;
         }
 
@@ -1043,9 +1103,60 @@ namespace TaskbarQuota.Taskbar
             {
                 ActivityHostWidth = width;
                 activityAppWindow.ResizeClient(new SizeInt32(width, activityAppWindow.Size.Height));
+                AnimateLayoutSurface(activityHostContent, ref activityLayoutStoryboard, 0);
                 return true;
             }
             return false;
+        }
+
+        private static void AnimateLayoutSurface(
+            Microsoft.UI.Xaml.FrameworkElement? content,
+            ref Anim.Storyboard? storyboard,
+            int travel)
+        {
+            if (content?.RenderTransform is not Microsoft.UI.Xaml.Media.CompositeTransform transform)
+                return;
+
+            storyboard?.Stop();
+            transform.TranslateX = travel;
+            transform.ScaleX = 0.985;
+            content.Opacity = Math.Min(content.Opacity <= 0 ? 1 : content.Opacity, 0.94);
+
+            var easing = new Anim.CubicEase { EasingMode = Anim.EasingMode.EaseOut };
+            var slide = new Anim.DoubleAnimation
+            {
+                To = 0,
+                Duration = new Microsoft.UI.Xaml.Duration(TimeSpan.FromMilliseconds(LayoutTransitionMilliseconds)),
+                EasingFunction = easing,
+                EnableDependentAnimation = true,
+            };
+            Anim.Storyboard.SetTarget(slide, transform);
+            Anim.Storyboard.SetTargetProperty(slide, "TranslateX");
+
+            var scale = new Anim.DoubleAnimation
+            {
+                To = 1,
+                Duration = new Microsoft.UI.Xaml.Duration(TimeSpan.FromMilliseconds(LayoutTransitionMilliseconds)),
+                EasingFunction = easing,
+            };
+            Anim.Storyboard.SetTarget(scale, transform);
+            Anim.Storyboard.SetTargetProperty(scale, "ScaleX");
+
+            var fade = new Anim.DoubleAnimation
+            {
+                To = 1,
+                Duration = new Microsoft.UI.Xaml.Duration(TimeSpan.FromMilliseconds(LayoutTransitionMilliseconds)),
+                EasingFunction = easing,
+            };
+            Anim.Storyboard.SetTarget(fade, content);
+            Anim.Storyboard.SetTargetProperty(fade, "Opacity");
+
+            var next = new Anim.Storyboard();
+            next.Children.Add(slide);
+            next.Children.Add(scale);
+            next.Children.Add(fade);
+            storyboard = next;
+            next.Begin();
         }
 
         private bool SetActivityHostVisible(bool visible)
@@ -1054,20 +1165,65 @@ namespace TaskbarQuota.Taskbar
                 return false;
             if (visible == isActivityVisible && activityAppWindow.IsVisible == visible)
                 return false;
+
+            activityFadeGeneration++;
+            int generation = activityFadeGeneration;
             isActivityVisible = visible;
-            activitySummary!.Visibility = visible
-                ? Microsoft.UI.Xaml.Visibility.Visible
-                : Microsoft.UI.Xaml.Visibility.Collapsed;
             if (visible)
             {
+                activitySummary!.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
                 activityAppWindow.Show(false);
-                activityHostContent.Opacity = 1;
+                AnimateActivityHostOpacity(1);
             }
             else
             {
-                activityAppWindow.Hide();
+                AnimateActivityHostOpacity(0, () =>
+                {
+                    if (generation != activityFadeGeneration || disposedValue)
+                        return;
+                    activityAppWindow.Hide();
+                    activitySummary!.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
+                    activityHostContent.Opacity = 1;
+                });
             }
             return true;
+        }
+
+        private void AnimateActivityHostOpacity(double to, Action? completed = null)
+        {
+            if (activityHostContent is not { } content)
+            {
+                completed?.Invoke();
+                return;
+            }
+
+            activityFadeStoryboard?.Stop();
+            double from = content.Opacity;
+            bool skip = Math.Abs(from - to) < 0.01 && to > 0.5;
+            if (skip)
+            {
+                content.Opacity = to;
+                completed?.Invoke();
+                return;
+            }
+
+            content.Opacity = to;
+            var animation = new Anim.DoubleAnimation
+            {
+                From = from < 0.01 ? 0.15 : from,
+                To = to,
+                Duration = new Microsoft.UI.Xaml.Duration(TimeSpan.FromMilliseconds(HostFadeMilliseconds)),
+                EasingFunction = new Anim.CubicEase { EasingMode = Anim.EasingMode.EaseOut },
+            };
+            Anim.Storyboard.SetTarget(animation, content);
+            Anim.Storyboard.SetTargetProperty(animation, "Opacity");
+
+            var storyboard = new Anim.Storyboard();
+            storyboard.Children.Add(animation);
+            if (completed is not null)
+                storyboard.Completed += (_, _) => completed();
+            activityFadeStoryboard = storyboard;
+            storyboard.Begin();
         }
 
         private void SetActivityLogicalWidthOnUiThread(int logicalWidth, int physicalWidth)
@@ -1241,20 +1397,69 @@ namespace TaskbarQuota.Taskbar
                 // it may occupy. That is the budget the tile-fit math trims against.
                 UpdateAvailableWidth(gaps);
 
-                var quotaGaps = gaps;
-                if (isActivityVisible && activityOffsetX != int.MinValue)
+                // Solve the two native windows together. Using the activity window's previous rectangle as
+                // an obstacle made a wider quota tile chase stale bounds; the quota would jump first, then
+                // the activity solver could no longer find a lane and hid its window. Only the activity
+                // width is flexible, so the quota anchor and the user's chosen left/right order stay stable.
+                int activityGap = (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale);
+                int minimumActivityWidth = (int)Math.Ceiling(
+                    AgentActivitySummary.MinimumLogicalWidth * dpiScale);
+                int maximumActivityWidth = (int)Math.Ceiling(
+                    AgentActivitySummary.DesiredLogicalWidth * dpiScale);
+                bool activityUsesDifferentTaskbarLane = isActivityVisible
+                    && hasManualActivityPosition
+                    && activityOffsetX != int.MinValue
+                    && TaskbarWidgetPlacement.OccupyDifferentGaps(
+                        preferredX,
+                        WidgetHostWidth,
+                        activityOffsetX,
+                        ActivityHostWidth,
+                        gaps);
+
+                AdaptiveWidgetPairPlacement? pairPlacement = null;
+                if (activityUsesDifferentTaskbarLane)
                 {
-                    var activityRect = new RECT
+                    int? detachedQuotaX = PlaceInFittingGap(preferredX, gaps, WidgetHostWidth);
+                    AdaptiveWidgetPlacement? detachedActivity = TaskbarWidgetPlacement.PlaceAdaptive(
+                        activityOffsetX,
+                        ActivityHostWidth,
+                        minimumActivityWidth,
+                        maximumActivityWidth,
+                        anchorRight: false,
+                        gaps);
+                    if (detachedQuotaX is { } quotaX
+                        && detachedActivity is { } activity
+                        && TaskbarWidgetPlacement.OccupyDifferentGaps(
+                            quotaX,
+                            WidgetHostWidth,
+                            activity.X,
+                            activity.Width,
+                            gaps))
                     {
-                        left = activityOffsetX - (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale),
-                        right = activityOffsetX + ActivityHostWidth + (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale),
-                        top = barRect.top,
-                        bottom = barRect.bottom,
-                    };
-                    var quotaObstacles = new List<RECT>(obstacles) { activityRect };
-                    quotaGaps = ComputeFreeGaps(leftBound, rightBound, quotaObstacles);
+                        pairPlacement = new AdaptiveWidgetPairPlacement(
+                            quotaX,
+                            activity.X,
+                            activity.Width,
+                            WidgetHostWidth + activity.Width);
+                    }
                 }
-                int? placed = PlaceInFittingGap(preferredX, quotaGaps, WidgetHostWidth);
+
+                pairPlacement ??= isActivityVisible
+                    ? TaskbarWidgetPlacement.PlaceAdaptivePair(
+                        preferredX,
+                        WidgetHostWidth,
+                        minimumActivityWidth,
+                        maximumActivityWidth,
+                        activityGap,
+                        widgetOrder,
+                        gaps,
+                        hasManualActivityPosition ? activityOffsetX : int.MinValue,
+                        ActivityHostWidth)
+                    : null;
+
+                int? placed = pairPlacement is { } pair
+                    ? pair.QuotaX
+                    : PlaceInFittingGap(preferredX, gaps, WidgetHostWidth);
                 if (placed is not { } fitX)
                 {
                     if (currentOffsetX != int.MinValue)
@@ -1264,6 +1469,20 @@ namespace TaskbarQuota.Taskbar
                 else
                 {
                     offsetX = fitX;
+                }
+
+                if (pairPlacement is { } adaptivePair)
+                {
+                    int logicalWidth = Math.Clamp(
+                        (int)Math.Floor(adaptivePair.ActivityWidth / dpiScale),
+                        AgentActivitySummary.MinimumLogicalWidth,
+                        AgentActivitySummary.DesiredLogicalWidth);
+                    int physicalWidth = (int)Math.Ceiling(logicalWidth * dpiScale);
+                    bool widthChanged = ActivityHostWidth != physicalWidth;
+                    ActivityHostWidth = physicalWidth;
+                    SetActivityLogicalWidthOnUiThread(logicalWidth, physicalWidth);
+                    if (widthChanged)
+                        Log.Debug($"activity width adapted to {logicalWidth} logical px beside quota");
                 }
 
                 offsetX = ClampToTaskbarMonitor(
@@ -1281,6 +1500,7 @@ namespace TaskbarQuota.Taskbar
                 if (disposedValue || targetAppWindow is null || !IsAlive)
                     return;
 
+                int previousQuotaOffsetX = currentOffsetX;
                 if (currentOffsetY != offsetY)
                 {
                     targetAppWindow.MoveAndResize(new RectInt32(offsetX, offsetY, WidgetHostWidth, barRect.bottom - barRect.top));
@@ -1291,77 +1511,29 @@ namespace TaskbarQuota.Taskbar
                     targetAppWindow.Move(new PointInt32(offsetX, offsetY));
                     currentOffsetX = offsetX;
                 }
+                if (previousQuotaOffsetX != int.MinValue && previousQuotaOffsetX != offsetX)
+                    AnimateLayoutSurface(hostContent, ref quotaLayoutStoryboard, previousQuotaOffsetX - offsetX);
 
                 if (isActivityVisible && activityAppWindow is not null)
                 {
-                    int quotaRightAnchor = offsetX + WidgetHostWidth
-                        + (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale);
-                    // In the normal quota-first order, keep the activity island to the quota's
-                    // right even when a previously saved activity position is stale or too far left.
-                    // This lets a wider quota widget push the optional activity view outward.
-                    int activityPreferred = widgetOrder == TaskbarWidgetOrder.QuotaFirst
-                        ? Math.Max(activityOffsetX, quotaRightAnchor)
-                        : activityOffsetX != int.MinValue
-                            ? activityOffsetX
-                            : quotaRightAnchor;
-                    var quotaRect = new RECT
+                    if (pairPlacement is null)
                     {
-                        left = offsetX - (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale),
-                        right = offsetX + WidgetHostWidth + (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale),
-                        top = barRect.top,
-                        bottom = barRect.bottom,
-                    };
-                    var activityObstacles = new List<RECT>(obstacles) { quotaRect };
-                    var activityGaps = ComputeFreeGaps(leftBound, rightBound, activityObstacles);
-                    int activityX;
-                    if (!IsUserRepositioning && TaskbarWidgetPlacement.PlaceAdaptive(
-                            activityPreferred,
-                            ActivityHostWidth,
-                            (int)Math.Ceiling(AgentActivitySummary.MinimumLogicalWidth * dpiScale),
-                            (int)Math.Ceiling(AgentActivitySummary.DesiredLogicalWidth * dpiScale),
-                            widgetOrder == TaskbarWidgetOrder.ActivityFirst,
-                            activityGaps) is { } adaptive)
-                    {
-                        int logicalWidth = Math.Clamp(
-                            (int)Math.Floor(adaptive.Width / dpiScale),
-                            AgentActivitySummary.MinimumLogicalWidth,
-                            AgentActivitySummary.DesiredLogicalWidth);
-                        int physicalWidth = (int)Math.Ceiling(logicalWidth * dpiScale);
-                        activityX = widgetOrder == TaskbarWidgetOrder.ActivityFirst
-                            ? adaptive.X + adaptive.Width - physicalWidth
-                            : adaptive.X;
-                        bool widthChanged = ActivityHostWidth != physicalWidth;
-                        ActivityHostWidth = physicalWidth;
-                        SetActivityLogicalWidthOnUiThread(logicalWidth, physicalWidth);
-                        if (widthChanged)
-                            Log.Debug($"activity width adapted to {logicalWidth} logical px in lane [{adaptive.X},{adaptive.X + adaptive.Width})");
+                        Log.Debug("activity hidden: no taskbar lane can fit quota plus the minimum activity width");
+                        SetActivityHostVisible(false);
+                        return;
                     }
-                    else
-                    {
-                        var fittedActivityX = PlaceInFittingGap(activityPreferred, activityGaps, ActivityHostWidth);
-                        if (fittedActivityX is not { } fittingX)
-                        {
-                            // There is no free lane for the activity host. Keeping the old preferred
-                            // position here would place the transparent activity window on top of quota
-                            // values, which is worse than temporarily hiding the optional activity view.
-                            Log.Debug("activity hidden: no taskbar gap can fit the activity host without overlap");
-                            SetActivityHostVisible(false);
-                            return;
-                        }
 
-                        activityX = fittingX;
-                    }
-                    activityX = ClampToTaskbarMonitor(
-                        activityX,
-                        ActivityHostWidth,
-                        taskbarScreenRect,
-                        notificationScreenRect,
-                        barRect,
-                        hwndShell,
-                        hasNotificationArea);
+                    var resolvedPair = pairPlacement.Value;
+                    // Keep the solver's saved/detached activity coordinate. If the final monitor clamp
+                    // nudged the quota by a few pixels, carry that same delta to the activity window so
+                    // the pair remains separated without collapsing back beside quota.
+                    int activityX = resolvedPair.ActivityX + (offsetX - resolvedPair.QuotaX);
+                    int previousActivityOffsetX = activityOffsetX;
                     activityAppWindow.MoveAndResize(new RectInt32(
                         activityX, offsetY, ActivityHostWidth, barRect.bottom - barRect.top));
                     activityOffsetX = activityX;
+                    if (previousActivityOffsetX != int.MinValue && previousActivityOffsetX != activityX)
+                        AnimateLayoutSurface(activityHostContent, ref activityLayoutStoryboard, previousActivityOffsetX - activityX);
                 }
             }
             catch (OperationCanceledException)
@@ -1500,9 +1672,7 @@ namespace TaskbarQuota.Taskbar
             {
                 if (Math.Abs(point.x - pressCursorPositionX) < Math.Ceiling(4 * dpiScale))
                     return;
-                isDirectDrag = true;
-                classicTaskbarReservation.Restore();
-                SuppressTileClicks();
+                BeginDirectDrag();
                 e.Handled = true;
             }
 
@@ -1598,9 +1768,7 @@ namespace TaskbarQuota.Taskbar
             {
                 if (Math.Abs(point.x - pressCursorPositionX) < Math.Ceiling(4 * dpiScale))
                     return;
-                isDirectDrag = true;
-                classicTaskbarReservation.Restore();
-                SuppressTileClicks();
+                BeginDirectDrag();
             }
 
             // Pointer events and the polling timer used to solve and move the native window in parallel.
@@ -1610,6 +1778,28 @@ namespace TaskbarQuota.Taskbar
                 return;
 
             MoveWidgetWithCursor(point.x);
+        }
+
+        private void BeginDirectDrag()
+        {
+            isDirectDrag = true;
+            if (draggingActivity)
+                CompactActivityForDrag();
+            classicTaskbarReservation.Restore();
+            SuppressTileClicks();
+        }
+
+        private void CompactActivityForDrag()
+        {
+            int dragLogicalWidth = Math.Clamp(
+                ActivityDragLogicalWidth,
+                AgentActivitySummary.MinimumLogicalWidth,
+                AgentActivitySummary.DesiredLogicalWidth);
+            activitySummary?.SetLogicalWidth(dragLogicalWidth);
+            ResizeActivityHost(dragLogicalWidth);
+            // A drag may begin from the far-right side of the expanded summary. Once compacted, keep the
+            // cursor's grab point inside the native window so crossing the centred icon cluster stays smooth.
+            draggingInnerOffsetX = Math.Clamp(draggingInnerOffsetX, 0, ActivityHostWidth);
         }
 
         private void FinishDirectDragFromPolling()
@@ -1790,6 +1980,19 @@ namespace TaskbarQuota.Taskbar
                     && separatedX + DragWidth <= selectedZone.end
                     ? separatedX
                     : (DragCurrentOffsetX != int.MinValue ? DragCurrentOffsetX : targetX);
+            }
+
+            if (draggingActivity && partnerX != int.MinValue
+                && TaskbarWidgetPlacement.SnapNextToPartner(
+                    targetX,
+                    DragWidth,
+                    partnerX,
+                    partnerWidth,
+                    (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale),
+                    (int)Math.Ceiling(PartnerSnapLogicalPx * dpiScale),
+                    gaps) is { } liveSnapX)
+            {
+                targetX = liveSnapX;
             }
 
             LogDragState(cursorClientX, desiredX, leftBound, rightBound, gaps, obstacles, selectedZone, targetX);
@@ -2072,6 +2275,7 @@ namespace TaskbarQuota.Taskbar
                 return;
             }
 
+            bool activityWasDragged = draggingActivity;
             isSettling = true;
             try
             {
@@ -2130,6 +2334,23 @@ namespace TaskbarQuota.Taskbar
                     ?? (DragCurrentOffsetX != int.MinValue
                         ? DragCurrentOffsetX
                         : ClampToSpan(droppedX, leftBound, rightBound, DragWidth));
+                bool activitySnappedToQuota = false;
+                if (activityWasDragged && currentOffsetX != int.MinValue
+                    && TaskbarWidgetPlacement.SnapNextToPartner(
+                        droppedX,
+                        DragWidth,
+                        currentOffsetX,
+                        WidgetHostWidth,
+                        snapGap,
+                        (int)Math.Ceiling(PartnerSnapLogicalPx * dpiScale),
+                        independentGaps) is { } partnerSnapX)
+                {
+                    settledX = partnerSnapX;
+                    activitySnappedToQuota = true;
+                    widgetOrder = settledX < currentOffsetX
+                        ? TaskbarWidgetOrder.ActivityFirst
+                        : TaskbarWidgetOrder.QuotaFirst;
+                }
 
                 DragAppWindow!.Move(new PointInt32(settledX, currentOffsetY));
                 if (draggingActivity)
@@ -2142,7 +2363,12 @@ namespace TaskbarQuota.Taskbar
                 }
                 if (currentOffsetX != int.MinValue)
                     SaveCustomPosition(currentOffsetX);
-                if (activityOffsetX != int.MinValue)
+                if (activitySnappedToQuota)
+                {
+                    ClearManualActivityPosition();
+                }
+                else if (activityOffsetX != int.MinValue
+                    && (activityWasDragged || hasManualActivityPosition))
                 {
                     SaveActivityPosition(activityOffsetX);
                 }
@@ -2164,6 +2390,8 @@ namespace TaskbarQuota.Taskbar
                 {
                     EndUserRepositioning();
                     RenderDeferredActivitySnapshot();
+                    if (activityWasDragged)
+                        QueuePositionUpdate(TaskbarChangeReason.None);
                 }
             }
         }
@@ -2172,6 +2400,12 @@ namespace TaskbarQuota.Taskbar
         {
             if (disposedValue || activitySummary is null)
                 return;
+            if (pendingEmptyActivitySnapshot is { } pending)
+            {
+                pendingEmptyActivitySnapshot = null;
+                activityEmptySnapshotTimer.Stop();
+                activitySnapshot = pending;
+            }
             activitySummary.Apply(activitySnapshot, activeTileProvider);
             foreach (var tile in tiles)
                 tile?.SetAgentActivity(activitySnapshot);
@@ -2698,11 +2932,16 @@ namespace TaskbarQuota.Taskbar
         {
             try
             {
-                if (File.Exists(activityPositionPath)
+                // Older builds wrote .activity while settling either widget, so that file by itself does
+                // not prove the user positioned Activity. Only coordinates accompanied by the explicit
+                // marker introduced with manual-position ownership are authoritative.
+                if (File.Exists(activityManualPositionPath)
+                    && File.Exists(activityPositionPath)
                     && int.TryParse(File.ReadAllText(activityPositionPath), NumberStyles.Integer,
                         CultureInfo.InvariantCulture, out var offset))
                 {
                     activityOffsetX = offset;
+                    hasManualActivityPosition = true;
                     int minimumWidth = (int)Math.Ceiling(AgentActivitySummary.MinimumLogicalWidth * dpiScale);
                     ActivityHostWidth = minimumWidth;
                     activitySummary?.SetLogicalWidth(AgentActivitySummary.MinimumLogicalWidth);
@@ -2718,8 +2957,19 @@ namespace TaskbarQuota.Taskbar
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(activityPositionPath)!);
                 File.WriteAllText(activityPositionPath, offset.ToString(CultureInfo.InvariantCulture));
+                File.WriteAllText(activityManualPositionPath, "1");
+                hasManualActivityPosition = true;
             }
             catch (Exception ex) { Log.Warning(ex, "Could not save detached activity position"); }
+        }
+
+        private void ClearManualActivityPosition()
+        {
+            hasManualActivityPosition = false;
+            try { if (File.Exists(activityPositionPath)) File.Delete(activityPositionPath); }
+            catch (Exception ex) { Log.Warning(ex, "Could not clear detached activity position"); }
+            try { if (File.Exists(activityManualPositionPath)) File.Delete(activityManualPositionPath); }
+            catch (Exception ex) { Log.Warning(ex, "Could not clear manual activity position marker"); }
         }
 
 
@@ -2939,7 +3189,9 @@ namespace TaskbarQuota.Taskbar
             summaryPanel = null;
             if (activitySummary is not null)
             {
-                activitySummary.PointerPressed -= WidgetSummary_PointerPressed;
+                activitySummary.RemoveHandler(
+                    Microsoft.UI.Xaml.UIElement.PointerPressedEvent,
+                    new Microsoft.UI.Xaml.Input.PointerEventHandler(WidgetSummary_PointerPressed));
                 activitySummary.PointerMoved -= WidgetSummary_PointerMoved;
                 activitySummary.PointerReleased -= WidgetSummary_PointerReleased;
                 activitySummary.PointerCanceled -= WidgetSummary_PointerCanceled;

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -58,6 +58,7 @@ namespace TaskbarQuota.Taskbar
         // Approx width of the Win11 far-left Widgets/weather pill; used to reserve clearance when its exact
         // bounds can't be read via UIA, so the widget never anchors on top of it (issue #17).
         private const int WidgetsButtonFallbackLogicalPx = 160;
+        private const int VK_LBUTTON = 0x01;
 
         private static readonly bool IsRtlUI = System.Globalization.CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft;
         private static readonly object WindowClassLock = new();
@@ -82,12 +83,16 @@ namespace TaskbarQuota.Taskbar
         private readonly TaskbarStructureWatcher taskbarWatcher;
         private readonly ClassicTaskbarSpaceReservation classicTaskbarReservation;
         private readonly string positionPath;
+        private readonly string orderPath;
+        private readonly string activityPositionPath;
         private readonly CancellationTokenSource positionUpdateCancellation = new();
         private readonly SemaphoreSlim positionUpdateGate = new(1, 1);
         private readonly object positionRequestLock = new();
 
         private IntPtr hwnd;
         private AppWindow? appWindow;
+        private IntPtr activityHwnd;
+        private AppWindow? activityAppWindow;
         // Fixed pool of tile slots, created once and reused. Slot i renders tileProviders[i]; reassigning a
         // slot to another provider re-renders it through WidgetSummary's normal provider-switch path. A
         // fixed pool means the panel's children never change, so no tile is ever unloaded and re-loaded
@@ -128,14 +133,18 @@ namespace TaskbarQuota.Taskbar
         private int? lastLayoutHash;
         private bool loggedMissingPanel;
         private DesktopWindowXamlSource? host;
+        private DesktopWindowXamlSource? activityHost;
         private Microsoft.UI.Xaml.FrameworkElement? hostContent;
+        private Microsoft.UI.Xaml.FrameworkElement? activityHostContent;
         // Show/hide cross-fade state. Short on purpose: the widget lives on the taskbar, so anything
         // slower reads as lag rather than as a transition.
         private const int HostFadeMilliseconds = 100;
         private Anim.Storyboard? hostFadeStoryboard;
         private int hostFadeGeneration;
         private int WidgetHostWidth;
+        private int ActivityHostWidth;
         private int currentOffsetX = int.MinValue;
+        private int activityOffsetX = int.MinValue;
         private int currentOffsetY = 0;
         // Last known Widgets/weather pill bounds in taskbar-client coords, captured during the resting
         // reposition so the synchronous drag path can avoid it without an async UIA read.
@@ -147,6 +156,9 @@ namespace TaskbarQuota.Taskbar
         private bool isDragging;
         private bool isPointerTracking;
         private bool isDirectDrag;
+        private Microsoft.UI.Xaml.DispatcherTimer? dragPollTimer;
+        private bool draggingActivity;
+        private TaskbarWidgetOrder widgetOrder = TaskbarWidgetOrder.QuotaFirst;
 
         // True while the user is actively repositioning the widget (tray "Move" mode or a direct pointer
         // drag). Background repositions (2s watcher poll, taskbar events) must not fire during this, or the
@@ -169,9 +181,16 @@ namespace TaskbarQuota.Taskbar
         private int loggedDragGapHash;
         private int lastCursorPositionX;
         private int pressCursorPositionX;
+        private int dragOriginX;
+        private int dragPartnerOriginX;
+        private TaskbarWidgetOrder dragOriginOrder;
+        private int? pendingSwapDraggedX;
+        private (int quotaOld, int quotaNew, int activityOld, int activityNew)? pendingSwapVisual;
+        private Anim.Storyboard? swapVisualStoryboard;
         private bool initialized;
         private bool destroyed;
         private bool isVisible;
+        private bool isActivityVisible;
         private bool windowClassAcquired;
         private bool disposedValue;
         private bool positionRunnerActive;
@@ -181,7 +200,14 @@ namespace TaskbarQuota.Taskbar
         private bool pendingTaskbarWidgetsEnabled;
 
         public IntPtr Handle => hwnd != IntPtr.Zero ? hwnd : throw new InvalidOperationException("Widget not initialized.");
+        public IntPtr ActivityHandle => activityHwnd != IntPtr.Zero && activityAppWindow?.IsVisible == true
+            ? activityHwnd
+            : Handle;
         public bool IsAlive => hwnd != IntPtr.Zero && User32.IsWindow(hwnd);
+        private AppWindow? DragAppWindow => draggingActivity ? activityAppWindow : appWindow;
+        private Microsoft.UI.Xaml.FrameworkElement? DragContent => draggingActivity ? activityHostContent : hostContent;
+        private int DragWidth => draggingActivity ? ActivityHostWidth : WidgetHostWidth;
+        private int DragCurrentOffsetX => draggingActivity ? activityOffsetX : currentOffsetX;
         /// <summary>True once <see cref="Initialize"/> has built the tile panel. A live window without it can
         /// render nothing at all, so the manager treats that pairing as a dead widget and recreates it.</summary>
         public bool IsHostContentReady => summaryPanel is not null;
@@ -226,8 +252,11 @@ namespace TaskbarQuota.Taskbar
             taskbarDpi = detectedDpi == 0 ? 96u : detectedDpi;
             dpiScale = taskbarDpi / 96d;
             WidgetHostWidth = (int)Math.Ceiling(dpiScale * DefaultWidgetHostWidth);
+            ActivityHostWidth = (int)Math.Ceiling(dpiScale * AgentActivitySummary.DefaultLogicalWidth);
             Log.Debug($"Widget ctor: taskbar=0x{hwndShell.ToInt64():X}, primary={isPrimaryTaskbar}, DPI={taskbarDpi}, Width={WidgetHostWidth}");
             positionPath = target.GetPositionPath();
+            orderPath = positionPath + ".order";
+            activityPositionPath = positionPath + ".activity";
 
             taskbarWatcher = new TaskbarStructureWatcher(hwndShell, hwndReBar);
             classicTaskbarReservation = new ClassicTaskbarSpaceReservation(hwndShell);
@@ -263,10 +292,13 @@ namespace TaskbarQuota.Taskbar
             hostContent = new Microsoft.UI.Xaml.Controls.Grid
             {
                 Children = { summaryPanel },
-                Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Colors.Transparent)
+                Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Colors.Transparent),
+                RenderTransform = new Microsoft.UI.Xaml.Media.CompositeTransform(),
             };
             host.Content = hostContent;
             ResizeWidgetHost(WidgetWidthForMode(WidgetSettingsService.Current));
+
+            InitializeActivityHost(taskbarRect);
 
             InjectIntoTaskbar();
             QueuePositionUpdate(TaskbarChangeReason.None);
@@ -279,6 +311,55 @@ namespace TaskbarQuota.Taskbar
             // same "no panel yet" early-out on every health tick. That left the host injected with every
             // tile still collapsed — an invisible widget for the life of the process.
             ApplyPendingDisplayProviders();
+        }
+
+        private void InitializeActivityHost(RECT taskbarRect)
+        {
+            activityHost = new DesktopWindowXamlSource();
+            activityHwnd = CreateHostWindow(hwndShell);
+            var activityId = Win32Interop.GetWindowIdFromWindow(activityHwnd);
+            activityAppWindow = AppWindow.GetFromWindowId(activityId);
+            activityAppWindow.IsShownInSwitchers = false;
+            activityAppWindow.Destroying += ActivityAppWindow_Destroying;
+            activityAppWindow.ResizeClient(new SizeInt32(ActivityHostWidth, taskbarRect.bottom - taskbarRect.top));
+            activityHost.Initialize(activityId);
+            activityHost.SiteBridge.ResizePolicy = Microsoft.UI.Content.ContentSizePolicy.ResizeContentToParentWindow;
+            activitySummary = CreateActivitySummary();
+            activityHostContent = new Microsoft.UI.Xaml.Controls.Grid
+            {
+                Children = { activitySummary },
+                Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Colors.Transparent),
+                RenderTransform = new Microsoft.UI.Xaml.Media.CompositeTransform(),
+            };
+            activityHost.Content = activityHostContent;
+            User32.SetParent(activityHwnd, hwndShell);
+            if (User32.GetAncestor(activityHwnd, GetAncestorFlags.GA_PARENT) != hwndShell)
+                throw new InvalidOperationException("Could not inject the activity widget into the taskbar.");
+            activityAppWindow.Hide();
+            LoadWidgetOrder();
+            LoadActivityPosition();
+        }
+
+        private AgentActivitySummary CreateActivitySummary()
+        {
+            var summary = new AgentActivitySummary
+            {
+                Visibility = Microsoft.UI.Xaml.Visibility.Collapsed,
+                HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
+                VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Stretch,
+            };
+            summary.PointerPressed += WidgetSummary_PointerPressed;
+            summary.PointerMoved += WidgetSummary_PointerMoved;
+            summary.PointerReleased += WidgetSummary_PointerReleased;
+            summary.PointerCanceled += WidgetSummary_PointerCanceled;
+            summary.Clicked += OnActivityClicked;
+            return summary;
+        }
+
+        private void ActivityAppWindow_Destroying(AppWindow sender, object args)
+        {
+            if (activityAppWindow is not null)
+                activityAppWindow.Destroying -= ActivityAppWindow_Destroying;
         }
 
         /// <summary>Replays the provider set that arrived before <see cref="Initialize"/> built the panel.</summary>
@@ -352,6 +433,8 @@ namespace TaskbarQuota.Taskbar
                     hostContent.Opacity = 0;
                 appWindow.Show(false);
                 AnimateHostOpacity(1);
+                if (isActivityVisible)
+                    activityAppWindow?.Show(false);
                 return;
             }
 
@@ -362,6 +445,7 @@ namespace TaskbarQuota.Taskbar
             {
                 classicTaskbarReservation.Restore();
                 appWindow.Hide();
+                activityAppWindow?.Hide();
                 return;
             }
 
@@ -373,6 +457,7 @@ namespace TaskbarQuota.Taskbar
 
                 classicTaskbarReservation.Restore();
                 appWindow.Hide();
+                activityAppWindow?.Hide();
                 // Leave the content opaque again so the next Show has nothing to undo if it takes the
                 // no-animation path (e.g. the host was rebuilt in between).
                 if (hostContent is { } content)
@@ -433,7 +518,14 @@ namespace TaskbarQuota.Taskbar
         public void UpdatePosition(bool resetManualPosition = false)
         {
             if (resetManualPosition)
+            {
                 SaveCustomPosition(-1);
+                widgetOrder = TaskbarWidgetOrder.QuotaFirst;
+                SaveWidgetOrder();
+                activityOffsetX = int.MinValue;
+                try { if (File.Exists(activityPositionPath)) File.Delete(activityPositionPath); }
+                catch (Exception ex) { Log.Warning(ex, "Could not clear detached activity position"); }
+            }
             QueuePositionUpdate(TaskbarChangeReason.None);
         }
 
@@ -448,19 +540,6 @@ namespace TaskbarQuota.Taskbar
                 VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Stretch,
             };
 
-            activitySummary = new AgentActivitySummary
-            {
-                Margin = new Microsoft.UI.Xaml.Thickness(ActivitySummaryMarginLogicalPx, 0, 0, 0),
-                Visibility = Microsoft.UI.Xaml.Visibility.Collapsed,
-                HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
-                VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Stretch,
-            };
-            activitySummary.PointerPressed += WidgetSummary_PointerPressed;
-            activitySummary.PointerMoved += WidgetSummary_PointerMoved;
-            activitySummary.PointerReleased += WidgetSummary_PointerReleased;
-            activitySummary.PointerCanceled += WidgetSummary_PointerCanceled;
-            activitySummary.Clicked += OnActivityClicked;
-
             for (int i = 0; i < tiles.Length; i++)
             {
                 if (i > 0)
@@ -472,9 +551,6 @@ namespace TaskbarQuota.Taskbar
                 tiles[i] = CreateTile();
                 panel.Children.Add(tiles[i]);
             }
-
-            // The quota is the stable anchor. The wider, changing agent step follows it on the right.
-            panel.Children.Add(activitySummary);
 
             return panel;
         }
@@ -519,6 +595,12 @@ namespace TaskbarQuota.Taskbar
         public void SetActivitySnapshot(AgentActivitySnapshot snapshot)
         {
             activitySnapshot = snapshot;
+            // Transcript discovery publishes about once per second. Rebuilding and resizing the separate
+            // activity island while its pointer is captured makes the native drag visibly stutter and can
+            // change which gap fits underneath the cursor. Keep the newest snapshot and render it as soon
+            // as the drag settles instead.
+            if (IsUserRepositioning)
+                return;
             activitySummary?.Apply(snapshot, activeTileProvider);
             foreach (var tile in tiles)
                 tile?.SetAgentActivity(snapshot);
@@ -635,11 +717,9 @@ namespace TaskbarQuota.Taskbar
             isRecomputingLayout = true;
             try
             {
-                bool showActivity = activitySnapshot.Primary is not null;
-                if (activitySummary is not null)
-                    activitySummary.Visibility = showActivity
-                        ? Microsoft.UI.Xaml.Visibility.Visible
-                        : Microsoft.UI.Xaml.Visibility.Collapsed;
+                bool showActivity = WidgetSettingsService.ShowAgentActivityInWidget
+                    && activitySnapshot.Primary is not null
+                    && activityAppWindow is not null;
 
                 Array.Clear(tileSuppressed);
 
@@ -672,22 +752,29 @@ namespace TaskbarQuota.Taskbar
                     total += width + TileHorizontalMarginLogicalPx + (n > 0 ? TileSeparatorLogicalPx : 0);
                 }
 
-                // Give the activity panel exactly the remaining taskbar budget. Its title and action
-                // TextBlocks can then trim against a real width instead of painting into the shell buttons.
-                int quotaWidth = total;
+                // The activity island is placed independently from the quota island. Keep its current
+                // width during layout/drag; the resting-position solver below expands it against the exact
+                // free lane it occupies, rather than an approximate shared-row budget.
                 int activityWidth = 0;
                 if (showActivity && activitySummary is not null)
                 {
-                    int remainingWidth = availableLogicalWidth - quotaWidth;
-                    int activityOuterWidth = Math.Clamp(
-                        remainingWidth,
-                        ActivitySummaryMarginLogicalPx + 1,
-                        AgentActivitySummary.DesiredLogicalWidth + ActivitySummaryMarginLogicalPx);
-                    activitySummary.SetLogicalWidth(activityOuterWidth - ActivitySummaryMarginLogicalPx);
-                    activityWidth = activityOuterWidth;
+                    if (availableLogicalWidth < AgentActivitySummary.MinimumLogicalWidth)
+                        showActivity = false;
+                    else
+                    {
+                        activityWidth = Math.Clamp(
+                            (int)Math.Floor(ActivityHostWidth / dpiScale),
+                            AgentActivitySummary.MinimumLogicalWidth,
+                            AgentActivitySummary.DesiredLogicalWidth);
+                        activitySummary.SetLogicalWidth(activityWidth);
+                    }
                 }
 
-                total += activityWidth;
+                if (activitySummary is not null)
+                    activitySummary.Visibility = showActivity
+                        ? Microsoft.UI.Xaml.Visibility.Visible
+                        : Microsoft.UI.Xaml.Visibility.Collapsed;
+                bool activityVisibilityChanged = SetActivityHostVisible(showActivity);
 
                 for (int i = 0; i < tiles.Length; i++)
                 {
@@ -720,7 +807,8 @@ namespace TaskbarQuota.Taskbar
                 }
 
                 bool resized = ResizeWidgetHost(count == 0 ? DefaultWidgetHostWidth : total);
-                if (resized || forceReposition)
+                bool activityResized = ResizeActivityHost(activityWidth);
+                if (resized || activityResized || activityVisibilityChanged || forceReposition)
                     UpdatePosition();
             }
             catch (Exception ex)
@@ -945,6 +1033,66 @@ namespace TaskbarQuota.Taskbar
             return true;
         }
 
+        private bool ResizeActivityHost(int logicalWidth)
+        {
+            if (activityAppWindow is null || logicalWidth <= 0)
+                return false;
+
+            int width = (int)Math.Ceiling(dpiScale * logicalWidth);
+            if (ActivityHostWidth != width)
+            {
+                ActivityHostWidth = width;
+                activityAppWindow.ResizeClient(new SizeInt32(width, activityAppWindow.Size.Height));
+                return true;
+            }
+            return false;
+        }
+
+        private bool SetActivityHostVisible(bool visible)
+        {
+            if (activityAppWindow is null || activityHostContent is null)
+                return false;
+            if (visible == isActivityVisible && activityAppWindow.IsVisible == visible)
+                return false;
+            isActivityVisible = visible;
+            activitySummary!.Visibility = visible
+                ? Microsoft.UI.Xaml.Visibility.Visible
+                : Microsoft.UI.Xaml.Visibility.Collapsed;
+            if (visible)
+            {
+                activityAppWindow.Show(false);
+                activityHostContent.Opacity = 1;
+            }
+            else
+            {
+                activityAppWindow.Hide();
+            }
+            return true;
+        }
+
+        private void SetActivityLogicalWidthOnUiThread(int logicalWidth, int physicalWidth)
+        {
+            var summary = activitySummary;
+            if (summary is null)
+                return;
+
+            var dispatcher = summary.DispatcherQueue;
+            if (dispatcher.HasThreadAccess)
+            {
+                summary.SetLogicalWidth(logicalWidth);
+                return;
+            }
+
+            if (!dispatcher.TryEnqueue(() =>
+                {
+                    if (!disposedValue && ActivityHostWidth == physicalWidth)
+                        summary.SetLogicalWidth(logicalWidth);
+                }))
+            {
+                Log.Warning("Could not enqueue adaptive activity width on the UI thread");
+            }
+        }
+
         private static int WidgetWidthForMode(WidgetDisplayMode mode) => mode switch
         {
             WidgetDisplayMode.PercentagesOnly => 220,
@@ -1093,7 +1241,20 @@ namespace TaskbarQuota.Taskbar
                 // it may occupy. That is the budget the tile-fit math trims against.
                 UpdateAvailableWidth(gaps);
 
-                int? placed = PlaceInFittingGap(preferredX, gaps, WidgetHostWidth);
+                var quotaGaps = gaps;
+                if (isActivityVisible && activityOffsetX != int.MinValue)
+                {
+                    var activityRect = new RECT
+                    {
+                        left = activityOffsetX - (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale),
+                        right = activityOffsetX + ActivityHostWidth + (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale),
+                        top = barRect.top,
+                        bottom = barRect.bottom,
+                    };
+                    var quotaObstacles = new List<RECT>(obstacles) { activityRect };
+                    quotaGaps = ComputeFreeGaps(leftBound, rightBound, quotaObstacles);
+                }
+                int? placed = PlaceInFittingGap(preferredX, quotaGaps, WidgetHostWidth);
                 if (placed is not { } fitX)
                 {
                     if (currentOffsetX != int.MinValue)
@@ -1130,6 +1291,61 @@ namespace TaskbarQuota.Taskbar
                     targetAppWindow.Move(new PointInt32(offsetX, offsetY));
                     currentOffsetX = offsetX;
                 }
+
+                if (isActivityVisible && activityAppWindow is not null)
+                {
+                    int activityPreferred = activityOffsetX != int.MinValue
+                        ? activityOffsetX
+                        : offsetX + WidgetHostWidth + (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale);
+                    var quotaRect = new RECT
+                    {
+                        left = offsetX - (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale),
+                        right = offsetX + WidgetHostWidth + (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale),
+                        top = barRect.top,
+                        bottom = barRect.bottom,
+                    };
+                    var activityObstacles = new List<RECT>(obstacles) { quotaRect };
+                    var activityGaps = ComputeFreeGaps(leftBound, rightBound, activityObstacles);
+                    int activityX;
+                    if (!IsUserRepositioning && TaskbarWidgetPlacement.PlaceAdaptive(
+                            activityPreferred,
+                            ActivityHostWidth,
+                            (int)Math.Ceiling(AgentActivitySummary.MinimumLogicalWidth * dpiScale),
+                            (int)Math.Ceiling(AgentActivitySummary.DesiredLogicalWidth * dpiScale),
+                            widgetOrder == TaskbarWidgetOrder.ActivityFirst,
+                            activityGaps) is { } adaptive)
+                    {
+                        int logicalWidth = Math.Clamp(
+                            (int)Math.Floor(adaptive.Width / dpiScale),
+                            AgentActivitySummary.MinimumLogicalWidth,
+                            AgentActivitySummary.DesiredLogicalWidth);
+                        int physicalWidth = (int)Math.Ceiling(logicalWidth * dpiScale);
+                        activityX = widgetOrder == TaskbarWidgetOrder.ActivityFirst
+                            ? adaptive.X + adaptive.Width - physicalWidth
+                            : adaptive.X;
+                        bool widthChanged = ActivityHostWidth != physicalWidth;
+                        ActivityHostWidth = physicalWidth;
+                        SetActivityLogicalWidthOnUiThread(logicalWidth, physicalWidth);
+                        if (widthChanged)
+                            Log.Debug($"activity width adapted to {logicalWidth} logical px in lane [{adaptive.X},{adaptive.X + adaptive.Width})");
+                    }
+                    else
+                    {
+                        activityX = PlaceInFittingGap(activityPreferred, activityGaps, ActivityHostWidth)
+                            ?? (activityOffsetX != int.MinValue ? activityOffsetX : activityPreferred);
+                    }
+                    activityX = ClampToTaskbarMonitor(
+                        activityX,
+                        ActivityHostWidth,
+                        taskbarScreenRect,
+                        notificationScreenRect,
+                        barRect,
+                        hwndShell,
+                        hasNotificationArea);
+                    activityAppWindow.MoveAndResize(new RectInt32(
+                        activityX, offsetY, ActivityHostWidth, barRect.bottom - barRect.top));
+                    activityOffsetX = activityX;
+                }
             }
             catch (OperationCanceledException)
             {
@@ -1159,6 +1375,8 @@ namespace TaskbarQuota.Taskbar
         public void StartDragging()
         {
             if (isDragging || appWindow is null || hostContent is null || summaryPanel is null) return;
+            draggingActivity = false;
+            CaptureDragOrigins();
             BeginUserRepositioning();
             isDragging = true;
             SetVisible(true);
@@ -1178,29 +1396,31 @@ namespace TaskbarQuota.Taskbar
 
         public void EndDragging(bool revert)
         {
-            if (!isDragging || appWindow is null || hostContent is null || summaryPanel is null)
+            StopDragPolling();
+            var dragWindow = DragAppWindow;
+            var dragContent = DragContent;
+            if (!isDragging || dragWindow is null || dragContent is null || summaryPanel is null)
             {
                 if (!isDragging && !isPointerTracking && !isDirectDrag)
                     EndUserRepositioning();
                 return;
             }
             isDragging = false;
-            hostContent.ReleasePointerCaptures();
-            hostContent.KeyUp -= Content_KeyUp;
-            hostContent.PointerMoved -= Content_PointerMoved;
-            hostContent.PointerPressed -= Content_PointerPressed;
-            hostContent.PointerReleased -= Content_PointerReleased;
+            dragContent.ReleasePointerCaptures();
+            dragContent.KeyUp -= Content_KeyUp;
+            dragContent.PointerMoved -= Content_PointerMoved;
+            dragContent.PointerPressed -= Content_PointerPressed;
+            dragContent.PointerReleased -= Content_PointerReleased;
             SetTilesHitTestVisible(true);
             if (revert)
             {
-                dragPreviewX = null;
-                activeDragGap = null;
-                appWindow.Move(new PointInt32(currentOffsetX, currentOffsetY));
+                RestoreDragOrigins();
                 QueuePositionUpdate(TaskbarChangeReason.None);
                 EndUserRepositioning();
+                RenderDeferredActivitySnapshot();
                 return;
             }
-            _ = SnapToValidPositionAsync(dragPreviewX ?? appWindow.Position.X);
+            _ = SnapToValidPositionAsync(dragPreviewX ?? dragWindow.Position.X);
         }
 
         private void Content_KeyUp(object sender, KeyRoutedEventArgs e)
@@ -1211,29 +1431,37 @@ namespace TaskbarQuota.Taskbar
 
         private void Content_PointerPressed(object sender, PointerRoutedEventArgs e)
         {
-            if (appWindow is null || hostContent is null) return;
+            var dragWindow = DragAppWindow;
+            var dragContent = DragContent;
+            if (dragWindow is null || dragContent is null) return;
             e.Handled = true;
-            hostContent.PointerMoved += Content_PointerMoved;
-            hostContent.CapturePointer(e.Pointer);
+            dragContent.PointerMoved += Content_PointerMoved;
+            dragContent.CapturePointer(e.Pointer);
             User32.GetCursorPos(out var point);
             lastCursorPositionX = point.x;
             User32.GetWindowRect(hwndShell, out var taskbarRect);
-            draggingInnerOffsetX = point.x - taskbarRect.left - appWindow.Position.X;
+            draggingInnerOffsetX = point.x - taskbarRect.left - dragWindow.Position.X;
+            StartDragPolling();
         }
 
-        private void Content_PointerReleased(object sender, PointerRoutedEventArgs e) => EndDragging(false);
+        private void Content_PointerReleased(object sender, PointerRoutedEventArgs e)
+        {
+            StopDragPolling();
+            EndDragging(false);
+        }
 
         private void Content_PointerMoved(object sender, PointerRoutedEventArgs e)
         {
             if (appWindow is null || hostContent is null) return;
-            User32.GetCursorPos(out var point);
-            MoveWidgetWithCursor(point.x);
             hostContent.Focus(Microsoft.UI.Xaml.FocusState.Programmatic);
         }
 
         private void WidgetSummary_PointerPressed(object sender, PointerRoutedEventArgs e)
         {
-            if (appWindow is null || sender is not Microsoft.UI.Xaml.UIElement element) return;
+            var dragWindow = ReferenceEquals(sender, activitySummary) ? activityAppWindow : appWindow;
+            if (dragWindow is null || sender is not Microsoft.UI.Xaml.UIElement element) return;
+            draggingActivity = ReferenceEquals(sender, activitySummary);
+            CaptureDragOrigins();
             BeginUserRepositioning();
             isPointerTracking = true;
             isDirectDrag = false;
@@ -1243,12 +1471,13 @@ namespace TaskbarQuota.Taskbar
             pressCursorPositionX = point.x;
             lastCursorPositionX = point.x;
             User32.GetWindowRect(hwndShell, out var taskbarRect);
-            draggingInnerOffsetX = point.x - taskbarRect.left - appWindow.Position.X;
+            draggingInnerOffsetX = point.x - taskbarRect.left - dragWindow.Position.X;
+            StartDragPolling();
         }
 
         private void WidgetSummary_PointerMoved(object sender, PointerRoutedEventArgs e)
         {
-            if (!isPointerTracking || appWindow is null || sender is not Microsoft.UI.Xaml.UIElement) return;
+            if (!isPointerTracking || DragAppWindow is null || sender is not Microsoft.UI.Xaml.UIElement) return;
             User32.GetCursorPos(out var point);
             if (!isDirectDrag)
             {
@@ -1260,35 +1489,132 @@ namespace TaskbarQuota.Taskbar
                 e.Handled = true;
             }
 
-            MoveWidgetWithCursor(point.x);
             SuppressTileClicks();
         }
 
         private void WidgetSummary_PointerReleased(object sender, PointerRoutedEventArgs e)
         {
+            StopDragPolling();
+            if (!isPointerTracking)
+                return;
             bool wasDirectDrag = isDirectDrag;
             (sender as Microsoft.UI.Xaml.UIElement)?.ReleasePointerCaptures();
-            if (wasDirectDrag && appWindow is not null)
+            if (wasDirectDrag && DragAppWindow is not null)
             {
-                _ = SnapToValidPositionAsync(dragPreviewX ?? appWindow.Position.X);
+                _ = SnapToValidPositionAsync(dragPreviewX ?? DragAppWindow.Position.X);
                 SuppressTileClicks();
                 e.Handled = true;
             }
             isPointerTracking = false;
             isDirectDrag = false;
             if (!wasDirectDrag)
+            {
+                draggingActivity = false;
                 EndUserRepositioning();
+            }
         }
 
         private void WidgetSummary_PointerCanceled(object sender, PointerRoutedEventArgs e)
         {
+            StopDragPolling();
+            if (!isPointerTracking)
+                return;
             bool wasDirectDrag = isDirectDrag;
             isPointerTracking = false;
             isDirectDrag = false;
             (sender as Microsoft.UI.Xaml.UIElement)?.ReleasePointerCaptures();
             if (wasDirectDrag)
+            {
+                RestoreDragOrigins();
                 QueuePositionUpdate(TaskbarChangeReason.None);
+            }
+            draggingActivity = false;
             EndUserRepositioning();
+            RenderDeferredActivitySnapshot();
+        }
+
+        private void StartDragPolling()
+        {
+            dragPollTimer ??= new Microsoft.UI.Xaml.DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(16),
+            };
+            dragPollTimer.Tick -= DragPollTimer_Tick;
+            dragPollTimer.Tick += DragPollTimer_Tick;
+            dragPollTimer.Start();
+        }
+
+        private void StopDragPolling()
+        {
+            if (dragPollTimer is null)
+                return;
+            dragPollTimer.Stop();
+            dragPollTimer.Tick -= DragPollTimer_Tick;
+        }
+
+        private void DragPollTimer_Tick(object? sender, object e)
+        {
+            if (!isDragging && !isPointerTracking)
+            {
+                StopDragPolling();
+                return;
+            }
+
+            bool leftButtonDown = (User32.GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0;
+            if (!leftButtonDown)
+            {
+                StopDragPolling();
+                if (isDragging)
+                {
+                    EndDragging(false);
+                    return;
+                }
+
+                FinishDirectDragFromPolling();
+                return;
+            }
+
+            if (!User32.GetCursorPos(out var point))
+                return;
+
+            if (isPointerTracking && !isDirectDrag)
+            {
+                if (Math.Abs(point.x - pressCursorPositionX) < Math.Ceiling(4 * dpiScale))
+                    return;
+                isDirectDrag = true;
+                classicTaskbarReservation.Restore();
+                SuppressTileClicks();
+            }
+
+            // Pointer events and the polling timer used to solve and move the native window in parallel.
+            // Polling is now the single clock; skip an unchanged sample unless a partner exchange is still
+            // easing to its destination.
+            if (point.x == lastCursorPositionX && pendingSwapDraggedX is null)
+                return;
+
+            MoveWidgetWithCursor(point.x);
+        }
+
+        private void FinishDirectDragFromPolling()
+        {
+            bool wasDirectDrag = isDirectDrag;
+            activitySummary?.ReleasePointerCaptures();
+            foreach (var tile in tiles)
+                tile?.ReleasePointerCaptures();
+
+            isPointerTracking = false;
+            isDirectDrag = false;
+            if (wasDirectDrag && DragAppWindow is not null)
+            {
+                _ = SnapToValidPositionAsync(dragPreviewX ?? DragAppWindow.Position.X);
+                SuppressTileClicks();
+            }
+            else
+            {
+                draggingActivity = false;
+                EndUserRepositioning();
+                RenderDeferredActivitySnapshot();
+            }
         }
 
         private void BeginUserRepositioning()
@@ -1307,6 +1633,43 @@ namespace TaskbarQuota.Taskbar
 
             userRepositioningRegistered = false;
             Interlocked.Decrement(ref userRepositioningCount);
+        }
+
+        private void CaptureDragOrigins()
+        {
+            dragOriginX = DragCurrentOffsetX != int.MinValue
+                ? DragCurrentOffsetX
+                : DragAppWindow?.Position.X ?? 0;
+            dragPartnerOriginX = draggingActivity ? currentOffsetX : activityOffsetX;
+            dragOriginOrder = widgetOrder;
+            pendingSwapDraggedX = null;
+            pendingSwapVisual = null;
+        }
+
+        private void RestoreDragOrigins()
+        {
+            if (draggingActivity)
+            {
+                activityAppWindow?.Move(new PointInt32(dragOriginX, currentOffsetY));
+                if (dragPartnerOriginX != int.MinValue)
+                    appWindow?.Move(new PointInt32(dragPartnerOriginX, currentOffsetY));
+                activityOffsetX = dragOriginX;
+                currentOffsetX = dragPartnerOriginX;
+            }
+            else
+            {
+                appWindow?.Move(new PointInt32(dragOriginX, currentOffsetY));
+                if (dragPartnerOriginX != int.MinValue)
+                    activityAppWindow?.Move(new PointInt32(dragPartnerOriginX, currentOffsetY));
+                currentOffsetX = dragOriginX;
+                activityOffsetX = dragPartnerOriginX;
+            }
+
+            widgetOrder = dragOriginOrder;
+            pendingSwapDraggedX = null;
+            pendingSwapVisual = null;
+            dragPreviewX = null;
+            activeDragGap = null;
         }
 
         private void SetTilesHitTestVisible(bool visible)
@@ -1345,7 +1708,8 @@ namespace TaskbarQuota.Taskbar
         /// </summary>
         private void MoveWidgetWithCursor(int cursorX)
         {
-            if (appWindow is null) return;
+            var dragWindow = DragAppWindow;
+            if (dragWindow is null) return;
             if (!TryGetLayoutRects(
                     out RECT taskbarRect,
                     out RECT notificationRect,
@@ -1368,8 +1732,16 @@ namespace TaskbarQuota.Taskbar
             int cursorClientX = cursorX - taskbarRect.left;
             int desiredX = cursorClientX - draggingInnerOffsetX;
 
-            var gap = SelectDragGap(gaps, cursorClientX, desiredX, WidgetHostWidth, activeDragGap);
-            if (gap is not { } zone)
+            var gap = SelectDragGap(gaps, cursorClientX, desiredX, DragWidth, activeDragGap);
+            // A separated pair can share one shell lane. While the pointer crosses the partner, the
+            // current lane is still the correct lane even if its cached bounds moved by a pixel or its
+            // width is temporarily tight. Keep the drag alive long enough for the partner swap to start.
+            if (gap is null && activeDragGap is { } rememberedGap
+                && rememberedGap.end - rememberedGap.start >= DragWidth)
+            {
+                gap = rememberedGap;
+            }
+            if (gap is not { } selectedZone)
             {
                 // No gap can hold the widget at all (very crowded bar): leave it where it is.
                 LogDragState(cursorClientX, desiredX, leftBound, rightBound, gaps, obstacles, null, currentOffsetX);
@@ -1377,14 +1749,131 @@ namespace TaskbarQuota.Taskbar
                 return;
             }
 
-            activeDragGap = zone;
-            int targetX = Math.Clamp(desiredX, zone.start, zone.end - WidgetHostWidth);
+            activeDragGap = selectedZone;
+            UpdatePartnerSwap(desiredX, gaps);
+            var swapVisual = pendingSwapVisual;
+            int targetX = pendingSwapDraggedX
+                ?? Math.Clamp(desiredX, selectedZone.start, selectedZone.end - DragWidth);
+            pendingSwapDraggedX = null;
 
-            LogDragState(cursorClientX, desiredX, leftBound, rightBound, gaps, obstacles, zone, targetX);
-            appWindow.Move(new PointInt32(targetX, currentOffsetY));
+            // Never allow the two native windows to occupy the same pixels. A pointer crossing the
+            // partner is held at the nearest separated edge until the atomic pair swap takes over.
+            int partnerX = draggingActivity ? currentOffsetX : activityOffsetX;
+            int partnerWidth = draggingActivity ? WidgetHostWidth : ActivityHostWidth;
+            if (partnerX != int.MinValue
+                && targetX < partnerX + partnerWidth
+                && targetX + DragWidth > partnerX)
+            {
+                int separation = (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale);
+                bool draggedGoesLeft = desiredX + DragWidth / 2 < partnerX + partnerWidth / 2;
+                int separatedX = draggedGoesLeft
+                    ? partnerX - separation - DragWidth
+                    : partnerX + partnerWidth + separation;
+                targetX = separatedX >= selectedZone.start
+                    && separatedX + DragWidth <= selectedZone.end
+                    ? separatedX
+                    : (DragCurrentOffsetX != int.MinValue ? DragCurrentOffsetX : targetX);
+            }
+
+            LogDragState(cursorClientX, desiredX, leftBound, rightBound, gaps, obstacles, selectedZone, targetX);
+            dragWindow.Move(new PointInt32(targetX, currentOffsetY));
             dragPreviewX = targetX;
+            if (swapVisual is { } visual)
+                AnimatePairSwapVisual(visual.quotaOld, visual.quotaNew, visual.activityOld, visual.activityNew);
+            pendingSwapVisual = null;
             ResyncGrabPoint(cursorClientX, targetX, desiredX);
             lastCursorPositionX = cursorX;
+        }
+
+        private void UpdatePartnerSwap(int draggedX, List<(int start, int end)> gaps)
+        {
+            int partnerX = draggingActivity ? currentOffsetX : activityOffsetX;
+            if (partnerX == int.MinValue)
+                return;
+
+            var nextOrder = TaskbarWidgetPlacement.OrderForDraggedWidget(
+                draggingActivity ? TaskbarWidgetRole.Activity : TaskbarWidgetRole.Quota,
+                draggedX,
+                DragWidth,
+                partnerX,
+                draggingActivity ? WidgetHostWidth : ActivityHostWidth,
+                widgetOrder,
+                (int)Math.Ceiling(12 * dpiScale));
+            if (nextOrder != widgetOrder)
+            {
+                int anchor = Math.Min(dragOriginX, dragPartnerOriginX);
+                int separation = (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale);
+                var pair = TaskbarWidgetPlacement.PlacePair(
+                    anchor,
+                    WidgetHostWidth,
+                    ActivityHostWidth,
+                    separation,
+                    nextOrder,
+                    gaps);
+                if (pair is not { } placement)
+                    return;
+
+                int oldQuotaX = currentOffsetX;
+                int oldActivityX = activityOffsetX;
+                int partnerTarget = draggingActivity ? placement.QuotaX : placement.ActivityX;
+                int draggedTarget = draggingActivity ? placement.ActivityX : placement.QuotaX;
+                if (draggingActivity)
+                {
+                    appWindow?.Move(new PointInt32(partnerTarget, currentOffsetY));
+                    currentOffsetX = partnerTarget;
+                }
+                else
+                {
+                    activityAppWindow?.Move(new PointInt32(partnerTarget, currentOffsetY));
+                    activityOffsetX = partnerTarget;
+                }
+
+                widgetOrder = nextOrder;
+                pendingSwapDraggedX = draggedTarget;
+                if (oldQuotaX != int.MinValue && oldActivityX != int.MinValue)
+                    pendingSwapVisual = (oldQuotaX, placement.QuotaX, oldActivityX, placement.ActivityX);
+            }
+        }
+
+        private void AnimatePairSwapVisual(int quotaOldX, int quotaNewX, int activityOldX, int activityNewX)
+        {
+            if (hostContent is null || activityHostContent is null)
+                return;
+
+            var quotaTransform = hostContent.RenderTransform as Microsoft.UI.Xaml.Media.CompositeTransform;
+            var activityTransform = activityHostContent.RenderTransform as Microsoft.UI.Xaml.Media.CompositeTransform;
+            if (quotaTransform is null || activityTransform is null)
+                return;
+
+            swapVisualStoryboard?.Stop();
+            quotaTransform.TranslateX = quotaOldX - quotaNewX;
+            activityTransform.TranslateX = activityOldX - activityNewX;
+
+            var storyboard = new Anim.Storyboard();
+            var quotaSlide = new Anim.DoubleAnimation
+            {
+                To = 0,
+                Duration = TimeSpan.FromMilliseconds(180),
+                EasingFunction = new Anim.CubicEase { EasingMode = Anim.EasingMode.EaseOut },
+                EnableDependentAnimation = true,
+            };
+            Anim.Storyboard.SetTarget(quotaSlide, quotaTransform);
+            Anim.Storyboard.SetTargetProperty(quotaSlide, "TranslateX");
+
+            var activitySlide = new Anim.DoubleAnimation
+            {
+                To = 0,
+                Duration = TimeSpan.FromMilliseconds(180),
+                EasingFunction = new Anim.CubicEase { EasingMode = Anim.EasingMode.EaseOut },
+                EnableDependentAnimation = true,
+            };
+            Anim.Storyboard.SetTarget(activitySlide, activityTransform);
+            Anim.Storyboard.SetTargetProperty(activitySlide, "TranslateX");
+
+            storyboard.Children.Add(quotaSlide);
+            storyboard.Children.Add(activitySlide);
+            swapVisualStoryboard = storyboard;
+            storyboard.Begin();
         }
 
         /// <summary>
@@ -1419,7 +1908,7 @@ namespace TaskbarQuota.Taskbar
             text.Append("drag solve: cursor=").Append(cursorClientX)
                 .Append(" grab=").Append(draggingInnerOffsetX)
                 .Append(" desired=").Append(desiredX)
-                .Append(" width=").Append(WidgetHostWidth)
+                .Append(" width=").Append(DragWidth)
                 .Append(" bounds=[").Append(leftBound).Append(',').Append(rightBound).Append(')')
                 .Append(" zone=");
             if (zone is { } z)
@@ -1479,7 +1968,7 @@ namespace TaskbarQuota.Taskbar
             if (desiredX == targetX)
                 return;
 
-            draggingInnerOffsetX = Math.Clamp(cursorClientX - targetX, 0, WidgetHostWidth);
+            draggingInnerOffsetX = Math.Clamp(cursorClientX - targetX, 0, DragWidth);
         }
 
         /// <summary>
@@ -1493,6 +1982,7 @@ namespace TaskbarQuota.Taskbar
         {
             (int start, int end)? underCursor = null;
             (int start, int end)? sticky = null;
+            (int start, int end)? directionalHandoff = null;
             (int start, int end)? nearest = null;
             long nearestDistance = long.MaxValue;
 
@@ -1517,7 +2007,38 @@ namespace TaskbarQuota.Taskbar
                 }
             }
 
-            return underCursor ?? sticky ?? nearest;
+            // While the pointer crosses an occupied center, hand off at the midpoint between the current
+            // lane and the next lane in the direction of travel. This gives one predictable snap and then
+            // continuous tracking, instead of pinning the widget until the pointer reaches the far lane.
+            if (sticky is { } currentGap)
+            {
+                if (cursorX >= currentGap.end)
+                {
+                    var nextCandidates = gaps
+                        .Where(gap => gap.end - gap.start >= width && gap.start >= currentGap.end)
+                        .OrderBy(gap => gap.start);
+                    if (nextCandidates.Any())
+                    {
+                        var next = nextCandidates.First();
+                        if (cursorX > currentGap.end + (next.start - currentGap.end) / 2)
+                            directionalHandoff = next;
+                    }
+                }
+                else if (cursorX < currentGap.start)
+                {
+                    var previousCandidates = gaps
+                        .Where(gap => gap.end - gap.start >= width && gap.end <= currentGap.start)
+                        .OrderByDescending(gap => gap.end);
+                    if (previousCandidates.Any())
+                    {
+                        var previous = previousCandidates.First();
+                        if (cursorX < previous.end + (currentGap.start - previous.end) / 2)
+                            directionalHandoff = previous;
+                    }
+                }
+            }
+
+            return underCursor ?? directionalHandoff ?? sticky ?? nearest;
         }
 
         /// <summary>
@@ -1528,7 +2049,7 @@ namespace TaskbarQuota.Taskbar
         /// </summary>
         private async Task SnapToValidPositionAsync(int droppedX)
         {
-            if (appWindow is null)
+            if (DragAppWindow is null)
             {
                 EndUserRepositioning();
                 return;
@@ -1565,14 +2086,54 @@ namespace TaskbarQuota.Taskbar
                     IsRtlUI);
                 var gaps = ComputeFreeGaps(leftBound, rightBound, obstacles);
 
-                int settledX = PlaceInFittingGap(droppedX, gaps, WidgetHostWidth)
-                    ?? (currentOffsetX != int.MinValue ? currentOffsetX : ClampToSpan(droppedX, leftBound, rightBound, WidgetHostWidth));
+                int snapGap = (int)Math.Ceiling(ActivitySummaryMarginLogicalPx * dpiScale);
+                var independentObstacles = new List<RECT>(obstacles);
+                if (draggingActivity && currentOffsetX != int.MinValue)
+                {
+                    independentObstacles.Add(new RECT
+                    {
+                        left = currentOffsetX - snapGap,
+                        right = currentOffsetX + WidgetHostWidth + snapGap,
+                        top = 0,
+                        bottom = taskbarRect.bottom,
+                    });
+                }
+                else if (!draggingActivity && activityOffsetX != int.MinValue)
+                {
+                    independentObstacles.Add(new RECT
+                    {
+                        left = activityOffsetX - snapGap,
+                        right = activityOffsetX + ActivityHostWidth + snapGap,
+                        top = 0,
+                        bottom = taskbarRect.bottom,
+                    });
+                }
+                var independentGaps = ComputeFreeGaps(leftBound, rightBound, independentObstacles);
+                int settledX = PlaceInFittingGap(droppedX, independentGaps, DragWidth)
+                    ?? (DragCurrentOffsetX != int.MinValue
+                        ? DragCurrentOffsetX
+                        : ClampToSpan(droppedX, leftBound, rightBound, DragWidth));
 
-                appWindow.Move(new PointInt32(settledX, currentOffsetY));
-                currentOffsetX = settledX;
+                DragAppWindow!.Move(new PointInt32(settledX, currentOffsetY));
+                if (draggingActivity)
+                {
+                    activityOffsetX = settledX;
+                }
+                else
+                {
+                    currentOffsetX = settledX;
+                }
+                if (currentOffsetX != int.MinValue)
+                    SaveCustomPosition(currentOffsetX);
+                if (activityOffsetX != int.MinValue)
+                {
+                    SaveActivityPosition(activityOffsetX);
+                }
                 dragPreviewX = null;
                 activeDragGap = null;
-                SaveCustomPosition(settledX);
+                pendingSwapDraggedX = null;
+                pendingSwapVisual = null;
+                SaveWidgetOrder();
             }
             catch (Exception ex)
             {
@@ -1581,9 +2142,23 @@ namespace TaskbarQuota.Taskbar
             finally
             {
                 isSettling = false;
+                draggingActivity = false;
                 if (!isDragging && !isPointerTracking && !isDirectDrag)
+                {
                     EndUserRepositioning();
+                    RenderDeferredActivitySnapshot();
+                }
             }
+        }
+
+        private void RenderDeferredActivitySnapshot()
+        {
+            if (disposedValue || activitySummary is null)
+                return;
+            activitySummary.Apply(activitySnapshot, activeTileProvider);
+            foreach (var tile in tiles)
+                tile?.SetAgentActivity(activitySnapshot);
+            RecomputeLayout(forceReposition: true);
         }
 
         /// <summary>
@@ -2081,6 +2656,55 @@ namespace TaskbarQuota.Taskbar
             }
         }
 
+        private void LoadWidgetOrder()
+        {
+            try
+            {
+                if (File.Exists(orderPath)
+                    && Enum.TryParse<TaskbarWidgetOrder>(File.ReadAllText(orderPath), true, out var order))
+                    widgetOrder = order;
+            }
+            catch (Exception ex) { Log.Warning(ex, "Could not read widget order"); }
+        }
+
+        private void SaveWidgetOrder()
+        {
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(orderPath)!);
+                File.WriteAllText(orderPath, widgetOrder.ToString());
+            }
+            catch (Exception ex) { Log.Warning(ex, "Could not save widget order"); }
+        }
+
+        private void LoadActivityPosition()
+        {
+            try
+            {
+                if (File.Exists(activityPositionPath)
+                    && int.TryParse(File.ReadAllText(activityPositionPath), NumberStyles.Integer,
+                        CultureInfo.InvariantCulture, out var offset))
+                {
+                    activityOffsetX = offset;
+                    int minimumWidth = (int)Math.Ceiling(AgentActivitySummary.MinimumLogicalWidth * dpiScale);
+                    ActivityHostWidth = minimumWidth;
+                    activitySummary?.SetLogicalWidth(AgentActivitySummary.MinimumLogicalWidth);
+                    activityAppWindow?.ResizeClient(new SizeInt32(minimumWidth, activityAppWindow.Size.Height));
+                }
+            }
+            catch (Exception ex) { Log.Warning(ex, "Could not read detached activity position"); }
+        }
+
+        private void SaveActivityPosition(int offset)
+        {
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(activityPositionPath)!);
+                File.WriteAllText(activityPositionPath, offset.ToString(CultureInfo.InvariantCulture));
+            }
+            catch (Exception ex) { Log.Warning(ex, "Could not save detached activity position"); }
+        }
+
 
         private IntPtr CreateHostWindow(IntPtr parent)
         {
@@ -2114,8 +2738,11 @@ namespace TaskbarQuota.Taskbar
                     windowClassRegistered = true;
                 }
 
-                windowClassUsers++;
-                windowClassAcquired = true;
+                if (!windowClassAcquired)
+                {
+                    windowClassUsers++;
+                    windowClassAcquired = true;
+                }
             }
         }
 
@@ -2155,7 +2782,7 @@ namespace TaskbarQuota.Taskbar
 
         private bool EnumWindow(IntPtr hWnd, IntPtr lParam)
         {
-            if (hWnd != hwnd
+            if (hWnd != hwnd && hWnd != activityHwnd
                 && User32.IsWindowVisible(hWnd)
                 && User32.GetAncestor(hWnd, GetAncestorFlags.GA_PARENT) == hwndShell)
             {
@@ -2181,6 +2808,7 @@ namespace TaskbarQuota.Taskbar
                 return;
 
             disposedValue = true;
+            StopDragPolling();
             EndUserRepositioning();
             initialized = false;
             isVisible = false;
@@ -2278,11 +2906,19 @@ namespace TaskbarQuota.Taskbar
             {
                 Log.Warning(ex, "Failed to destroy the taskbar widget window");
             }
+            try { activityAppWindow?.Destroy(); }
+            catch (Exception ex) { Log.Warning(ex, "Failed to destroy the activity widget window"); }
             try { host?.Dispose(); }
             catch (Exception ex) { Log.Warning(ex, "Failed to dispose the taskbar XAML host"); }
+            try { activityHost?.Dispose(); }
+            catch (Exception ex) { Log.Warning(ex, "Failed to dispose the activity XAML host"); }
             appWindow = null;
+            activityAppWindow = null;
+            activityHwnd = IntPtr.Zero;
             host = null;
+            activityHost = null;
             hostContent = null;
+            activityHostContent = null;
             summaryPanel = null;
             if (activitySummary is not null)
             {

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -203,8 +203,10 @@ namespace TaskbarQuota.Taskbar
         /// until the next fetch lands. Set by <see cref="TaskBarManager"/>.
         /// </summary>
         public Func<ProviderId, UsageResult?>? HydrateProvider { get; set; }
-        /// <summary>Raised when any tile is clicked; provider-agnostic, it just opens the flyout.</summary>
+        /// <summary>Raised when any quota tile is clicked; provider-agnostic, it opens the provider flyout.</summary>
         public event Action? Clicked;
+        /// <summary>Raised when the agent activity summary is clicked, so its activity panel can open.</summary>
+        public event Action? ActivityClicked;
         public event EventHandler? Destroying;
 
         public TaskBarWidget(TaskbarWindowTarget target)
@@ -453,7 +455,7 @@ namespace TaskbarQuota.Taskbar
                 HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
                 VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Stretch,
             };
-            activitySummary.Clicked += OnTileClicked;
+            activitySummary.Clicked += OnActivityClicked;
 
             for (int i = 0; i < tiles.Length; i++)
             {
@@ -505,6 +507,8 @@ namespace TaskbarQuota.Taskbar
         };
 
         private void OnTileClicked() => Clicked?.Invoke();
+
+        private void OnActivityClicked() => ActivityClicked?.Invoke();
 
         private void WidgetSummary_DesiredHostWidthChanged(int logicalWidth) => RecomputeLayout();
 
@@ -2273,7 +2277,10 @@ namespace TaskbarQuota.Taskbar
             hostContent = null;
             summaryPanel = null;
             if (activitySummary is not null)
-                activitySummary.Clicked -= OnTileClicked;
+            {
+                activitySummary.Clicked -= OnActivityClicked;
+            }
+            ActivityClicked = null;
             activitySummary = null;
             pendingProviders = null;
             pendingActiveProvider = null;

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -511,7 +511,7 @@ namespace TaskbarQuota.Taskbar
             activitySnapshot = snapshot;
             activitySummary?.Apply(snapshot, activeTileProvider);
             foreach (var tile in tiles)
-                tile?.SetAgentActivity(activitySummary?.FollowedItem ?? snapshot.Primary);
+                tile?.SetAgentActivity(snapshot);
             RecomputeLayout(forceReposition: true);
         }
 

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -410,7 +410,7 @@ namespace TaskbarQuota.Taskbar
         public void SetActivitySnapshot(AgentActivitySnapshot snapshot)
         {
             activitySnapshot = snapshot;
-            activitySummary?.Apply(snapshot);
+            activitySummary?.Apply(snapshot, activeTileProvider);
             foreach (var tile in tiles)
                 tile?.SetAgentActivity(activitySummary?.FollowedItem ?? snapshot.Primary);
             RecomputeLayout(forceReposition: true);
@@ -434,6 +434,7 @@ namespace TaskbarQuota.Taskbar
             }
 
             activeTileProvider = activeProvider;
+            activitySummary?.Apply(activitySnapshot, activeTileProvider);
 
             bool changed = false;
             for (int i = 0; i < tiles.Length; i++)

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -455,6 +455,10 @@ namespace TaskbarQuota.Taskbar
                 HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
                 VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Stretch,
             };
+            activitySummary.PointerPressed += WidgetSummary_PointerPressed;
+            activitySummary.PointerMoved += WidgetSummary_PointerMoved;
+            activitySummary.PointerReleased += WidgetSummary_PointerReleased;
+            activitySummary.PointerCanceled += WidgetSummary_PointerCanceled;
             activitySummary.Clicked += OnActivityClicked;
 
             for (int i = 0; i < tiles.Length; i++)
@@ -1229,12 +1233,12 @@ namespace TaskbarQuota.Taskbar
 
         private void WidgetSummary_PointerPressed(object sender, PointerRoutedEventArgs e)
         {
-            if (appWindow is null || sender is not WidgetSummary summary) return;
+            if (appWindow is null || sender is not Microsoft.UI.Xaml.UIElement element) return;
             BeginUserRepositioning();
             isPointerTracking = true;
             isDirectDrag = false;
             PrimeObstacleCacheForDrag();
-            summary.CapturePointer(e.Pointer);
+            element.CapturePointer(e.Pointer);
             User32.GetCursorPos(out var point);
             pressCursorPositionX = point.x;
             lastCursorPositionX = point.x;
@@ -1244,7 +1248,7 @@ namespace TaskbarQuota.Taskbar
 
         private void WidgetSummary_PointerMoved(object sender, PointerRoutedEventArgs e)
         {
-            if (!isPointerTracking || appWindow is null || sender is not WidgetSummary) return;
+            if (!isPointerTracking || appWindow is null || sender is not Microsoft.UI.Xaml.UIElement) return;
             User32.GetCursorPos(out var point);
             if (!isDirectDrag)
             {
@@ -1263,7 +1267,7 @@ namespace TaskbarQuota.Taskbar
         private void WidgetSummary_PointerReleased(object sender, PointerRoutedEventArgs e)
         {
             bool wasDirectDrag = isDirectDrag;
-            (sender as WidgetSummary)?.ReleasePointerCaptures();
+            (sender as Microsoft.UI.Xaml.UIElement)?.ReleasePointerCaptures();
             if (wasDirectDrag && appWindow is not null)
             {
                 _ = SnapToValidPositionAsync(dragPreviewX ?? appWindow.Position.X);
@@ -1281,7 +1285,7 @@ namespace TaskbarQuota.Taskbar
             bool wasDirectDrag = isDirectDrag;
             isPointerTracking = false;
             isDirectDrag = false;
-            (sender as WidgetSummary)?.ReleasePointerCaptures();
+            (sender as Microsoft.UI.Xaml.UIElement)?.ReleasePointerCaptures();
             if (wasDirectDrag)
                 QueuePositionUpdate(TaskbarChangeReason.None);
             EndUserRepositioning();
@@ -1312,6 +1316,8 @@ namespace TaskbarQuota.Taskbar
                 if (tile is not null)
                     tile.IsHitTestVisible = visible;
             }
+            if (activitySummary is not null)
+                activitySummary.IsHitTestVisible = visible;
         }
 
         // A drag can cross tiles, so every tile swallows the click that ends it — otherwise releasing over
@@ -1323,6 +1329,8 @@ namespace TaskbarQuota.Taskbar
                 if (tile is not null)
                     tile.SuppressNextClick = true;
             }
+            if (activitySummary is not null)
+                activitySummary.SuppressNextClick = true;
         }
 
         /// <summary>
@@ -2278,6 +2286,10 @@ namespace TaskbarQuota.Taskbar
             summaryPanel = null;
             if (activitySummary is not null)
             {
+                activitySummary.PointerPressed -= WidgetSummary_PointerPressed;
+                activitySummary.PointerMoved -= WidgetSummary_PointerMoved;
+                activitySummary.PointerReleased -= WidgetSummary_PointerReleased;
+                activitySummary.PointerCanceled -= WidgetSummary_PointerCanceled;
                 activitySummary.Clicked -= OnActivityClicked;
             }
             ActivityClicked = null;

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -18,6 +18,7 @@ using TaskbarQuota.Controls;
 using TaskbarQuota.Diagnostics;
 using TaskbarQuota.Interop;
 using TaskbarQuota.Usage;
+using TaskbarQuota.AgentActivity;
 
 namespace TaskbarQuota.Taskbar
 {
@@ -87,6 +88,8 @@ namespace TaskbarQuota.Taskbar
         // fixed pool means the panel's children never change, so no tile is ever unloaded and re-loaded
         // (which would drop its WidgetSettingsService subscription) when the display order shifts.
         private readonly WidgetSummary[] tiles = new WidgetSummary[UsageCoordinator.MaxWidgetTiles];
+        private AgentActivitySummary? activitySummary;
+        private AgentActivitySnapshot activitySnapshot = new(Array.Empty<AgentActivityItem>());
         // separators[i] is the "|" divider between slot i and slot i+1.
         private readonly Microsoft.UI.Xaml.Controls.TextBlock[] separators =
             new Microsoft.UI.Xaml.Controls.TextBlock[UsageCoordinator.MaxWidgetTiles - 1];
@@ -342,6 +345,15 @@ namespace TaskbarQuota.Taskbar
                 VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Stretch,
             };
 
+            activitySummary = new AgentActivitySummary
+            {
+                Margin = new Microsoft.UI.Xaml.Thickness(8, 0, 0, 0),
+                Visibility = Microsoft.UI.Xaml.Visibility.Collapsed,
+                HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
+                VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Stretch,
+            };
+            activitySummary.Clicked += OnTileClicked;
+
             for (int i = 0; i < tiles.Length; i++)
             {
                 if (i > 0)
@@ -353,6 +365,9 @@ namespace TaskbarQuota.Taskbar
                 tiles[i] = CreateTile();
                 panel.Children.Add(tiles[i]);
             }
+
+            // The quota is the stable anchor. The wider, changing agent step follows it on the right.
+            panel.Children.Add(activitySummary);
 
             return panel;
         }
@@ -391,6 +406,15 @@ namespace TaskbarQuota.Taskbar
         private void OnTileClicked() => Clicked?.Invoke();
 
         private void WidgetSummary_DesiredHostWidthChanged(int logicalWidth) => RecomputeLayout();
+
+        public void SetActivitySnapshot(AgentActivitySnapshot snapshot)
+        {
+            activitySnapshot = snapshot;
+            activitySummary?.Apply(snapshot);
+            foreach (var tile in tiles)
+                tile?.SetAgentActivity(activitySummary?.FollowedItem ?? snapshot.Primary);
+            RecomputeLayout(forceReposition: true);
+        }
 
         /// <summary>
         /// Binds the tile slots to <paramref name="providers"/> in order (leftmost first) and re-lays out.
@@ -496,6 +520,12 @@ namespace TaskbarQuota.Taskbar
             isRecomputingLayout = true;
             try
             {
+                bool showActivity = activitySnapshot.Primary is not null;
+                if (activitySummary is not null)
+                    activitySummary.Visibility = showActivity
+                        ? Microsoft.UI.Xaml.Visibility.Visible
+                        : Microsoft.UI.Xaml.Visibility.Collapsed;
+
                 Array.Clear(tileSuppressed);
 
                 // Slot and width buffers are fields, not locals: at most three tiles, and this pass runs on
@@ -507,13 +537,14 @@ namespace TaskbarQuota.Taskbar
                         layoutSlots[count++] = i;
                 }
 
-                count = HoldBackTilesThatDoNotFit(layoutSlots, count);
+                int activityWidth = showActivity ? AgentActivitySummary.DesiredLogicalWidth + 8 : 0;
+                count = HoldBackTilesThatDoNotFit(layoutSlots, count, activityWidth);
 
                 // Widths are measured, never rendered — MeasureDesiredWidth is a pure calculation.
                 // Rendering to measure made the tile restart its refresh animation on every usage publish,
                 // which read as a tile flashing about once a second.
                 var brush = TaskbarForegroundBrush();
-                int total = 0;
+                int total = activityWidth;
                 for (int n = 0; n < count; n++)
                 {
                     int i = layoutSlots[n];
@@ -615,7 +646,7 @@ namespace TaskbarQuota.Taskbar
         /// straight back when you switch away, so a pin still guarantees presence the rest of the time.
         /// </summary>
         /// <param name="slots">Occupied slot indices; compacted in place. Returns how many survive.</param>
-        private int HoldBackTilesThatDoNotFit(int[] slots, int count)
+        private int HoldBackTilesThatDoNotFit(int[] slots, int count, int reservedWidth)
         {
             if (count <= 1)
                 return count;
@@ -626,7 +657,7 @@ namespace TaskbarQuota.Taskbar
             // a linear scan rather than an ordered projection: at most three tiles, and this runs on every
             // usage publish, so the LINQ pipeline it replaces was allocating a dictionary, a lambda closure
             // and two lists per pass to sort three items.
-            while (count > 1 && MeasureRow(slots, count) > availableLogicalWidth)
+            while (count > 1 && reservedWidth + MeasureRow(slots, count) > availableLogicalWidth)
             {
                 int worstAt = -1;
                 int worstRecency = int.MinValue;
@@ -2063,6 +2094,9 @@ namespace TaskbarQuota.Taskbar
             host = null;
             hostContent = null;
             summaryPanel = null;
+            if (activitySummary is not null)
+                activitySummary.Clicked -= OnTileClicked;
+            activitySummary = null;
             pendingProviders = null;
             pendingActiveProvider = null;
             Array.Clear(tiles);

--- a/src/TaskbarQuota.App/Taskbar/TaskbarWidgetPlacement.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskbarWidgetPlacement.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+
+namespace TaskbarQuota.Taskbar;
+
+internal enum TaskbarWidgetRole
+{
+    Quota,
+    Activity,
+}
+
+internal enum TaskbarWidgetOrder
+{
+    QuotaFirst,
+    ActivityFirst,
+}
+
+internal readonly record struct WidgetPairPlacement(int QuotaX, int ActivityX, int Width);
+internal readonly record struct AdaptiveWidgetPlacement(int X, int Width);
+
+internal static class TaskbarWidgetPlacement
+{
+    internal static WidgetPairPlacement? PlacePair(
+        int preferredAnchor,
+        int quotaWidth,
+        int activityWidth,
+        int gap,
+        TaskbarWidgetOrder order,
+        IReadOnlyList<(int start, int end)> freeGaps)
+    {
+        int total = quotaWidth + activityWidth + gap;
+        int? anchor = null;
+        long bestDistance = long.MaxValue;
+        foreach (var zone in freeGaps)
+        {
+            if (zone.end - zone.start < total)
+                continue;
+            int candidate = Math.Clamp(preferredAnchor, zone.start, zone.end - total);
+            long distance = Math.Abs((long)candidate - preferredAnchor);
+            if (distance < bestDistance)
+            {
+                bestDistance = distance;
+                anchor = candidate;
+            }
+        }
+
+        if (anchor is not { } x)
+            return null;
+
+        return order == TaskbarWidgetOrder.QuotaFirst
+            ? new WidgetPairPlacement(x, x + quotaWidth + gap, total)
+            : new WidgetPairPlacement(x + activityWidth + gap, x, total);
+    }
+
+    internal static AdaptiveWidgetPlacement? PlaceAdaptive(
+        int preferredX,
+        int currentWidth,
+        int minimumWidth,
+        int maximumWidth,
+        bool anchorRight,
+        IReadOnlyList<(int start, int end)> freeGaps)
+    {
+        int preferredEdge = anchorRight ? preferredX + currentWidth : preferredX;
+        AdaptiveWidgetPlacement? best = null;
+        long bestDistance = long.MaxValue;
+
+        foreach (var zone in freeGaps)
+        {
+            int laneWidth = zone.end - zone.start;
+            if (laneWidth < minimumWidth)
+                continue;
+
+            int width = Math.Min(maximumWidth, laneWidth);
+            int desiredX = anchorRight ? preferredEdge - width : preferredEdge;
+            int x = Math.Clamp(desiredX, zone.start, zone.end - width);
+            int placedEdge = anchorRight ? x + width : x;
+            long distance = Math.Abs((long)placedEdge - preferredEdge);
+            if (distance < bestDistance
+                || (distance == bestDistance && (best is null || width > best.Value.Width)))
+            {
+                bestDistance = distance;
+                best = new AdaptiveWidgetPlacement(x, width);
+            }
+        }
+
+        return best;
+    }
+
+    internal static TaskbarWidgetOrder OrderForDraggedWidget(
+        TaskbarWidgetRole dragged,
+        int draggedX,
+        int draggedWidth,
+        int partnerX,
+        int partnerWidth,
+        TaskbarWidgetOrder current,
+        int hysteresis = 0)
+    {
+        int draggedCenter = draggedX + draggedWidth / 2;
+        int partnerCenter = partnerX + partnerWidth / 2;
+        if (Math.Abs((long)draggedCenter - partnerCenter) <= hysteresis)
+            return current;
+
+        if (dragged == TaskbarWidgetRole.Activity)
+            return draggedCenter < partnerCenter ? TaskbarWidgetOrder.ActivityFirst : TaskbarWidgetOrder.QuotaFirst;
+
+        return draggedCenter < partnerCenter ? TaskbarWidgetOrder.QuotaFirst : TaskbarWidgetOrder.ActivityFirst;
+    }
+
+    internal static int StepAnimatedPosition(int current, int target)
+    {
+        int distance = target - current;
+        if (Math.Abs((long)distance) <= 1)
+            return target;
+
+        int step = (int)Math.Round(distance * 0.32, MidpointRounding.AwayFromZero);
+        if (step == 0)
+            step = Math.Sign(distance);
+        return current + step;
+    }
+}

--- a/src/TaskbarQuota.App/Taskbar/TaskbarWidgetPlacement.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskbarWidgetPlacement.cs
@@ -17,6 +17,11 @@ internal enum TaskbarWidgetOrder
 
 internal readonly record struct WidgetPairPlacement(int QuotaX, int ActivityX, int Width);
 internal readonly record struct AdaptiveWidgetPlacement(int X, int Width);
+internal readonly record struct AdaptiveWidgetPairPlacement(
+    int QuotaX,
+    int ActivityX,
+    int ActivityWidth,
+    int Width);
 
 internal static class TaskbarWidgetPlacement
 {
@@ -84,6 +89,144 @@ internal static class TaskbarWidgetPlacement
         }
 
         return best;
+    }
+
+    /// <summary>
+    /// Places quota and activity as one unit while allowing only the activity surface to shrink.
+    /// The quota stays at its preferred position whenever the lane permits, which prevents a quota
+    /// width change from using the activity window's stale bounds and making the two islands jump.
+    /// </summary>
+    internal static AdaptiveWidgetPairPlacement? PlaceAdaptivePair(
+        int preferredQuotaX,
+        int quotaWidth,
+        int minimumActivityWidth,
+        int maximumActivityWidth,
+        int gap,
+        TaskbarWidgetOrder order,
+        IReadOnlyList<(int start, int end)> freeGaps,
+        int preferredActivityX = int.MinValue,
+        int currentActivityWidth = 0)
+    {
+        AdaptiveWidgetPairPlacement? best = null;
+        long bestDistance = long.MaxValue;
+
+        foreach (var zone in freeGaps)
+        {
+            int laneWidth = zone.end - zone.start;
+            int fixedWidth = quotaWidth + gap;
+            if (laneWidth < fixedWidth + minimumActivityWidth)
+                continue;
+
+            int quotaX;
+            int activityX;
+            int activityWidth;
+            if (order == TaskbarWidgetOrder.QuotaFirst)
+            {
+                quotaX = Math.Clamp(
+                    preferredQuotaX,
+                    zone.start,
+                    zone.end - fixedWidth - minimumActivityWidth);
+                int defaultActivityX = quotaX + fixedWidth;
+                activityX = preferredActivityX == int.MinValue
+                    ? defaultActivityX
+                    : Math.Clamp(preferredActivityX, defaultActivityX, zone.end - minimumActivityWidth);
+                activityWidth = Math.Min(maximumActivityWidth, zone.end - activityX);
+            }
+            else
+            {
+                quotaX = Math.Clamp(
+                    preferredQuotaX,
+                    zone.start + gap + minimumActivityWidth,
+                    zone.end - quotaWidth);
+                int defaultActivityRight = quotaX - gap;
+                if (preferredActivityX == int.MinValue)
+                {
+                    activityWidth = Math.Min(maximumActivityWidth, defaultActivityRight - zone.start);
+                    activityX = defaultActivityRight - activityWidth;
+                }
+                else
+                {
+                    // A manual drop owns its left edge. Grow into the free space on its right instead of
+                    // preserving the compact drag width's right edge and pulling the window toward zero.
+                    activityX = Math.Clamp(
+                        preferredActivityX,
+                        zone.start,
+                        defaultActivityRight - minimumActivityWidth);
+                    activityWidth = Math.Min(maximumActivityWidth, defaultActivityRight - activityX);
+                }
+            }
+
+            int totalWidth = fixedWidth + activityWidth;
+            long distance = Math.Abs((long)quotaX - preferredQuotaX);
+
+            if (distance < bestDistance
+                || (distance == bestDistance
+                    && (best is null || activityWidth > best.Value.ActivityWidth)))
+            {
+                bestDistance = distance;
+                best = new AdaptiveWidgetPairPlacement(quotaX, activityX, activityWidth, totalWidth);
+            }
+        }
+
+        return best;
+    }
+
+    internal static bool OccupyDifferentGaps(
+        int firstX,
+        int firstWidth,
+        int secondX,
+        int secondWidth,
+        IReadOnlyList<(int start, int end)> freeGaps)
+    {
+        int firstGap = ContainingGap(firstX, firstWidth, freeGaps);
+        int secondGap = ContainingGap(secondX, secondWidth, freeGaps);
+        return firstGap >= 0 && secondGap >= 0 && firstGap != secondGap;
+    }
+
+    internal static int? SnapNextToPartner(
+        int droppedX,
+        int draggedWidth,
+        int partnerX,
+        int partnerWidth,
+        int gap,
+        int maximumDistance,
+        IReadOnlyList<(int start, int end)> fittingGaps)
+    {
+        int leftCandidate = partnerX - gap - draggedWidth;
+        int rightCandidate = partnerX + partnerWidth + gap;
+        int? best = null;
+        long bestDistance = long.MaxValue;
+
+        foreach (int candidate in new[] { leftCandidate, rightCandidate })
+        {
+            long distance = Math.Abs((long)candidate - droppedX);
+            if (distance > maximumDistance
+                || ContainingGap(candidate, draggedWidth, fittingGaps) < 0
+                || distance >= bestDistance)
+            {
+                continue;
+            }
+
+            best = candidate;
+            bestDistance = distance;
+        }
+
+        return best;
+    }
+
+    private static int ContainingGap(
+        int x,
+        int width,
+        IReadOnlyList<(int start, int end)> freeGaps)
+    {
+        for (int i = 0; i < freeGaps.Count; i++)
+        {
+            var gap = freeGaps[i];
+            if (x >= gap.start && x + width <= gap.end)
+                return i;
+        }
+
+        return -1;
     }
 
     internal static TaskbarWidgetOrder OrderForDraggedWidget(

--- a/src/TaskbarQuota.App/TaskbarQuota.App.csproj
+++ b/src/TaskbarQuota.App/TaskbarQuota.App.csproj
@@ -65,6 +65,8 @@
     <PackageReference Include="System.Management" Version="10.0.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
+    <!-- Override Microsoft.Data.Sqlite's vulnerable 2.1.11 native bundle (CVE-2025-6965). -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -1063,7 +1063,6 @@ namespace TaskbarQuota
                     ClearPendingDetectedProvider();
                 if (detected is ProviderId p
                     && (previousActive == p
-                        || detectedSource.Kind is ProviderSourceKind.DesktopApp or ProviderSourceKind.HostApp
                         || AcceptDetectedProvider(p)))
                 {
                     _lastActive = p;

--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -48,6 +48,12 @@ namespace TaskbarQuota
         private const int SynaraStableMaxAttempts = 4;
         private static readonly TimeSpan SynaraStableDelay = TimeSpan.FromMilliseconds(8);
         private ProviderId? _lastActive;
+        // A foreground process can briefly report a sibling provider while a GUI window is being raised.
+        // Do not publish a one-sample provider switch: that makes the taskbar animate a foreign quota tile
+        // in and back out even though the user never left the current app.
+        private ProviderId? _pendingDetectedProvider;
+        private int _pendingDetectedProviderSamples;
+        private const int RequiredProviderSwitchSamples = 2;
         private ProviderId? _lastLogged;
         private ProviderId? _synaraHoldProvider;
         private DateTime _synaraHoldUntilUtc = DateTime.MinValue;
@@ -493,6 +499,8 @@ namespace TaskbarQuota
                 HoldSynaraProvider(provider);
                 var previous = _lastActive;
                 var providerChanged = previous != provider;
+                if (providerChanged)
+                    ClearPendingDetectedProvider();
                 var hostChanged = !SameSynaraSelection(previousHost, host);
                 _lastActive = provider;
                 if (providerChanged)
@@ -660,6 +668,8 @@ namespace TaskbarQuota
                 }
 
                 var previous = _lastActive;
+                if (previous != target)
+                    ClearPendingDetectedProvider();
                 _lastActive = target;
                 _activeProviderSource = foregroundSource;
                 PromoteRecentProvider(target);
@@ -800,6 +810,8 @@ namespace TaskbarQuota
                     return;
 
                 var previous = _lastActive;
+                if (previous != target)
+                    ClearPendingDetectedProvider();
                 _lastActive = target;
                 _activeProviderSource = _detector.ActiveSource;
                 PromoteRecentProvider(target);
@@ -1026,6 +1038,8 @@ namespace TaskbarQuota
                 // Foreground bookkeeping runs on every tick, including the ones that end in the no-tool
                 // early-out below, so the hide grace period keeps counting while nothing is detected.
                 UpdateProviderForeground(detected is not null);
+                if (detected is null)
+                    ClearPendingDetectedProvider();
 
                 var hasDetectedTool = detected != null || ShouldAssumeToolStillRunning() || ProbeToolPresence();
                 if (!hasDetectedTool)
@@ -1036,6 +1050,7 @@ namespace TaskbarQuota
                         _lastActive = null;
                         _lastLogged = null;
                         _activeProviderSource = ProviderSource.Unknown;
+                        ClearPendingDetectedProvider();
                         ActiveSynaraHost = null;
                         ClearSynaraHold(force: true);
                         ActiveToolPresenceChanged?.Invoke(false);
@@ -1044,7 +1059,8 @@ namespace TaskbarQuota
                 }
 
                 ProviderId? previousActive = _lastActive;
-                if (detected is ProviderId p)
+                if (detected is ProviderId p
+                    && (previousActive == p || AcceptDetectedProvider(p)))
                 {
                     _lastActive = p;
                     _activeProviderSource = detectedSource;
@@ -1142,6 +1158,29 @@ namespace TaskbarQuota
 
         private ProviderSource SourceFor(ProviderId provider)
             => _lastActive == provider ? _activeProviderSource : ProviderSource.Unknown;
+
+        private bool AcceptDetectedProvider(ProviderId provider)
+        {
+            if (_pendingDetectedProvider != provider)
+            {
+                _pendingDetectedProvider = provider;
+                _pendingDetectedProviderSamples = 1;
+                return false;
+            }
+
+            _pendingDetectedProviderSamples++;
+            if (_pendingDetectedProviderSamples < RequiredProviderSwitchSamples)
+                return false;
+
+            ClearPendingDetectedProvider();
+            return true;
+        }
+
+        private void ClearPendingDetectedProvider()
+        {
+            _pendingDetectedProvider = null;
+            _pendingDetectedProviderSamples = 0;
+        }
 
         private static ProviderSource SynaraSource(HostApp host)
             => new(

--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -73,17 +73,18 @@ namespace TaskbarQuota
         public ProviderSource ActiveProviderSource => _activeProviderSource;
 
         /// <summary>
-        /// The provider the taskbar widget should display: the active provider when its widget is enabled,
-        /// otherwise the first enabled-and-available provider (most recently active first, then enum order).
-        /// Null when no provider qualifies, in which case the widget hides instead of falling back to a
-        /// hidden default. Fixes the "widget disappears when Codex is disabled / only Cursor enabled" bug
-        /// (the old code hard-coded <see cref="ProviderId.Codex"/> as the fallback). See issue #7.
+        /// The provider the taskbar widget should display when an active provider is known. A missing active
+        /// provider returns null; the widget must not invent one from the installed-provider enum order.
+        /// Pinned providers are handled separately by <see cref="WidgetDisplayProviders"/>.
         /// </summary>
         public ProviderId? WidgetDisplayProvider
         {
             get
             {
-                if (_lastActive is { } active && WidgetSettingsService.IsProviderVisible(active))
+                if (_lastActive is not { } active)
+                    return null;
+
+                if (WidgetSettingsService.IsProviderVisible(active))
                     return active;
                 foreach (var p in RecentProviders)
                     if (WidgetSettingsService.IsProviderVisible(p) && IsProviderAvailable(p))
@@ -108,8 +109,8 @@ namespace TaskbarQuota
         /// So with Claude pinned + Z.AI pinned and Codex active you get "Codex | Claude | Z.AI", and
         /// focusing Claude re-orders to "Claude | Z.AI" + whatever else is pinned — the active provider
         /// keeps the leading slot while the pinned tiles stay put behind it (issue #25).
-        /// With nothing pinned this returns exactly <see cref="WidgetDisplayProvider"/>, so the existing
-        /// single-tile behavior is unchanged.
+        /// With no active provider this returns only pinned providers; with neither an active nor pinned
+        /// provider it is empty, so the taskbar stays clear until detection selects a provider.
         /// </summary>
         public IReadOnlyList<ProviderId> WidgetDisplayProviders
             => ComputeWidgetDisplayProviders(
@@ -119,8 +120,7 @@ namespace TaskbarQuota
                 Enum.GetValues<ProviderId>(),
                 WidgetSettingsService.IsProviderPinned,
                 WidgetSettingsService.IsProviderVisible,
-                IsProviderAvailable,
-                WidgetDisplayProvider);
+                IsProviderAvailable);
 
         /// <summary>Pure, testable core of <see cref="WidgetDisplayProviders"/>.</summary>
         internal static IReadOnlyList<ProviderId> ComputeWidgetDisplayProviders(
@@ -130,8 +130,7 @@ namespace TaskbarQuota
             IReadOnlyList<ProviderId> ordered,
             Func<ProviderId, bool> isPinned,
             Func<ProviderId, bool> isVisible,
-            Func<ProviderId, bool> isAvailable,
-            ProviderId? fallback)
+            Func<ProviderId, bool> isAvailable)
         {
             var result = new List<ProviderId>();
 
@@ -149,11 +148,6 @@ namespace TaskbarQuota
                 .OrderBy(p => recentIndex.TryGetValue(p, out int index) ? index : int.MaxValue)
                 .ToList();
             result.AddRange(pinned);
-
-            // Nothing active and nothing pinned: keep today's single-tile fallback so users with no pins
-            // still see the last-used / first-enabled provider.
-            if (result.Count == 0 && present && fallback is { } fb)
-                result.Add(fb);
 
             if (result.Count > MaxWidgetTiles)
                 result.RemoveRange(MaxWidgetTiles, result.Count - MaxWidgetTiles);

--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -1164,19 +1164,35 @@ namespace TaskbarQuota
             => _lastActive == provider ? _activeProviderSource : ProviderSource.Unknown;
 
         private bool AcceptDetectedProvider(ProviderId provider)
+            => ShouldAcceptDetectedProvider(
+                ref _pendingDetectedProvider,
+                ref _pendingDetectedProviderSamples,
+                provider,
+                RequiredProviderSwitchSamples);
+
+        internal static bool ShouldAcceptDetectedProvider(
+            ref ProviderId? pendingProvider,
+            ref int pendingSamples,
+            ProviderId provider,
+            int requiredSamples)
         {
-            if (_pendingDetectedProvider != provider)
+            if (pendingProvider != provider)
             {
-                _pendingDetectedProvider = provider;
-                _pendingDetectedProviderSamples = 1;
-                return false;
+                pendingProvider = provider;
+                pendingSamples = 1;
+                if (requiredSamples > 1)
+                    return false;
+                pendingProvider = null;
+                pendingSamples = 0;
+                return true;
             }
 
-            _pendingDetectedProviderSamples++;
-            if (_pendingDetectedProviderSamples < RequiredProviderSwitchSamples)
+            pendingSamples++;
+            if (pendingSamples < requiredSamples)
                 return false;
 
-            ClearPendingDetectedProvider();
+            pendingProvider = null;
+            pendingSamples = 0;
             return true;
         }
 

--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -1059,8 +1059,12 @@ namespace TaskbarQuota
                 }
 
                 ProviderId? previousActive = _lastActive;
+                if (detected is ProviderId matchingActive && previousActive == matchingActive)
+                    ClearPendingDetectedProvider();
                 if (detected is ProviderId p
-                    && (previousActive == p || AcceptDetectedProvider(p)))
+                    && (previousActive == p
+                        || detectedSource.Kind is ProviderSourceKind.DesktopApp or ProviderSourceKind.HostApp
+                        || AcceptDetectedProvider(p)))
                 {
                     _lastActive = p;
                     _activeProviderSource = detectedSource;

--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -123,11 +123,14 @@ namespace TaskbarQuota
         }
 
         /// <summary>
-        /// Hard cap on taskbar tiles. Three is the most that fits beside the tray on a normal bar even in
-        /// the narrow display modes; <see cref="Taskbar.TaskBarWidget"/> trims further when the measured
-        /// widths don't fit the free gap it actually has.
+        /// Maximum number of quota tile slots allocated by the widget. The effective display cap is lower
+        /// while the activity widget is enabled because the activity island occupies the same taskbar area.
         /// </summary>
         public const int MaxWidgetTiles = 3;
+
+        /// <summary>Effective quota-tile cap: active + two pinned tiles normally, active + one pinned with activity.</summary>
+        public static int MaxDisplayedWidgetTiles =>
+            WidgetSettingsService.ShowAgentActivityInWidget ? 2 : MaxWidgetTiles;
 
         /// <summary>
         /// Every provider the taskbar widget should render as its own tile, left to right: the ACTIVE
@@ -146,7 +149,8 @@ namespace TaskbarQuota
                 Enum.GetValues<ProviderId>(),
                 WidgetSettingsService.IsProviderPinned,
                 WidgetSettingsService.IsProviderVisible,
-                IsProviderAvailable);
+                IsProviderAvailable,
+                WidgetSettingsService.ShowAgentActivityInWidget);
 
         /// <summary>Pure, testable core of <see cref="WidgetDisplayProviders"/>.</summary>
         internal static IReadOnlyList<ProviderId> ComputeWidgetDisplayProviders(
@@ -156,7 +160,8 @@ namespace TaskbarQuota
             IReadOnlyList<ProviderId> ordered,
             Func<ProviderId, bool> isPinned,
             Func<ProviderId, bool> isVisible,
-            Func<ProviderId, bool> isAvailable)
+            Func<ProviderId, bool> isAvailable,
+            bool activityWidgetEnabled = false)
         {
             var result = new List<ProviderId>();
 
@@ -175,8 +180,9 @@ namespace TaskbarQuota
                 .ToList();
             result.AddRange(pinned);
 
-            if (result.Count > MaxWidgetTiles)
-                result.RemoveRange(MaxWidgetTiles, result.Count - MaxWidgetTiles);
+            int maxTiles = activityWidgetEnabled ? 2 : MaxWidgetTiles;
+            if (result.Count > maxTiles)
+                result.RemoveRange(maxTiles, result.Count - maxTiles);
             return result;
         }
 

--- a/tests/TaskbarQuota.Tests/AgentActivityLifecycleTests.cs
+++ b/tests/TaskbarQuota.Tests/AgentActivityLifecycleTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using TaskbarQuota;
+using TaskbarQuota.AgentActivity;
+using TaskbarQuota.Usage;
+using Xunit;
+
+namespace TaskbarQuota.Tests;
+
+public sealed class AgentActivityLifecycleTests
+{
+    [Fact]
+    public void SuccessfulScan_RemovesScannerItemsMissingFromNextSnapshot()
+    {
+        var service = new AgentActivityService();
+        service.ApplyScan([Item("live", AgentActivityStatus.Working)]);
+
+        service.ApplyScan([]);
+
+        Assert.Empty(service.Snapshot.Items);
+        Assert.False(service.Snapshot.HasLiveItems);
+    }
+
+    [Fact]
+    public void SuccessfulScan_DoesNotRetainExpiredCompletion()
+    {
+        var service = new AgentActivityService();
+        var old = Item("old", AgentActivityStatus.Completed) with
+        {
+            UpdatedAt = DateTimeOffset.Now - AgentActivityService.CompletedRetention - TimeSpan.FromSeconds(1),
+        };
+
+        service.ApplyScan([old]);
+
+        Assert.Empty(service.Snapshot.Items);
+    }
+
+    [Fact]
+    public void AcknowledgedCompletion_RemainsHiddenWhenScannerReturnsItAgain()
+    {
+        var service = new AgentActivityService();
+        var completed = Item("done", AgentActivityStatus.Completed);
+        service.ApplyScan([completed]);
+        service.Acknowledge("done");
+
+        service.ApplyScan([completed]);
+
+        Assert.Empty(service.Snapshot.Items);
+    }
+
+    [Fact]
+    public void ThrowingSubscriber_DoesNotBlockOtherSubscribers()
+    {
+        var service = new AgentActivityService();
+        var observed = 0;
+        service.Changed += _ => throw new InvalidOperationException("test");
+        service.Changed += _ => observed++;
+
+        service.ApplyScan([Item("live", AgentActivityStatus.Working)]);
+
+        Assert.Equal(1, observed);
+    }
+
+    [Fact]
+    public void ItemsForDisplay_MovesSelectedAgentToFront()
+    {
+        var snapshot = new AgentActivitySnapshot([
+            Item("first", AgentActivityStatus.Working),
+            Item("selected", AgentActivityStatus.Waiting),
+            Item("last", AgentActivityStatus.Completed),
+        ]);
+
+        Assert.Equal(["selected", "first", "last"], snapshot.ItemsForDisplay("selected").Select(item => item.Id));
+        Assert.Equal(["first", "selected", "last"], snapshot.ItemsForDisplay("missing").Select(item => item.Id));
+    }
+
+    [Fact]
+    public void CandidateSelection_AppliesLimitPerProvider()
+    {
+        var now = DateTimeOffset.Now;
+        var candidates = Enumerable.Range(0, 25)
+            .Select(index => (ProviderId.Codex, $"codex-{index}", now.AddSeconds(-index)))
+            .Concat(Enumerable.Range(0, 3)
+                .Select(index => (ProviderId.Claude, $"claude-{index}", now.AddMinutes(-10).AddSeconds(-index))))
+            .ToArray();
+
+        var selected = AgentActivityScanner.SelectCandidates(candidates, maxPerProvider: 20);
+
+        Assert.Equal(20, selected.Count(item => item.Provider == ProviderId.Codex));
+        Assert.Equal(3, selected.Count(item => item.Provider == ProviderId.Claude));
+    }
+
+    [Theory]
+    [InlineData("powershell", "powershell.exe -Command rg codex", null)]
+    [InlineData("node", "node.exe C:\\tools\\unrelated.js --query cline", null)]
+    [InlineData("codex", "codex.exe exec", ProviderId.Codex)]
+    [InlineData("node", "node.exe C:\\npm\\node_modules\\@anthropic-ai\\claude-code\\cli.js", ProviderId.Claude)]
+    public void TerminalDetection_RequiresExecutableOrKnownPackage(
+        string executable, string commandLine, ProviderId? expected)
+        => Assert.Equal(expected, AgentActivityScanner.DetectTerminalProviderForTesting(executable, commandLine));
+
+    [Fact]
+    public void ClineSession_UsesFilenameWhenSessionIdIsBlank()
+    {
+        var directory = CreateTemporaryDirectory();
+        try
+        {
+            var path = Path.Combine(directory, "fallback-session.json");
+            File.WriteAllText(path, "{\"session_id\":\"\",\"metadata\":{\"title\":\"Fallback\"}}");
+
+            var item = AgentActivityScanner.ReadClineForTesting(path);
+
+            Assert.Equal("cline:fallback-session", item?.Id);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CodexThreadIndex_SkipsMalformedAndWrongTypeRows()
+    {
+        var directory = CreateTemporaryDirectory();
+        try
+        {
+            var path = Path.Combine(directory, "session_index.jsonl");
+            File.WriteAllLines(path,
+            [
+                "{\"id\":42,\"thread_name\":false}",
+                "{not-finished",
+                "{\"id\":\"thread-1\",\"thread_name\":\"Useful name\"}",
+            ]);
+            var resolver = new CodexThreadNameResolver(path);
+
+            Assert.Equal("Useful name", resolver.GetName("thread-1"));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ProviderSwitchDebounce_RequiresConsecutiveMatchingSamples()
+    {
+        ProviderId? pending = null;
+        var samples = 0;
+
+        Assert.False(UsageCoordinator.ShouldAcceptDetectedProvider(
+            ref pending, ref samples, ProviderId.Claude, requiredSamples: 2));
+        Assert.False(UsageCoordinator.ShouldAcceptDetectedProvider(
+            ref pending, ref samples, ProviderId.Codex, requiredSamples: 2));
+        Assert.True(UsageCoordinator.ShouldAcceptDetectedProvider(
+            ref pending, ref samples, ProviderId.Codex, requiredSamples: 2));
+        Assert.Null(pending);
+        Assert.Equal(0, samples);
+    }
+
+    private static AgentActivityItem Item(string id, AgentActivityStatus status)
+    {
+        var now = DateTimeOffset.Now;
+        return new AgentActivityItem(id, ProviderId.Codex, id, status.ToString(), status, now, now);
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"TaskbarQuotaTests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/tests/TaskbarQuota.Tests/AgentActivityTests.cs
+++ b/tests/TaskbarQuota.Tests/AgentActivityTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO;
+using Microsoft.Data.Sqlite;
 using TaskbarQuota.AgentActivity;
 using TaskbarQuota.Usage;
 using Xunit;
@@ -88,6 +90,83 @@ public sealed class AgentActivityTests
         Assert.Equal("Run the tests for the scanner", info.Prompt);
         Assert.Equal("Ran tests", info.Step);
         Assert.Equal(AgentActivityScanner.TranscriptState.Action, info.State);
+    }
+
+    [Fact]
+    public void OpenCodeDatabase_ExtractsSessionPromptModelAndRunningTool()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"taskbarquota-opencode-{Guid.NewGuid():N}.db");
+        try
+        {
+            var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            using (var connection = new SqliteConnection($"Data Source={path}"))
+            {
+                connection.Open();
+                using var command = connection.CreateCommand();
+                command.CommandText = """
+                    CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT, title TEXT, model TEXT, time_created INTEGER, time_updated INTEGER);
+                    CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, data TEXT, time_created INTEGER, time_updated INTEGER);
+                    CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, data TEXT, time_created INTEGER, time_updated INTEGER);
+                    """;
+                command.ExecuteNonQuery();
+
+                command.Parameters.Clear();
+                command.CommandText = "INSERT INTO session VALUES ($id, NULL, $title, $model, $created, $updated);";
+                command.Parameters.AddWithValue("$id", "ses_1");
+                command.Parameters.AddWithValue("$title", "Refactor activity scanner");
+                command.Parameters.AddWithValue("$model", "{\"id\":\"gpt-5\",\"providerID\":\"openai\"}");
+                command.Parameters.AddWithValue("$created", now - 5_000);
+                command.Parameters.AddWithValue("$updated", now);
+                command.ExecuteNonQuery();
+
+                command.Parameters.Clear();
+                command.CommandText = "INSERT INTO message VALUES ($id, 'ses_1', $data, $created, $updated);";
+                command.Parameters.AddWithValue("$id", "msg_user");
+                command.Parameters.AddWithValue("$data", $"{{\"role\":\"user\",\"time\":{{\"created\":{now - 2_000}}}}}");
+                command.Parameters.AddWithValue("$created", now - 2_000);
+                command.Parameters.AddWithValue("$updated", now - 2_000);
+                command.ExecuteNonQuery();
+
+                command.Parameters.Clear();
+                command.CommandText = "INSERT INTO message VALUES ($id, 'ses_1', $data, $created, $updated);";
+                command.Parameters.AddWithValue("$id", "msg_assistant");
+                command.Parameters.AddWithValue("$data", $"{{\"role\":\"assistant\",\"time\":{{\"created\":{now - 1_000}}},\"finish\":\"tool-calls\",\"modelID\":\"gpt-5\",\"providerID\":\"openai\"}}");
+                command.Parameters.AddWithValue("$created", now - 1_000);
+                command.Parameters.AddWithValue("$updated", now - 1_000);
+                command.ExecuteNonQuery();
+
+                command.Parameters.Clear();
+                command.CommandText = "INSERT INTO part VALUES ($id, 'msg_user', 'ses_1', $data, $created, $updated);";
+                command.Parameters.AddWithValue("$id", "part_prompt");
+                command.Parameters.AddWithValue("$data", "{\"type\":\"text\",\"text\":\"Run the tests for the scanner\"}");
+                command.Parameters.AddWithValue("$created", now - 2_000);
+                command.Parameters.AddWithValue("$updated", now - 2_000);
+                command.ExecuteNonQuery();
+
+                command.Parameters.Clear();
+                command.CommandText = "INSERT INTO part VALUES ($id, 'msg_assistant', 'ses_1', $data, $created, $updated);";
+                command.Parameters.AddWithValue("$id", "part_tool");
+                command.Parameters.AddWithValue("$data", $"{{\"type\":\"tool\",\"tool\":\"bash\",\"state\":{{\"status\":\"running\",\"input\":{{\"command\":\"dotnet test\"}},\"time\":{{\"start\":{now - 500}}}}}}}");
+                command.Parameters.AddWithValue("$created", now - 500);
+                command.Parameters.AddWithValue("$updated", now - 500);
+                command.ExecuteNonQuery();
+            }
+
+            var item = Assert.Single(AgentActivityScanner.ReadOpenCodeForTesting(path));
+
+            Assert.Equal(ProviderId.OpenCode, item.Provider);
+            Assert.Equal("Refactor activity scanner", item.Title);
+            Assert.Equal("Run the tests for the scanner", item.Detail);
+            Assert.Equal("gpt-5", item.Model);
+            Assert.Equal("Ran tests", item.Step);
+            Assert.Equal(AgentActivityStatus.Working, item.Status);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(path))
+                File.Delete(path);
+        }
     }
 
     [Fact]

--- a/tests/TaskbarQuota.Tests/AgentActivityTests.cs
+++ b/tests/TaskbarQuota.Tests/AgentActivityTests.cs
@@ -170,6 +170,52 @@ public sealed class AgentActivityTests
     }
 
     [Fact]
+    public void GrokSession_ExtractsPromptModelAndRunningTool()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"taskbarquota-grok-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var now = DateTimeOffset.UtcNow.ToString("O");
+            File.WriteAllText(Path.Combine(directory, "summary.json"), $$"""
+                {
+                  "info": { "id": "grok-session-1", "cwd": "C:\\work" },
+                  "session_summary": "",
+                  "created_at": "{{now}}",
+                  "updated_at": "{{now}}",
+                  "current_model_id": "grok-4.5",
+                  "agent_name": "grok-build"
+                }
+                """);
+            File.WriteAllText(Path.Combine(directory, "chat_history.jsonl"), $$"""
+                {"type":"system","content":"system prompt"}
+                {"type":"user","content":[{"type":"text","text":"Refactor Grok activity tracking"}]}
+                {"type":"assistant","content":"","tool_calls":[{"id":"call-1","name":"shell_command","arguments":"dotnet test"}]}
+                """);
+            File.WriteAllText(Path.Combine(directory, "events.jsonl"), $$"""
+                {"type":"turn_started","ts":"{{now}}","session_id":"grok-session-1"}
+                {"type":"tool_started","ts":"{{now}}","tool_name":"shell_command"}
+                """);
+
+            var item = Assert.Single(AgentActivityScanner.ReadGrokForTesting(
+                Path.Combine(directory, "summary.json")));
+
+            Assert.Equal(ProviderId.Grok, item.Provider);
+            Assert.Equal("grok-session-1", item.ThreadId);
+            Assert.Equal("Refactor Grok activity tracking", item.Title);
+            Assert.Equal("Refactor Grok activity tracking", item.Detail);
+            Assert.Equal("grok-4.5", item.Model);
+            Assert.Equal("Running command", item.Step);
+            Assert.Equal(AgentActivityStatus.Working, item.Status);
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ActivityTitle_IsSummarizedFromLatestPrompt()
     {
         var title = AgentActivityScanner.SummarizeTitleForTesting(

--- a/tests/TaskbarQuota.Tests/AgentActivityTests.cs
+++ b/tests/TaskbarQuota.Tests/AgentActivityTests.cs
@@ -126,6 +126,27 @@ public sealed class AgentActivityTests
     }
 
     [Fact]
+    public void CopilotCompletedSession_DoesNotStayLiveJustBecauseVsCodeIsOpen()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "taskbarquota-copilot-" + Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            File.WriteAllText(path, """
+                {"v":{"sessionId":"copilot-old","requests":[{"message":{"text":"Old request"},"response":[{"value":"Done"}]}]}}
+                """);
+            File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddMinutes(-5));
+
+            var item = Assert.Single(AgentActivityScanner.ReadCopilotForTesting(path, claimLive: true));
+
+            Assert.Equal(AgentActivityStatus.Completed, item.Status);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void CopilotJsonSession_EmptyResponseRemainsWorking()
     {
         var path = Path.Combine(Path.GetTempPath(), "taskbarquota-copilot-" + Guid.NewGuid().ToString("N") + ".json");

--- a/tests/TaskbarQuota.Tests/AgentActivityTests.cs
+++ b/tests/TaskbarQuota.Tests/AgentActivityTests.cs
@@ -34,4 +34,67 @@ public sealed class AgentActivityTests
         Assert.True(snapshot.HasLiveItems);
         Assert.Equal("waiting", snapshot.Primary?.Id);
     }
+
+    [Fact]
+    public void ClaudeTranscript_ExtractsPromptModelAndToolAction()
+    {
+        var transcript = string.Join('\n',
+            "{\"type\":\"user\",\"sessionId\":\"claude-thread\",\"timestamp\":\"2026-08-01T12:00:00Z\",\"message\":{\"role\":\"user\",\"content\":\"Refactor the activity scanner and add tests\"}}",
+            "{\"type\":\"assistant\",\"sessionId\":\"claude-thread\",\"timestamp\":\"2026-08-01T12:00:02Z\",\"message\":{\"model\":\"claude-sonnet-4\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"input\":{\"file_path\":\"AgentActivityScanner.cs\"}}]}}" );
+
+        var info = AgentActivityScanner.ParseTranscriptForTesting(ProviderId.Claude, transcript);
+
+        Assert.Equal("claude-thread", info.ThreadId);
+        Assert.Equal("Refactor the activity scanner and add tests", info.Prompt);
+        Assert.Equal("claude-sonnet-4", info.Model);
+        Assert.Equal("Edited code", info.Step);
+        Assert.Equal(AgentActivityScanner.TranscriptState.Action, info.State);
+    }
+
+    [Fact]
+    public void ClaudeTranscript_AskUserToolBecomesWaiting()
+    {
+        var transcript = "{\"type\":\"assistant\",\"sessionId\":\"claude-thread\",\"timestamp\":\"2026-08-01T12:00:02Z\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"AskUserQuestion\",\"input\":{}}]}}";
+
+        var info = AgentActivityScanner.ParseTranscriptForTesting(ProviderId.Claude, transcript);
+
+        Assert.Equal("Waiting for input", info.Step);
+        Assert.Equal(AgentActivityScanner.TranscriptState.Waiting, info.State);
+    }
+
+    [Fact]
+    public void CodexTranscript_ExtractsPromptAndShellAction()
+    {
+        var transcript = string.Join('\n',
+            "{\"timestamp\":\"2026-08-01T11:59:59Z\",\"payload\":{\"type\":\"session_meta\",\"id\":\"codex-thread\"}}",
+            "{\"timestamp\":\"2026-08-01T12:00:00Z\",\"payload\":{\"type\":\"user_message\",\"id\":\"codex-thread\",\"message\":\"Run the tests for the scanner\"}}",
+            "{\"timestamp\":\"2026-08-01T12:00:02Z\",\"payload\":{\"type\":\"custom_tool_call\",\"id\":\"tool-1\",\"name\":\"shell_command\",\"arguments\":\"dotnet test\"}}" );
+
+        var info = AgentActivityScanner.ParseTranscriptForTesting(ProviderId.Codex, transcript);
+
+        Assert.Equal("codex-thread", info.ThreadId);
+        Assert.Equal("Run the tests for the scanner", info.Prompt);
+        Assert.Equal("Ran tests", info.Step);
+        Assert.Equal(AgentActivityScanner.TranscriptState.Action, info.State);
+    }
+
+    [Fact]
+    public void ActivityTitle_IsSummarizedFromLatestPrompt()
+    {
+        var title = AgentActivityScanner.SummarizeTitleForTesting(
+            "  # Add Claude parity\n\nPlease parse tool calls, session titles, and state colors consistently.");
+
+        Assert.Equal("Add Claude parity", title);
+    }
+
+    [Fact]
+    public void IdleAgentRemainsLiveAndHasItsOwnStateText()
+    {
+        var item = new AgentActivityItem(
+            "idle", ProviderId.Claude, "Claude", "Waiting for the next prompt",
+            AgentActivityStatus.Idle, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+
+        Assert.True(item.IsLive);
+        Assert.Equal("Idle", item.StatusText);
+    }
 }

--- a/tests/TaskbarQuota.Tests/AgentActivityTests.cs
+++ b/tests/TaskbarQuota.Tests/AgentActivityTests.cs
@@ -62,6 +62,18 @@ public sealed class AgentActivityTests
         Assert.Equal(AgentActivityScanner.TranscriptState.Waiting, info.State);
     }
 
+    [Theory]
+    [InlineData("t3code_desktop", "T3 Code")]
+    [InlineData("synara", "Synara")]
+    public void ClaudeTranscript_ExtractsHost(string originator, string expectedHost)
+    {
+        var transcript = $"{{\"type\":\"user\",\"originator\":\"{originator}\",\"sessionId\":\"claude-thread\",\"timestamp\":\"2026-08-01T12:00:00Z\",\"message\":{{\"content\":\"Identify the host\"}}}}";
+
+        var info = AgentActivityScanner.ParseTranscriptForTesting(ProviderId.Claude, transcript);
+
+        Assert.Equal(expectedHost, info.Host);
+    }
+
     [Fact]
     public void CodexTranscript_ExtractsPromptAndShellAction()
     {

--- a/tests/TaskbarQuota.Tests/AgentActivityTests.cs
+++ b/tests/TaskbarQuota.Tests/AgentActivityTests.cs
@@ -311,12 +311,13 @@ public sealed class AgentActivityTests
                 {"step_index":0,"source":"user","type":"USER_INPUT","status":"SUCCESS","created_at":"{{{now}}}","content":"Refactor Antigravity GUI activity tracking"}
                 {"step_index":1,"source":"agent","type":"PLANNER_RESPONSE","status":"SUCCESS","created_at":"{{{now}}}","tool_calls":[{"name":"grep_search","args":{"Query":"activation","toolAction":"Searching for activation","toolSummary":"Grep for activation"}}]}
                 {"step_index":2,"source":"tool","type":"GREP_SEARCH","status":"SUCCESS","created_at":"{{{now}}}","content":"matches"}
+                {"step_index":3,"source":"system","type":"CHECKPOINT","status":"DONE","created_at":"{{{now}}}","content":"# USER Objective:\nSystem Connectivity Test\n"}
                 """);
 
             var item = Assert.Single(AgentActivityScanner.ReadAntigravityGuiForTesting(path));
 
             Assert.Equal(ProviderId.Antigravity, item.Provider);
-            Assert.Equal("Refactor Antigravity GUI activity tracking", item.Title);
+            Assert.Equal("System Connectivity Test", item.Title);
             Assert.Equal("Refactor Antigravity GUI activity tracking", item.Detail);
             Assert.Equal("Inspected files", item.Step);
             Assert.Equal(AgentActivityStatus.Working, item.Status);

--- a/tests/TaskbarQuota.Tests/AgentActivityTests.cs
+++ b/tests/TaskbarQuota.Tests/AgentActivityTests.cs
@@ -298,6 +298,37 @@ public sealed class AgentActivityTests
     }
 
     [Fact]
+    public void AntigravityGuiTranscript_ExtractsPromptAndToolAction()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"taskbarquota-antigravity-gui-{Guid.NewGuid():N}",
+            ".system_generated", "logs");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "transcript.jsonl");
+        try
+        {
+            var now = DateTimeOffset.UtcNow.ToString("O");
+            File.WriteAllText(path, $$$"""
+                {"step_index":0,"source":"user","type":"USER_INPUT","status":"SUCCESS","created_at":"{{{now}}}","content":"Refactor Antigravity GUI activity tracking"}
+                {"step_index":1,"source":"agent","type":"PLANNER_RESPONSE","status":"SUCCESS","created_at":"{{{now}}}","tool_calls":[{"name":"grep_search","args":{"Query":"activation","toolAction":"Searching for activation","toolSummary":"Grep for activation"}}]}
+                {"step_index":2,"source":"tool","type":"GREP_SEARCH","status":"SUCCESS","created_at":"{{{now}}}","content":"matches"}
+                """);
+
+            var item = Assert.Single(AgentActivityScanner.ReadAntigravityGuiForTesting(path));
+
+            Assert.Equal(ProviderId.Antigravity, item.Provider);
+            Assert.Equal("Refactor Antigravity GUI activity tracking", item.Title);
+            Assert.Equal("Refactor Antigravity GUI activity tracking", item.Detail);
+            Assert.Equal("Inspected files", item.Step);
+            Assert.Equal(AgentActivityStatus.Working, item.Status);
+        }
+        finally
+        {
+            if (Directory.Exists(Path.GetDirectoryName(path)!))
+                Directory.Delete(Path.GetDirectoryName(path)!, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ActivityTitle_IsSummarizedFromLatestPrompt()
     {
         var title = AgentActivityScanner.SummarizeTitleForTesting(

--- a/tests/TaskbarQuota.Tests/AgentActivityTests.cs
+++ b/tests/TaskbarQuota.Tests/AgentActivityTests.cs
@@ -38,6 +38,13 @@ public sealed class AgentActivityTests
         Assert.Equal("waiting", snapshot.Primary?.Id);
     }
 
+    [Theory]
+    [InlineData("OpenCode Beta", ProviderId.OpenCode)]
+    [InlineData("opencode", ProviderId.OpenCode)]
+    [InlineData("opencode-beta", ProviderId.OpenCode)]
+    public void DesktopOpenCodeProcess_IsRecognizedAsLiveProvider(string processName, ProviderId expected)
+        => Assert.Equal(expected, AgentActivityScanner.DetectDesktopProviderForTesting(processName));
+
     [Fact]
     public void ClineSession_ExtractsTitleToolActionAndWorkingState()
     {

--- a/tests/TaskbarQuota.Tests/AgentActivityTests.cs
+++ b/tests/TaskbarQuota.Tests/AgentActivityTests.cs
@@ -38,12 +38,223 @@ public sealed class AgentActivityTests
         Assert.Equal("waiting", snapshot.Primary?.Id);
     }
 
+    [Fact]
+    public void CompactItems_ExpiresCompletedButRetainsFailureLonger()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var snapshot = new AgentActivitySnapshot(new[]
+        {
+            new AgentActivityItem("old-done", ProviderId.Claude, "Done", "Finished", AgentActivityStatus.Completed,
+                now.AddMinutes(-2), now.AddMinutes(-2)),
+            new AgentActivityItem("recent-failed", ProviderId.Cline, "Build", "Failed", AgentActivityStatus.Failed,
+                now.AddMinutes(-2), now.AddMinutes(-2)),
+        });
+
+        Assert.DoesNotContain(snapshot.CompactItems, item => item.Id == "old-done");
+        Assert.Contains(snapshot.CompactItems, item => item.Id == "recent-failed");
+        Assert.Contains(snapshot.Items, item => item.Id == "old-done");
+    }
+
+    [Fact]
+    public void CompactItems_KeepsLiveAgentsRegardlessOfAge()
+    {
+        var now = DateTimeOffset.UtcNow.AddDays(-2);
+        var snapshot = new AgentActivitySnapshot(new[]
+        {
+            new AgentActivityItem("live", ProviderId.Codex, "Tests", "Working", AgentActivityStatus.Working,
+                now, now),
+        });
+
+        Assert.Contains(snapshot.CompactItems, item => item.Id == "live");
+        Assert.Equal("live", snapshot.Primary?.Id);
+    }
+
+    [Fact]
+    public void CompactItems_ShowsIdleThenCompletedThenExpires()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var snapshot = new AgentActivitySnapshot(new[]
+        {
+            new AgentActivityItem("recent-idle", ProviderId.Codex, "Task", "Waiting for the next prompt",
+                AgentActivityStatus.Idle, now.AddSeconds(-30), now.AddSeconds(-30)),
+              new AgentActivityItem("completed-idle", ProviderId.Codex, "Completed task", "Waiting for the next prompt",
+                  AgentActivityStatus.Idle, now.AddSeconds(-100), now.AddSeconds(-100)),
+              new AgentActivityItem("old-idle", ProviderId.Codex, "Old task", "Waiting for the next prompt",
+                  AgentActivityStatus.Idle, now.AddSeconds(-130), now.AddSeconds(-130)),
+          });
+
+          Assert.Contains(snapshot.CompactItems, item => item.Id == "recent-idle");
+          var completed = Assert.Single(snapshot.CompactItems, item => item.Id == "completed-idle");
+          Assert.Equal(AgentActivityStatus.Completed, completed.Status);
+          Assert.Equal("Completed", completed.Step);
+          Assert.DoesNotContain(snapshot.CompactItems, item => item.Id == "old-idle");
+    }
+
     [Theory]
     [InlineData("OpenCode Beta", ProviderId.OpenCode)]
     [InlineData("opencode", ProviderId.OpenCode)]
     [InlineData("opencode-beta", ProviderId.OpenCode)]
     public void DesktopOpenCodeProcess_IsRecognizedAsLiveProvider(string processName, ProviderId expected)
         => Assert.Equal(expected, AgentActivityScanner.DetectDesktopProviderForTesting(processName));
+
+    [Theory]
+    [InlineData("code")]
+    [InlineData("code-insiders")]
+    public void DesktopVsCodeProcess_IsRecognizedAsCopilot(string processName)
+        => Assert.Equal(ProviderId.Copilot, AgentActivityScanner.DetectDesktopProviderForTesting(processName));
+
+    [Fact]
+    public void CopilotJsonSession_ExtractsPromptModelAndCompletedState()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "taskbarquota-copilot-" + Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            File.WriteAllText(path, """
+                {"v":{"sessionId":"copilot-json-1","customTitle":"Project SEO Evaluation","selectedModel":{"family":"GPT-4.1"},"requests":[{"message":{"text":"Fix the build"},"response":[{"value":"Done"}]}]}}
+                """);
+
+            var item = Assert.Single(AgentActivityScanner.ReadCopilotForTesting(path, claimLive: true));
+            Assert.Equal(ProviderId.Copilot, item.Provider);
+            Assert.Equal("Project SEO Evaluation", item.Title);
+            Assert.Equal("GPT-4.1", item.Model);
+            Assert.Equal(AgentActivityStatus.Idle, item.Status);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void CopilotJsonSession_EmptyResponseRemainsWorking()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "taskbarquota-copilot-" + Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            File.WriteAllText(path, """
+                {"sessionId":"copilot-in-progress","customTitle":"Project SEO Evaluation","requests":[{"message":{"text":"Evaluate the SEO project"},"response":[]}]}
+                """);
+
+            var item = Assert.Single(AgentActivityScanner.ReadCopilotForTesting(path, claimLive: true));
+            Assert.Equal("Project SEO Evaluation", item.Title);
+            Assert.Equal(AgentActivityStatus.Working, item.Status);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void CopilotJsonlSnapshotAndDeltas_UseCustomTitleAndModelState()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "taskbarquota-copilot-" + Guid.NewGuid().ToString("N") + ".jsonl");
+        try
+        {
+            File.WriteAllText(path, """
+                {"kind":0,"v":{"sessionId":"copilot-snapshot-1","customTitle":"Project SEO Evaluation","requests":[{"message":{"text":"Evaluate SEO"},"modelId":"copilot/auto","modelState":{"value":0},"response":[{"kind":"thinking","value":"Working"}]}]}}
+                {"kind":1,"k":["requests",0,"modelState"],"v":{"value":0}}
+                """);
+
+            var item = Assert.Single(AgentActivityScanner.ReadCopilotForTesting(path, claimLive: true));
+            Assert.Equal("Project SEO Evaluation", item.Title);
+            Assert.Equal("copilot/auto", item.Model);
+            Assert.Equal(AgentActivityStatus.Working, item.Status);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void CopilotJsonlSession_ReportsWorkingOnlyWhenVsCodeIsLive()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "taskbarquota-copilot-" + Guid.NewGuid().ToString("N") + ".jsonl");
+        try
+        {
+            File.WriteAllText(path, """
+                {"type":"session.start","data":{"sessionId":"copilot-jsonl-1","startTime":"2026-08-03T12:00:00Z"}}
+                {"type":"user.message","data":{"content":"Inspect the failing test"}}
+                """);
+
+            var live = Assert.Single(AgentActivityScanner.ReadCopilotForTesting(path, claimLive: true));
+            Assert.Equal("Inspect the failing test", live.Title);
+            Assert.Equal(AgentActivityStatus.Working, live.Status);
+
+            var closed = Assert.Single(AgentActivityScanner.ReadCopilotForTesting(path, claimLive: false));
+            Assert.Equal(AgentActivityStatus.Completed, closed.Status);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void CopilotJsonlSession_ReportsToolActivityAndInsidersHost()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "Code - Insiders", "User", "workspaceStorage", Guid.NewGuid().ToString("N"), "chatSessions");
+        var path = Path.Combine(root, "copilot-tool.jsonl");
+        try
+        {
+            Directory.CreateDirectory(root);
+            File.WriteAllText(path, """
+                {"type":"user.message","data":{"content":"Run the tests"}}
+                {"type":"assistant.message","data":{"toolRequests":[{"name":"shell"}],"status":"running"}}
+                """);
+
+            var item = Assert.Single(AgentActivityScanner.ReadCopilotForTesting(path, claimLive: true));
+            Assert.Equal("Running shell", item.Step);
+            Assert.Equal("VS Code Insiders", item.Host);
+            Assert.Equal(AgentActivityStatus.Working, item.Status);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ZcodeDatabase_ExtractsPromptToolAndModel()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "taskbarquota-zcode-" + Guid.NewGuid().ToString("N") + ".sqlite");
+        try
+        {
+            var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            using (var connection = new SqliteConnection($"Data Source={path}"))
+            {
+                connection.Open();
+                using var command = connection.CreateCommand();
+                command.CommandText = """
+                    CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT, title TEXT, time_created INTEGER, time_updated INTEGER);
+                    CREATE TABLE session_target (session_id TEXT PRIMARY KEY, status TEXT);
+                    CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+                    CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+                    INSERT INTO session VALUES ('s1', NULL, 'Review the build', $now, $now);
+                    INSERT INTO session_target VALUES ('s1', 'active');
+                    INSERT INTO message VALUES ('m1', 's1', $now, $now, '{"role":"user","content":[{"type":"text","text":"Review the build"}]}');
+                    INSERT INTO message VALUES ('m2', 's1', $now, $now, '{"role":"assistant","modelID":"GLM-5.2"}');
+                    INSERT INTO part VALUES ('p1', 'm2', 's1', $now, $now, '{"type":"tool","tool":"shell","state":{"status":"running","input":{"command":"dotnet test"}}}');
+                    """;
+                command.Parameters.AddWithValue("$now", now);
+                command.ExecuteNonQuery();
+            }
+
+            var item = Assert.Single(AgentActivityScanner.ReadZcodeForTesting(path));
+            Assert.Equal(ProviderId.Zai, item.Provider);
+            Assert.Equal("Review the build", item.Title);
+            Assert.Equal("Ran tests", item.Step);
+            Assert.Equal("GLM-5.2", item.Model);
+            Assert.Equal(AgentActivityStatus.Working, item.Status);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            try { if (File.Exists(path)) File.Delete(path); } catch (IOException) { }
+        }
+    }
 
     [Fact]
     public void ClineSession_ExtractsTitleToolActionAndWorkingState()

--- a/tests/TaskbarQuota.Tests/AgentActivityTests.cs
+++ b/tests/TaskbarQuota.Tests/AgentActivityTests.cs
@@ -1,0 +1,37 @@
+using System;
+using TaskbarQuota.AgentActivity;
+using TaskbarQuota.Usage;
+using Xunit;
+
+namespace TaskbarQuota.Tests;
+
+public sealed class AgentActivityTests
+{
+    [Fact]
+    public void PrimaryPrefersLiveAgentOverNewerCompletedItem()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var snapshot = new AgentActivitySnapshot(new[]
+        {
+            new AgentActivityItem("done", ProviderId.Claude, "Auth", "Finished", AgentActivityStatus.Completed, now.AddMinutes(-2), now),
+            new AgentActivityItem("live", ProviderId.Codex, "Tests", "Running tests", AgentActivityStatus.Working, now.AddMinutes(-1), now.AddSeconds(-1)),
+        });
+
+        Assert.Equal("live", snapshot.Primary?.Id);
+        Assert.True(snapshot.HasUnreadCompletions);
+    }
+
+    [Fact]
+    public void WaitingAgentIsLiveButFailureIsNot()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var snapshot = new AgentActivitySnapshot(new[]
+        {
+            new AgentActivityItem("waiting", ProviderId.Cursor, "Review", "Waiting for approval", AgentActivityStatus.Waiting, now, now),
+            new AgentActivityItem("failed", ProviderId.Cline, "Build", "Build failed", AgentActivityStatus.Failed, now, now),
+        });
+
+        Assert.True(snapshot.HasLiveItems);
+        Assert.Equal("waiting", snapshot.Primary?.Id);
+    }
+}

--- a/tests/TaskbarQuota.Tests/AgentActivityTests.cs
+++ b/tests/TaskbarQuota.Tests/AgentActivityTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 using Microsoft.Data.Sqlite;
 using TaskbarQuota.AgentActivity;
 using TaskbarQuota.Usage;
@@ -212,6 +213,87 @@ public sealed class AgentActivityTests
         {
             if (Directory.Exists(directory))
                 Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void AntigravityMetadata_ExtractsPreviewAndWorkspace()
+    {
+        var metadata = $$"""
+            {
+              "conversations": {
+                "agy-1": {
+                  "summary": {
+                    "ID": "agy-1",
+                    "Title": "",
+                    "Preview": "Refactor Antigravity activity tracking",
+                    "WorkspaceURIs": ["file:///c:/work/TaskbarQuota"]
+                  }
+                }
+              }
+            }
+            """;
+
+        var parsed = AgentActivityScanner.ParseAntigravityMetadataForTesting(metadata, "agy-1");
+
+        Assert.NotNull(parsed);
+        Assert.Equal("Refactor Antigravity activity tracking", parsed!.Value.Preview);
+        Assert.Equal("C:\\work\\TaskbarQuota", parsed.Value.Workspace);
+    }
+
+    [Fact]
+    public void AntigravityDatabase_ExtractsPromptModelToolAndSubagent()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"taskbarquota-antigravity-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var connection = new SqliteConnection($"Data Source={path}"))
+            {
+                connection.Open();
+                using var command = connection.CreateCommand();
+                command.CommandText = """
+                    CREATE TABLE steps (
+                        idx INTEGER PRIMARY KEY,
+                        step_type INTEGER NOT NULL DEFAULT 0,
+                        status INTEGER NOT NULL DEFAULT 0,
+                        has_subtrajectory NUMERIC NOT NULL DEFAULT false,
+                        metadata BLOB,
+                        error_details BLOB,
+                        permissions BLOB,
+                        task_details BLOB,
+                        render_info BLOB,
+                        step_payload BLOB,
+                        step_format INTEGER NOT NULL DEFAULT 0
+                    );
+                    """;
+                command.ExecuteNonQuery();
+
+                command.Parameters.Clear();
+                command.CommandText = """
+                    INSERT INTO steps (idx, step_type, status, has_subtrajectory, step_payload)
+                    VALUES (1, 5, 3, 1, $payload);
+                    """;
+                command.Parameters.AddWithValue("$payload", Encoding.UTF8.GetBytes("""
+                    {"prompt":"Refactor Antigravity activity tracking","model":"gemini-3","toolName":"grep_search","toolSummary":"Grep for activation","toolAction":"Searching for activation"}
+                    """));
+                command.ExecuteNonQuery();
+            }
+
+            var item = Assert.Single(AgentActivityScanner.ReadAntigravityForTesting(path));
+
+            Assert.Equal(ProviderId.Antigravity, item.Provider);
+            Assert.Equal("Refactor Antigravity activity tracking", item.Title);
+            Assert.Equal("Refactor Antigravity activity tracking", item.Detail);
+            Assert.Equal("gemini-3", item.Model);
+            Assert.Equal("Grep for activation", item.Step);
+            Assert.Equal(1, item.SubagentCount);
+            Assert.Equal(AgentActivityStatus.Working, item.Status);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(path))
+                File.Delete(path);
         }
     }
 

--- a/tests/TaskbarQuota.Tests/AgentActivityTests.cs
+++ b/tests/TaskbarQuota.Tests/AgentActivityTests.cs
@@ -39,6 +39,123 @@ public sealed class AgentActivityTests
     }
 
     [Fact]
+    public void ClineSession_ExtractsTitleToolActionAndWorkingState()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "taskbarquota-cline-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var now = DateTimeOffset.UtcNow;
+            var metadataPath = Path.Combine(root, "cline-1.json");
+            var messagesPath = Path.Combine(root, "cline-1.messages.json");
+            File.WriteAllText(metadataPath, $$"""
+                {
+                  "session_id": "cline-1",
+                  "started_at": "{{now:O}}",
+                  "status": "running",
+                  "model": "cline/kimi-k3",
+                  "prompt": "<user_input mode=\"act\">Run the build checks</user_input>",
+                  "metadata": { "title": "Run the build checks" }
+                }
+                """);
+            File.WriteAllText(messagesPath, $$"""
+                {
+                  "messages": [
+                    { "role": "user", "content": [{ "type": "text", "text": "Run the build checks" }], "ts": {{now.ToUnixTimeMilliseconds()}} },
+                    { "role": "assistant", "content": [{ "type": "thinking", "thinking": "Checking the project" }], "ts": {{now.ToUnixTimeMilliseconds()}} },
+                    { "role": "assistant", "content": [{ "type": "tool_use", "name": "shell_command", "input": { "command": "dotnet test" } }], "ts": {{now.ToUnixTimeMilliseconds()}} }
+                  ]
+                }
+                """);
+
+            var item = AgentActivityScanner.ReadClineForTesting(metadataPath);
+
+            Assert.NotNull(item);
+            Assert.Equal(ProviderId.Cline, item.Provider);
+            Assert.Equal("Run the build checks", item.Title);
+            Assert.Equal("Ran tests", item.Step);
+            Assert.Equal(AgentActivityStatus.Working, item.Status);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void KimiSession_ExtractsTitleToolActionAndSubagentCount()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "taskbarquota-kimi-" + Guid.NewGuid().ToString("N"));
+        var session = Path.Combine(root, "session_kimi-1");
+        var main = Path.Combine(session, "agents", "main");
+        Directory.CreateDirectory(main);
+        try
+        {
+            var now = DateTimeOffset.UtcNow;
+            var statePath = Path.Combine(session, "state.json");
+            File.WriteAllText(statePath, $$"""
+                {
+                  "createdAt": "{{now:O}}",
+                  "updatedAt": "{{now:O}}",
+                  "title": "New Session",
+                  "agents": {
+                    "main": { "type": "main" },
+                    "worker": { "type": "subagent" }
+                  }
+                }
+                """);
+            File.WriteAllText(Path.Combine(main, "wire.jsonl"), $$"""
+                {"type":"user_input","text":"Inspect the build" ,"time":{{now.ToUnixTimeMilliseconds()}}}
+                {"type":"tool_call","name":"shell","arguments":{"command":"dotnet test"},"time":{{now.ToUnixTimeMilliseconds()}}}
+                """);
+
+            var item = AgentActivityScanner.ReadKimiForTesting(statePath);
+
+            Assert.NotNull(item);
+            Assert.Equal(ProviderId.Kimi, item.Provider);
+            Assert.Equal("Inspect the build", item.Title);
+            Assert.Equal("Ran tests", item.Step);
+            Assert.Equal(AgentActivityStatus.Working, item.Status);
+            Assert.Equal(1, item.SubagentCount);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LegacyKimiSession_ExtractsDirectWireLog()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "taskbarquota-kimi-legacy-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var now = DateTimeOffset.UtcNow;
+            var statePath = Path.Combine(root, "state.json");
+            File.WriteAllText(statePath, $$"""
+                { "created_at": "{{now:O}}", "title": "Legacy session" }
+                """);
+            File.WriteAllText(Path.Combine(root, "wire.jsonl"), $$"""
+                {"type":"user","text":"Review the legacy session","timestamp":{{now.ToUnixTimeMilliseconds()}}}
+                {"type":"tool_call","name":"Read","timestamp":{{now.ToUnixTimeMilliseconds()}}}
+                """);
+
+            var item = AgentActivityScanner.ReadKimiForTesting(statePath);
+
+            Assert.NotNull(item);
+            Assert.Equal(ProviderId.Kimi, item.Provider);
+            Assert.Equal("Legacy session", item.Title);
+            Assert.Equal("Inspected files", item.Step);
+            Assert.Equal(AgentActivityStatus.Working, item.Status);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ClaudeTranscript_ExtractsPromptModelAndToolAction()
     {
         var transcript = string.Join('\n',

--- a/tests/TaskbarQuota.Tests/FlyoutLayoutTests.cs
+++ b/tests/TaskbarQuota.Tests/FlyoutLayoutTests.cs
@@ -25,7 +25,7 @@ public class FlyoutLayoutTests
     public void ComputeLogicalWidth_GrowsWithInstalledProviders()
     {
         int width = FlyoutLayout.ComputeLogicalWidth(stripIconCount: 9, detailContentWidth: 300);
-        Assert.Equal(532, width);
+        Assert.Equal(582, width);
     }
 
     [Fact]

--- a/tests/TaskbarQuota.Tests/TaskBarWidgetGapTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskBarWidgetGapTests.cs
@@ -167,6 +167,24 @@ public class TaskBarWidgetGapTests
     }
 
     [Fact]
+    public void SelectDragGap_CursorPassesLaneMidpoint_HandsOverWithoutWaitingForFarLane()
+    {
+        var gap = TaskBarWidget.SelectDragGap(CentredLayout, cursorX: 501, desiredX: 451, width: 172,
+            current: (0, 400));
+
+        Assert.Equal((600, 1000), gap);
+    }
+
+    [Fact]
+    public void SelectDragGap_CursorMovesBackPastLaneMidpoint_ReturnsToPreviousLane()
+    {
+        var gap = TaskBarWidget.SelectDragGap(CentredLayout, cursorX: 499, desiredX: 549, width: 172,
+            current: (600, 1000));
+
+        Assert.Equal((0, 400), gap);
+    }
+
+    [Fact]
     public void SelectDragGap_StickyZoneSurvivesObstacleRectsShiftingByAPixel()
     {
         var relaidOut = new List<(int start, int end)> { (0, 398), (602, 1000) };

--- a/tests/TaskbarQuota.Tests/TaskbarWidgetPlacementTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskbarWidgetPlacementTests.cs
@@ -65,6 +65,138 @@ public sealed class TaskbarWidgetPlacementTests
     }
 
     [Fact]
+    public void PlaceAdaptivePair_QuotaFirst_ShrinksActivityWithoutMovingQuota()
+    {
+        var result = TaskbarWidgetPlacement.PlaceAdaptivePair(
+            preferredQuotaX: 100, quotaWidth: 440,
+            minimumActivityWidth: 120, maximumActivityWidth: 400, gap: 8,
+            TaskbarWidgetOrder.QuotaFirst, new[] { (0, 800) });
+
+        Assert.Equal(new AdaptiveWidgetPairPlacement(100, 548, 252, 700), result);
+    }
+
+    [Fact]
+    public void PlaceAdaptivePair_ActivityFirst_PreservesQuotaAndOrder()
+    {
+        var result = TaskbarWidgetPlacement.PlaceAdaptivePair(
+            preferredQuotaX: 600, quotaWidth: 180,
+            minimumActivityWidth: 120, maximumActivityWidth: 400, gap: 8,
+            TaskbarWidgetOrder.ActivityFirst, new[] { (100, 1000) });
+
+        Assert.Equal(new AdaptiveWidgetPairPlacement(600, 192, 400, 588), result);
+    }
+
+    [Fact]
+    public void PlaceAdaptivePair_ChoosesNearestLaneThatFitsBothWidgets()
+    {
+        var result = TaskbarWidgetPlacement.PlaceAdaptivePair(
+            preferredQuotaX: 300, quotaWidth: 180,
+            minimumActivityWidth: 120, maximumActivityWidth: 400, gap: 8,
+            TaskbarWidgetOrder.QuotaFirst, new[] { (0, 250), (500, 900) });
+
+        Assert.Equal(new AdaptiveWidgetPairPlacement(500, 688, 212, 400), result);
+    }
+
+    [Fact]
+    public void PlaceAdaptivePair_ReturnsNullWhenMinimumPairCannotFit()
+    {
+        var result = TaskbarWidgetPlacement.PlaceAdaptivePair(
+            preferredQuotaX: 0, quotaWidth: 180,
+            minimumActivityWidth: 120, maximumActivityWidth: 400, gap: 8,
+            TaskbarWidgetOrder.QuotaFirst, new[] { (0, 300) });
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void PlaceAdaptivePair_PreservesDetachedActivityPosition()
+    {
+        var result = TaskbarWidgetPlacement.PlaceAdaptivePair(
+            preferredQuotaX: 100, quotaWidth: 180,
+            minimumActivityWidth: 120, maximumActivityWidth: 400, gap: 8,
+            TaskbarWidgetOrder.QuotaFirst, new[] { (0, 1000) },
+            preferredActivityX: 700, currentActivityWidth: 120);
+
+        Assert.Equal(new AdaptiveWidgetPairPlacement(100, 700, 300, 488), result);
+    }
+
+    [Fact]
+    public void PlaceAdaptivePair_ManualActivityFirstDropKeepsItsLeftEdge()
+    {
+        var result = TaskbarWidgetPlacement.PlaceAdaptivePair(
+            preferredQuotaX: 800, quotaWidth: 180,
+            minimumActivityWidth: 120, maximumActivityWidth: 400, gap: 8,
+            TaskbarWidgetOrder.ActivityFirst, new[] { (0, 1000) },
+            preferredActivityX: 200, currentActivityWidth: 120);
+
+        Assert.Equal(new AdaptiveWidgetPairPlacement(800, 200, 400, 588), result);
+    }
+
+    [Fact]
+    public void PlaceAdaptivePair_AutomaticPositionReturnsBesideNarrowerQuota()
+    {
+        var wideQuota = TaskbarWidgetPlacement.PlaceAdaptivePair(
+            preferredQuotaX: 100, quotaWidth: 440,
+            minimumActivityWidth: 120, maximumActivityWidth: 400, gap: 8,
+            TaskbarWidgetOrder.QuotaFirst, new[] { (0, 800) });
+        var narrowQuota = TaskbarWidgetPlacement.PlaceAdaptivePair(
+            preferredQuotaX: 100, quotaWidth: 180,
+            minimumActivityWidth: 120, maximumActivityWidth: 400, gap: 8,
+            TaskbarWidgetOrder.QuotaFirst, new[] { (0, 800) });
+
+        Assert.Equal(new AdaptiveWidgetPairPlacement(100, 548, 252, 700), wideQuota);
+        Assert.Equal(new AdaptiveWidgetPairPlacement(100, 288, 400, 588), narrowQuota);
+    }
+
+    [Fact]
+    public void OccupyDifferentGaps_DetectsOppositeTaskbarLanes()
+    {
+        var gaps = new[] { (0, 360), (620, 1200) };
+
+        Assert.True(TaskbarWidgetPlacement.OccupyDifferentGaps(
+            firstX: 100, firstWidth: 180,
+            secondX: 700, secondWidth: 120,
+            gaps));
+    }
+
+    [Fact]
+    public void OccupyDifferentGaps_IsFalseWithinOneTaskbarLane()
+    {
+        var gaps = new[] { (0, 1000) };
+
+        Assert.False(TaskbarWidgetPlacement.OccupyDifferentGaps(
+            firstX: 100, firstWidth: 180,
+            secondX: 700, secondWidth: 120,
+            gaps));
+    }
+
+    [Theory]
+    [InlineData(266, 272)]
+    [InlineData(470, 488)]
+    public void SnapNextToPartner_GluesActivityWhenDroppedClose(int droppedX, int expectedX)
+    {
+        var result = TaskbarWidgetPlacement.SnapNextToPartner(
+            droppedX, draggedWidth: 120,
+            partnerX: 400, partnerWidth: 80,
+            gap: 8, maximumDistance: 32,
+            new[] { (0, 392), (488, 1000) });
+
+        Assert.Equal(expectedX, result);
+    }
+
+    [Fact]
+    public void SnapNextToPartner_LeavesDetachedActivityAloneOutsideMagneticZone()
+    {
+        var result = TaskbarWidgetPlacement.SnapNextToPartner(
+            droppedX: 200, draggedWidth: 120,
+            partnerX: 400, partnerWidth: 80,
+            gap: 8, maximumDistance: 32,
+            new[] { (0, 392), (488, 1000) });
+
+        Assert.Null(result);
+    }
+
+    [Fact]
     public void OrderForDraggedActivity_SwapsAtPartnerCenter()
     {
         Assert.Equal(TaskbarWidgetOrder.ActivityFirst,

--- a/tests/TaskbarQuota.Tests/TaskbarWidgetPlacementTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskbarWidgetPlacementTests.cs
@@ -1,0 +1,102 @@
+using TaskbarQuota.Taskbar;
+
+namespace TaskbarQuota.Tests;
+
+public sealed class TaskbarWidgetPlacementTests
+{
+    private static readonly IReadOnlyList<(int start, int end)> Gaps =
+        new[] { (0, 1000) };
+
+    [Fact]
+    public void PlacePair_QuotaFirst_UsesRequestedAnchor()
+    {
+        var result = TaskbarWidgetPlacement.PlacePair(200, 180, 120, 8,
+            TaskbarWidgetOrder.QuotaFirst, Gaps);
+
+        Assert.Equal(new WidgetPairPlacement(200, 388, 308), result);
+    }
+
+    [Fact]
+    public void PlacePair_ActivityFirst_ClampsToGap()
+    {
+        var result = TaskbarWidgetPlacement.PlacePair(900, 180, 120, 8,
+            TaskbarWidgetOrder.ActivityFirst, Gaps);
+
+        Assert.Equal(new WidgetPairPlacement(820, 692, 308), result);
+    }
+
+    [Fact]
+    public void PlacePair_ReturnsNullWhenPairDoesNotFit()
+    {
+        var result = TaskbarWidgetPlacement.PlacePair(0, 180, 120, 8,
+            TaskbarWidgetOrder.QuotaFirst, new[] { (0, 300) });
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void PlaceAdaptive_ExpandsToAvailableWidthUpToMaximum()
+    {
+        var result = TaskbarWidgetPlacement.PlaceAdaptive(
+            preferredX: 200, currentWidth: 240, minimumWidth: 160, maximumWidth: 400,
+            anchorRight: false, new[] { (0, 700) });
+
+        Assert.Equal(new AdaptiveWidgetPlacement(200, 400), result);
+    }
+
+    [Fact]
+    public void PlaceAdaptive_PreservesRightEdgeWhenWidgetIsLeftOfPartner()
+    {
+        var result = TaskbarWidgetPlacement.PlaceAdaptive(
+            preferredX: 300, currentWidth: 240, minimumWidth: 160, maximumWidth: 400,
+            anchorRight: true, new[] { (100, 540) });
+
+        Assert.Equal(new AdaptiveWidgetPlacement(140, 400), result);
+    }
+
+    [Fact]
+    public void PlaceAdaptive_UsesLaneWidthButNeverChoosesAnUndersizedLane()
+    {
+        var result = TaskbarWidgetPlacement.PlaceAdaptive(
+            preferredX: 100, currentWidth: 240, minimumWidth: 160, maximumWidth: 400,
+            anchorRight: false, new[] { (0, 120), (200, 480) });
+
+        Assert.Equal(new AdaptiveWidgetPlacement(200, 280), result);
+    }
+
+    [Fact]
+    public void OrderForDraggedActivity_SwapsAtPartnerCenter()
+    {
+        Assert.Equal(TaskbarWidgetOrder.ActivityFirst,
+            TaskbarWidgetPlacement.OrderForDraggedWidget(TaskbarWidgetRole.Activity, 100, 100, 220, 100,
+                TaskbarWidgetOrder.QuotaFirst));
+        Assert.Equal(TaskbarWidgetOrder.QuotaFirst,
+            TaskbarWidgetPlacement.OrderForDraggedWidget(TaskbarWidgetRole.Activity, 300, 100, 220, 100,
+                TaskbarWidgetOrder.ActivityFirst));
+    }
+
+    [Fact]
+    public void OrderForDraggedWidget_HoldsCurrentOrderInsideHysteresisBand()
+    {
+        Assert.Equal(TaskbarWidgetOrder.QuotaFirst,
+            TaskbarWidgetPlacement.OrderForDraggedWidget(TaskbarWidgetRole.Activity, 211, 100, 220, 100,
+                TaskbarWidgetOrder.QuotaFirst, hysteresis: 12));
+        Assert.Equal(TaskbarWidgetOrder.ActivityFirst,
+            TaskbarWidgetPlacement.OrderForDraggedWidget(TaskbarWidgetRole.Activity, 207, 100, 220, 100,
+                TaskbarWidgetOrder.QuotaFirst, hysteresis: 12));
+    }
+
+    [Fact]
+    public void StepAnimatedPosition_EasesTowardTargetWithoutOvershooting()
+    {
+        int position = 100;
+        for (int i = 0; i < 30; i++)
+        {
+            int next = TaskbarWidgetPlacement.StepAnimatedPosition(position, 300);
+            Assert.InRange(next, position, 300);
+            position = next;
+        }
+
+        Assert.Equal(300, position);
+    }
+}

--- a/tests/TaskbarQuota.Tests/WidgetDisplayProvidersTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetDisplayProvidersTests.cs
@@ -17,7 +17,8 @@ public class WidgetDisplayProvidersTests
         IReadOnlyList<ProviderId>? recent = null,
         bool present = true,
         Func<ProviderId, bool>? isVisible = null,
-        Func<ProviderId, bool>? isAvailable = null)
+        Func<ProviderId, bool>? isAvailable = null,
+        bool activityWidgetEnabled = false)
         => UsageCoordinator.ComputeWidgetDisplayProviders(
             active,
             present,
@@ -25,7 +26,8 @@ public class WidgetDisplayProvidersTests
             Enum.GetValues<ProviderId>(),
             p => pinned.Contains(p),
             isVisible ?? (_ => true),
-            isAvailable ?? (_ => true));
+            isAvailable ?? (_ => true),
+            activityWidgetEnabled);
 
     [Fact]
     public void ActiveProviderLeadsAndPinnedTrailInRecencyOrder()
@@ -108,6 +110,17 @@ public class WidgetDisplayProvidersTests
 
         Assert.Equal(UsageCoordinator.MaxWidgetTiles, result.Count);
         Assert.Equal(ProviderId.Codex, result[0]);
+    }
+
+    [Fact]
+    public void ActivityWidgetLeavesRoomForActiveAndOnePinnedTile()
+    {
+        var result = Compute(
+            active: ProviderId.Codex,
+            pinned: new[] { ProviderId.Claude, ProviderId.Zai },
+            activityWidgetEnabled: true);
+
+        Assert.Equal(new[] { ProviderId.Codex, ProviderId.Claude }, result);
     }
 
     [Fact]

--- a/tests/TaskbarQuota.Tests/WidgetDisplayProvidersTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetDisplayProvidersTests.cs
@@ -16,7 +16,6 @@ public class WidgetDisplayProvidersTests
         IReadOnlyList<ProviderId> pinned,
         IReadOnlyList<ProviderId>? recent = null,
         bool present = true,
-        ProviderId? fallback = null,
         Func<ProviderId, bool>? isVisible = null,
         Func<ProviderId, bool>? isAvailable = null)
         => UsageCoordinator.ComputeWidgetDisplayProviders(
@@ -26,8 +25,7 @@ public class WidgetDisplayProvidersTests
             Enum.GetValues<ProviderId>(),
             p => pinned.Contains(p),
             isVisible ?? (_ => true),
-            isAvailable ?? (_ => true),
-            fallback);
+            isAvailable ?? (_ => true));
 
     [Fact]
     public void ActiveProviderLeadsAndPinnedTrailInRecencyOrder()
@@ -64,14 +62,14 @@ public class WidgetDisplayProvidersTests
     }
 
     [Fact]
-    public void WithoutPinsFallsBackToTheSingleDisplayProvider()
+    public void WithoutActiveProviderOrPins_IsEmptyEvenWhenAToolIsPresent()
     {
         var result = Compute(
             active: null,
             pinned: Array.Empty<ProviderId>(),
-            fallback: ProviderId.Codex);
+            present: true);
 
-        Assert.Equal(new[] { ProviderId.Codex }, result);
+        Assert.Empty(result);
     }
 
     [Fact]
@@ -118,8 +116,7 @@ public class WidgetDisplayProvidersTests
         var result = Compute(
             active: null,
             pinned: Array.Empty<ProviderId>(),
-            present: false,
-            fallback: ProviderId.Codex);
+            present: false);
 
         Assert.Empty(result);
     }


### PR DESCRIPTION
## Summary

- discover running Codex and Claude agent sessions from desktop/terminal processes and recent transcripts
- show the current task, step, completion progress, and status color alongside quota tiles
- add an agent-activity section to the flyout and a tray-menu shortcut
- group Codex parent/subagent threads and resolve persisted Codex thread names
- keep activity monitoring independent from foreground-provider detection

## Validation

- AgentActivityTests: 2 passed
- full suite: 488 passed; one existing parallel WidgetSettingsService/Z.ai test failed and passed when run alone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local monitoring for active desktop and terminal-based coding agents across multiple providers.
  * Added taskbar widgets and flyout activity summaries with provider, status, progress, navigation, acknowledgement, and unread indicators.
  * Added configurable monitoring and widget display settings.
  * Improved widget placement, sizing, dragging, activity visibility, and provider-switch stability.

* **Documentation**
  * Documented supported activity sources, retention, privacy, and controls.

* **Tests**
  * Added coverage for activity parsing, lifecycle states, prioritization, and widget placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->