### PR TITLE
Fix OpenCode Zen and Go usage fetching

### DIFF
--- a/src/TaskbarQuota.App/Usage/CredentialStore.cs
+++ b/src/TaskbarQuota.App/Usage/CredentialStore.cs
@@ -25,6 +25,7 @@ namespace TaskbarQuota.Usage
         {
             public string? ApiKey { get; set; }
             public string? CookieHeader { get; set; }
+            public string? WorkspaceId { get; set; }
             public string? Extra { get; set; } // provider-specific (e.g. MiniMax group id)
         }
 
@@ -66,6 +67,12 @@ namespace TaskbarQuota.Usage
         {
             var v = For(id).CookieHeader;
             return string.IsNullOrWhiteSpace(v) ? null : v!.Trim();
+        }
+
+        public string? WorkspaceId(ProviderId id)
+        {
+            var value = For(id).WorkspaceId;
+            return string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
         }
 
         public void Save()

--- a/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
@@ -120,14 +120,26 @@ namespace TaskbarQuota.Usage.Providers
 
         internal static async Task<string> FetchWorkspaceId(string cookie, CancellationToken ct, string providerName)
         {
-            var text = await GetText($"{ServerUrl}?id={WorkspacesServerId}", WorkspacesServerId,
-                "https://opencode.ai", cookie, ct).ConfigureAwait(false);
-            var ids = ParseWorkspaceIds(text);
-            if (ids.Count > 0) return ids[0];
+            try
+            {
+                var getText = await GetText($"{ServerUrl}?id={WorkspacesServerId}", WorkspacesServerId,
+                    "https://opencode.ai", cookie, ct).ConfigureAwait(false);
+                var getIds = ParseWorkspaceIds(getText);
+                if (getIds.Count > 0) return getIds[0];
+            }
+            catch (ProviderException ex) when (ex.Kind != ProviderErrorKind.AuthRequired)
+            {
+                // Solid server functions can reject GET after a deployment changes their transport.
+                // Preserve auth errors, but let API/status failures use the POST form below.
+            }
+            catch (HttpRequestException)
+            {
+                // A connection-level GET failure may still succeed through the POST route.
+            }
 
-            text = await GetText(ServerUrl, WorkspacesServerId, "https://opencode.ai", cookie, ct,
+            var text = await GetText(ServerUrl, WorkspacesServerId, "https://opencode.ai", cookie, ct,
                 HttpMethod.Post, "[]").ConfigureAwait(false);
-            ids = ParseWorkspaceIds(text);
+            var ids = ParseWorkspaceIds(text);
             if (ids.Count > 0) return ids[0];
             throw new ProviderException(ProviderErrorKind.Parse, $"{providerName}: no workspace id found.");
         }

--- a/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
@@ -247,7 +247,13 @@ namespace TaskbarQuota.Usage.Providers
         internal static bool LooksSignedOut(string text)
         {
             var lower = text.ToLowerInvariant();
-            return lower.Contains("auth/authorize") || lower.Contains("\"signin\"") || lower.Contains("please sign in") || lower.Contains("sign in");
+            return lower.Contains("auth/authorize")
+                || lower.Contains("\"signin\"")
+                || lower.Contains("please sign in")
+                || lower.Contains("sign in")
+                || lower.Contains("openauth")
+                || lower.Contains("continue with github")
+                || lower.Contains("continue with google");
         }
 
         internal static double? FindMoneyValue(string text, params string[] keys)
@@ -459,7 +465,7 @@ namespace TaskbarQuota.Usage.Providers
 
         public ProviderId Id => ProviderId.OpenCodeGo;
         public string DisplayName => "OpenCode Go";
-        public string SessionLabel => "Session";
+        public string SessionLabel => "Rolling";
         public string WeeklyLabel => "Weekly";
         public BillingKind Billing => BillingKind.Subscription;
 

--- a/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -35,7 +37,7 @@ namespace TaskbarQuota.Usage.Providers
     {
         private const string ServerUrl = "https://opencode.ai/_server";
         private const string WorkspacesServerId = "def39973159c7f0483d8793a822b8dbb10d067e12c65455fcb4608459ba0234f";
-        private const string SubscriptionServerId = "7abeebee372f304e050aaaf92be863f4a86490e382f8c79db68fd94040d691b4";
+        private const string BillingServerId = "c83b78a614689c38ebee981f9b39a8b377716db85c1fd7dbab604adc02d3313d";
         private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(30) };
         private static readonly Regex WorkspaceRe = new(@"wrk_[A-Za-z0-9_-]+", RegexOptions.Compiled);
 
@@ -55,12 +57,10 @@ namespace TaskbarQuota.Usage.Providers
         {
             var cookie = CookieHelper.Resolve(Id, "opencode.ai");
 
-            string wsText = await GetText($"{ServerUrl}?id={WorkspacesServerId}", WorkspacesServerId, "https://opencode.ai", cookie, ct).ConfigureAwait(false);
-            var ws = WorkspaceRe.Match(wsText);
-            if (!ws.Success) throw new ProviderException(ProviderErrorKind.Parse, "OpenCode: no workspace id found.");
-            string workspaceId = ws.Value;
+            string workspaceId = NormalizeWorkspaceId(CredentialStore.Instance.WorkspaceId(Id))
+                ?? await FetchWorkspaceId(cookie, ct, "OpenCode").ConfigureAwait(false);
 
-            var texts = new List<string> { wsText };
+            var texts = new List<string>();
             var pageTasks = new[]
             {
                 $"https://opencode.ai/workspace/{workspaceId}",
@@ -74,9 +74,14 @@ namespace TaskbarQuota.Usage.Providers
                 if (!string.IsNullOrEmpty(text))
                     texts.Add(text);
 
+            var billingText = await TryGetBillingText(workspaceId, cookie, ct).ConfigureAwait(false);
+            if (!string.IsNullOrEmpty(billingText))
+                texts.Add(billingText);
+
             var combined = string.Join("\n", texts);
             var monthlyUsage = FindMoneyValue(combined, "monthlyUsage", "monthly_usage", "currentUsage", "usage");
-            var balance = FindMoneyValue(combined, "balance", "currentBalance", "current_balance");
+            var balance = ParseBillingBalance(combined)
+                ?? FindMoneyValue(combined, "zenBalance", "currentBalance", "current_balance", "balance");
             var monthlyLimit = FindMoneyValue(combined, "monthlyLimit", "monthly_limit");
 
             if (monthlyUsage is null && balance is null)
@@ -97,9 +102,92 @@ namespace TaskbarQuota.Usage.Providers
             return new ProviderFetchResult(usage, "web");
         }
 
-        private static async Task<string> GetText(string url, string serverId, string referer, string cookie, CancellationToken ct)
+        internal static string? NormalizeWorkspaceId(string? raw)
         {
-            using var req = new HttpRequestMessage(HttpMethod.Get, url);
+            if (string.IsNullOrWhiteSpace(raw)) return null;
+            var match = WorkspaceRe.Match(raw.Trim());
+            return match.Success ? match.Value : null;
+        }
+
+        internal static IReadOnlyList<string> ParseWorkspaceIds(string text)
+        {
+            var results = new List<string>();
+            foreach (Match match in WorkspaceRe.Matches(text))
+                if (!results.Contains(match.Value, StringComparer.Ordinal))
+                    results.Add(match.Value);
+            return results;
+        }
+
+        internal static async Task<string> FetchWorkspaceId(string cookie, CancellationToken ct, string providerName)
+        {
+            var text = await GetText($"{ServerUrl}?id={WorkspacesServerId}", WorkspacesServerId,
+                "https://opencode.ai", cookie, ct).ConfigureAwait(false);
+            var ids = ParseWorkspaceIds(text);
+            if (ids.Count > 0) return ids[0];
+
+            text = await GetText(ServerUrl, WorkspacesServerId, "https://opencode.ai", cookie, ct,
+                HttpMethod.Post, "[]").ConfigureAwait(false);
+            ids = ParseWorkspaceIds(text);
+            if (ids.Count > 0) return ids[0];
+            throw new ProviderException(ProviderErrorKind.Parse, $"{providerName}: no workspace id found.");
+        }
+
+        private static async Task<string?> TryGetBillingText(string workspaceId, string cookie, CancellationToken ct)
+        {
+            try
+            {
+                var args = JsonSerializer.Serialize(new[] { workspaceId });
+                return await GetText($"{ServerUrl}?id={BillingServerId}&args={Uri.EscapeDataString(args)}",
+                    BillingServerId, WorkspacePageUrl(workspaceId), cookie, ct).ConfigureAwait(false);
+            }
+            catch { return null; }
+        }
+
+        internal static double? ParseBillingBalance(string text)
+        {
+            using var doc = TryJson(text);
+            if (doc != null && TryFindBillingBalance(doc.RootElement, out var raw))
+                return raw / 100_000_000d;
+
+            if (!Regex.IsMatch(text, "(?:\\\"customerID\\\"|customerID)\\s*:\\s*(?:\\$R\\[\\d+\\]\\s*=\\s*)?\\\"[^\\\"]+\\\""))
+                return null;
+            var match = Regex.Match(text, "(?:\\\"balance\\\"|balance)\\s*:\\s*(?:\\$R\\[\\d+\\]\\s*=\\s*)?(-?[0-9]+(?:\\.[0-9]+)?)");
+            return match.Success && double.TryParse(match.Groups[1].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out raw)
+                ? raw / 100_000_000d
+                : null;
+        }
+
+        private static bool TryFindBillingBalance(JsonElement element, out double balance)
+        {
+            if (element.ValueKind == JsonValueKind.Object)
+            {
+                if (element.TryGetProperty("customerID", out var customer) && customer.ValueKind == JsonValueKind.String
+                    && !string.IsNullOrEmpty(customer.GetString()) && element.TryGetProperty("balance", out var value)
+                    && TryJsonDouble(value, out balance))
+                    return true;
+                foreach (var property in element.EnumerateObject())
+                    if (TryFindBillingBalance(property.Value, out balance)) return true;
+            }
+            else if (element.ValueKind == JsonValueKind.Array)
+                foreach (var item in element.EnumerateArray())
+                    if (TryFindBillingBalance(item, out balance)) return true;
+            balance = 0;
+            return false;
+        }
+
+        private static bool TryJsonDouble(JsonElement value, out double result)
+        {
+            if (value.ValueKind == JsonValueKind.Number) return value.TryGetDouble(out result);
+            if (value.ValueKind == JsonValueKind.String)
+                return double.TryParse(value.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out result);
+            result = 0;
+            return false;
+        }
+
+        private static async Task<string> GetText(string url, string serverId, string referer, string cookie,
+            CancellationToken ct, HttpMethod? method = null, string? body = null)
+        {
+            using var req = new HttpRequestMessage(method ?? HttpMethod.Get, url);
             req.Headers.TryAddWithoutValidation("Cookie", cookie);
             req.Headers.TryAddWithoutValidation("X-Server-Id", serverId);
             req.Headers.TryAddWithoutValidation("X-Server-Instance", $"server-fn:{Guid.NewGuid()}");
@@ -107,6 +195,8 @@ namespace TaskbarQuota.Usage.Providers
             req.Headers.TryAddWithoutValidation("Origin", "https://opencode.ai");
             req.Headers.TryAddWithoutValidation("Referer", referer);
             req.Headers.TryAddWithoutValidation("Accept", "text/javascript, application/json;q=0.9, */*;q=0.8");
+            if (body != null)
+                req.Content = new StringContent(body, Encoding.UTF8, "application/json");
             using var resp = await Http.SendAsync(req, ct).ConfigureAwait(false);
             if (resp.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
                 throw new ProviderException(ProviderErrorKind.AuthRequired, "OpenCode cookies expired.");
@@ -349,11 +439,7 @@ namespace TaskbarQuota.Usage.Providers
     /// <summary>OpenCode Go subscription usage from the workspace /go page: rolling, weekly and monthly windows.</summary>
     public sealed class OpenCodeGoProvider : IUsageProvider
     {
-        private const string ServerUrl = "https://opencode.ai/_server";
-        private const string WorkspacesServerId = "def39973159c7f0483d8793a822b8dbb10d067e12c65455fcb4608459ba0234f";
-        private const string LiteSubscriptionServerId = "c7389bd0e731f80f49593e5ee53835475f4e28594dd6bd83eb229bab753498cd";
         private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(30) };
-        private static readonly Regex WorkspaceRe = new(@"wrk_[A-Za-z0-9_-]+", RegexOptions.Compiled);
 
         public ProviderId Id => ProviderId.OpenCodeGo;
         public string DisplayName => "OpenCode Go";
@@ -366,16 +452,14 @@ namespace TaskbarQuota.Usage.Providers
             var cookie = CredentialStore.Instance.ManualCookieHeader(Id)
                 ?? CredentialStore.Instance.ManualCookieHeader(ProviderId.OpenCode)
                 ?? CookieHelper.Resolve(Id, "opencode.ai");
-            string wsText = await GetText($"{ServerUrl}?id={WorkspacesServerId}", "https://opencode.ai", cookie, ct).ConfigureAwait(false);
-            var ws = WorkspaceRe.Match(wsText);
-            if (!ws.Success) throw new ProviderException(ProviderErrorKind.Parse, "OpenCode Go: no workspace id found.");
+            string workspaceId = OpenCodeProvider.NormalizeWorkspaceId(CredentialStore.Instance.WorkspaceId(Id))
+                ?? OpenCodeProvider.NormalizeWorkspaceId(CredentialStore.Instance.WorkspaceId(ProviderId.OpenCode))
+                ?? await OpenCodeProvider.FetchWorkspaceId(cookie, ct, "OpenCode Go").ConfigureAwait(false);
 
-            string usageText = await GetText(
-                $"{ServerUrl}?id={LiteSubscriptionServerId}&args={ServerStringArg(ws.Value)}",
-                $"https://opencode.ai/workspace/{ws.Value}/go",
+            string usageText = await GetPageText(
+                OpenCodeProvider.WorkspacePageUrl(workspaceId, "go"),
                 cookie,
-                ct,
-                LiteSubscriptionServerId).ConfigureAwait(false);
+                ct).ConfigureAwait(false);
             if (OpenCodeProvider.LooksSignedOut(usageText)) throw new ProviderException(ProviderErrorKind.AuthRequired, "OpenCode Go cookies expired.");
 
             var rolling = OpenCodeProvider.ExtractWindow(usageText, 300, "rollingUsage", "rolling_usage", "rolling")
@@ -388,43 +472,18 @@ namespace TaskbarQuota.Usage.Providers
                 Secondary = weekly,
                 Monthly = monthly,
                 LoginMethod = "Go",
-                UsageDashboardUrl = OpenCodeProvider.WorkspacePageUrl(ws.Value, "go"),
+                UsageDashboardUrl = OpenCodeProvider.WorkspacePageUrl(workspaceId, "go"),
             };
 
             return new ProviderFetchResult(usage, "opencode");
         }
 
-        private static string ServerStringArg(string value)
-        {
-            var payload = new
-            {
-                t = new
-                {
-                    t = 9,
-                    i = 0,
-                    l = 1,
-                    a = new[] { new { t = 1, s = value } },
-                    o = 0,
-                },
-                f = 31,
-                m = Array.Empty<object>(),
-            };
-            return Uri.EscapeDataString(JsonSerializer.Serialize(payload));
-        }
-
-        private static async Task<string> GetText(string url, string referer, string cookie, CancellationToken ct, string serverId = WorkspacesServerId)
+        private static async Task<string> GetPageText(string url, string cookie, CancellationToken ct)
         {
             using var req = new HttpRequestMessage(HttpMethod.Get, url);
             req.Headers.TryAddWithoutValidation("Cookie", cookie);
-            if (url.StartsWith(ServerUrl, StringComparison.OrdinalIgnoreCase))
-            {
-                req.Headers.TryAddWithoutValidation("X-Server-Id", serverId);
-                req.Headers.TryAddWithoutValidation("X-Server-Instance", $"server-fn:{Guid.NewGuid()}");
-            }
             req.Headers.TryAddWithoutValidation("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
-            req.Headers.TryAddWithoutValidation("Origin", "https://opencode.ai");
-            req.Headers.TryAddWithoutValidation("Referer", referer);
-            req.Headers.TryAddWithoutValidation("Accept", "text/javascript, application/json;q=0.9, */*;q=0.8");
+            req.Headers.TryAddWithoutValidation("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
             using var resp = await Http.SendAsync(req, ct).ConfigureAwait(false);
             var text = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             if (resp.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden || OpenCodeProvider.LooksSignedOut(text))

--- a/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -40,6 +41,9 @@ namespace TaskbarQuota.Usage.Providers
         private const string BillingServerId = "c83b78a614689c38ebee981f9b39a8b377716db85c1fd7dbab604adc02d3313d";
         private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(30) };
         private static readonly Regex WorkspaceRe = new(@"wrk_[A-Za-z0-9_-]+", RegexOptions.Compiled);
+        private static readonly object WorkspaceCacheGate = new();
+        private static readonly Dictionary<string, (string workspaceId, DateTimeOffset expiresAt)> WorkspaceCache = new(StringComparer.Ordinal);
+        private static readonly TimeSpan WorkspaceCacheTtl = TimeSpan.FromMinutes(5);
 
         internal static string WorkspacePageUrl(string workspaceId, string? segment = null)
         {
@@ -80,8 +84,11 @@ namespace TaskbarQuota.Usage.Providers
 
             var combined = string.Join("\n", texts);
             var monthlyUsage = FindMoneyValue(combined, "monthlyUsage", "monthly_usage", "currentUsage", "usage");
-            var balance = ParseBillingBalance(combined)
-                ?? FindMoneyValue(combined, "zenBalance", "currentBalance", "current_balance", "balance");
+            // Billing responses contain the customer ID and balance in the same object. Parse that
+            // response on its own so an unrelated customerID on a page cannot be paired with a
+            // balance from a different response.
+            var balance = !string.IsNullOrEmpty(billingText) ? ParseBillingBalance(billingText) : null;
+            balance ??= FindMoneyValue(combined, "zenBalance", "currentBalance", "current_balance", "balance");
             var monthlyLimit = FindMoneyValue(combined, "monthlyLimit", "monthly_limit");
 
             if (monthlyUsage is null && balance is null)
@@ -120,28 +127,53 @@ namespace TaskbarQuota.Usage.Providers
 
         internal static async Task<string> FetchWorkspaceId(string cookie, CancellationToken ct, string providerName)
         {
+            var cacheKey = WorkspaceCacheKey(providerName, cookie);
+            lock (WorkspaceCacheGate)
+            {
+                if (WorkspaceCache.TryGetValue(cacheKey, out var cached)
+                    && cached.expiresAt > DateTimeOffset.UtcNow)
+                    return cached.workspaceId;
+            }
+
             try
             {
                 var getText = await GetText($"{ServerUrl}?id={WorkspacesServerId}", WorkspacesServerId,
                     "https://opencode.ai", cookie, ct).ConfigureAwait(false);
                 var getIds = ParseWorkspaceIds(getText);
-                if (getIds.Count > 0) return getIds[0];
+                if (getIds.Count > 0)
+                    return CacheWorkspaceId(cacheKey, getIds[0]);
             }
-            catch (ProviderException ex) when (ex.Kind != ProviderErrorKind.AuthRequired)
+            catch (ProviderException ex) when (ex.Kind == ProviderErrorKind.Other)
             {
                 // Solid server functions can reject GET after a deployment changes their transport.
-                // Preserve auth errors, but let API/status failures use the POST form below.
+                // Only an undifferentiated server failure should fall back to POST; auth and rate
+                // limit responses must be surfaced to the caller.
             }
             catch (HttpRequestException)
             {
                 // A connection-level GET failure may still succeed through the POST route.
             }
+            catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+            {
+                // HttpClient.Timeout presents as TaskCanceledException; the POST route may still work.
+            }
 
             var text = await GetText(ServerUrl, WorkspacesServerId, "https://opencode.ai", cookie, ct,
                 HttpMethod.Post, "[]").ConfigureAwait(false);
             var ids = ParseWorkspaceIds(text);
-            if (ids.Count > 0) return ids[0];
+            if (ids.Count > 0)
+                return CacheWorkspaceId(cacheKey, ids[0]);
             throw new ProviderException(ProviderErrorKind.Parse, $"{providerName}: no workspace id found.");
+        }
+
+        private static string WorkspaceCacheKey(string providerName, string cookie)
+            => $"{providerName}:{Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(cookie)))}";
+
+        private static string CacheWorkspaceId(string cacheKey, string workspaceId)
+        {
+            lock (WorkspaceCacheGate)
+                WorkspaceCache[cacheKey] = (workspaceId, DateTimeOffset.UtcNow + WorkspaceCacheTtl);
+            return workspaceId;
         }
 
         private static async Task<string?> TryGetBillingText(string workspaceId, string cookie, CancellationToken ct)
@@ -152,7 +184,7 @@ namespace TaskbarQuota.Usage.Providers
                 return await GetText($"{ServerUrl}?id={BillingServerId}&args={Uri.EscapeDataString(args)}",
                     BillingServerId, WorkspacePageUrl(workspaceId), cookie, ct).ConfigureAwait(false);
             }
-            catch (ProviderException ex) when (ex.Kind == ProviderErrorKind.AuthRequired) { throw; }
+            catch (ProviderException ex) when (ex.Kind is ProviderErrorKind.AuthRequired or ProviderErrorKind.RateLimited) { throw; }
             catch (OperationCanceledException) { throw; }
             catch { return null; }
         }
@@ -212,11 +244,16 @@ namespace TaskbarQuota.Usage.Providers
             if (body != null)
                 req.Content = new StringContent(body, Encoding.UTF8, "application/json");
             using var resp = await Http.SendAsync(req, ct).ConfigureAwait(false);
+            var text = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            if (LooksSignedOut(text))
+                throw new ProviderException(ProviderErrorKind.AuthRequired, "OpenCode cookies expired.");
             if (resp.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
                 throw new ProviderException(ProviderErrorKind.AuthRequired, "OpenCode cookies expired.");
+            if (resp.StatusCode == HttpStatusCode.TooManyRequests)
+                throw new ProviderException(ProviderErrorKind.RateLimited, "OpenCode API rate limited.");
             if (!resp.IsSuccessStatusCode)
                 throw new ProviderException(ProviderErrorKind.Other, $"OpenCode API {(int)resp.StatusCode}");
-            return await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            return text;
         }
 
         private static async Task<string> GetPageText(string url, string referer, string cookie, CancellationToken ct)
@@ -231,6 +268,8 @@ namespace TaskbarQuota.Usage.Providers
             var text = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             if (resp.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden || LooksSignedOut(text))
                 throw new ProviderException(ProviderErrorKind.AuthRequired, "OpenCode cookies expired.");
+            if (resp.StatusCode == HttpStatusCode.TooManyRequests)
+                throw new ProviderException(ProviderErrorKind.RateLimited, "OpenCode API rate limited.");
             if (!resp.IsSuccessStatusCode)
                 throw new ProviderException(ProviderErrorKind.Other, $"OpenCode API {(int)resp.StatusCode}");
             return text;
@@ -239,7 +278,7 @@ namespace TaskbarQuota.Usage.Providers
         private static async Task<string?> TryGetPageText(string url, string referer, string cookie, CancellationToken ct)
         {
             try { return await GetPageText(url, referer, cookie, ct).ConfigureAwait(false); }
-            catch (ProviderException ex) when (ex.Kind == ProviderErrorKind.AuthRequired) { throw; }
+            catch (ProviderException ex) when (ex.Kind is ProviderErrorKind.AuthRequired or ProviderErrorKind.RateLimited) { throw; }
             catch (OperationCanceledException) { throw; }
             catch { return null; }
         }
@@ -510,6 +549,8 @@ namespace TaskbarQuota.Usage.Providers
             var text = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             if (resp.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden || OpenCodeProvider.LooksSignedOut(text))
                 throw new ProviderException(ProviderErrorKind.AuthRequired, "OpenCode Go cookies expired.");
+            if (resp.StatusCode == HttpStatusCode.TooManyRequests)
+                throw new ProviderException(ProviderErrorKind.RateLimited, "OpenCode Go API rate limited.");
             if (!resp.IsSuccessStatusCode)
                 throw new ProviderException(ProviderErrorKind.Other, $"OpenCode Go API {(int)resp.StatusCode}");
             return text;

--- a/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
@@ -152,6 +152,8 @@ namespace TaskbarQuota.Usage.Providers
                 return await GetText($"{ServerUrl}?id={BillingServerId}&args={Uri.EscapeDataString(args)}",
                     BillingServerId, WorkspacePageUrl(workspaceId), cookie, ct).ConfigureAwait(false);
             }
+            catch (ProviderException ex) when (ex.Kind == ProviderErrorKind.AuthRequired) { throw; }
+            catch (OperationCanceledException) { throw; }
             catch { return null; }
         }
 
@@ -237,6 +239,8 @@ namespace TaskbarQuota.Usage.Providers
         private static async Task<string?> TryGetPageText(string url, string referer, string cookie, CancellationToken ct)
         {
             try { return await GetPageText(url, referer, cookie, ct).ConfigureAwait(false); }
+            catch (ProviderException ex) when (ex.Kind == ProviderErrorKind.AuthRequired) { throw; }
+            catch (OperationCanceledException) { throw; }
             catch { return null; }
         }
 

--- a/src/TaskbarQuota.App/ViewModels/SettingsViewModel.cs
+++ b/src/TaskbarQuota.App/ViewModels/SettingsViewModel.cs
@@ -45,6 +45,8 @@ namespace TaskbarQuota.ViewModels
     {
         private readonly ProviderId _id;
 
+        public ProviderId Id => _id;
+
         public string Title { get; }
         public string Description { get; }
         public CredentialKind Kind { get; }
@@ -52,6 +54,7 @@ namespace TaskbarQuota.ViewModels
 
         [ObservableProperty] public partial string ApiKey { get; set; }
         [ObservableProperty] public partial string CookieHeader { get; set; }
+        [ObservableProperty] public partial string WorkspaceId { get; set; }
         [ObservableProperty] public partial bool Saved { get; set; }
 
         public bool IsApiKey => Kind == CredentialKind.ApiKey;
@@ -75,6 +78,7 @@ namespace TaskbarQuota.ViewModels
             var e = CredentialStore.Instance.For(id);
             ApiKey = e.ApiKey ?? "";
             CookieHeader = e.CookieHeader ?? "";
+            WorkspaceId = e.WorkspaceId ?? "";
         }
 
         [RelayCommand]
@@ -83,6 +87,7 @@ namespace TaskbarQuota.ViewModels
             var e = CredentialStore.Instance.For(_id);
             e.ApiKey = string.IsNullOrWhiteSpace(ApiKey) ? null : ApiKey.Trim();
             e.CookieHeader = string.IsNullOrWhiteSpace(CookieHeader) ? null : CookieHeader.Trim();
+            e.WorkspaceId = string.IsNullOrWhiteSpace(WorkspaceId) ? null : WorkspaceId.Trim();
             CredentialStore.Instance.Save();
             Saved = true;
         }

--- a/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
@@ -194,6 +194,21 @@ namespace TaskbarQuota.Views
                 stack.Children.Add(new TextBlock { Text = "Cookie header", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold });
                 stack.Children.Add(new TextBlock { Text = "Leave blank to keep auto-detection.", Opacity = 0.6, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
                 stack.Children.Add(tb);
+
+                if (vm.Id is ProviderId.OpenCode or ProviderId.OpenCodeGo)
+                {
+                    var workspace = new TextBox
+                    {
+                        Text = vm.WorkspaceId,
+                        MinWidth = 280,
+                        PlaceholderText = "wrk_... or workspace URL",
+                        AcceptsReturn = false,
+                    };
+                    workspace.TextChanged += (_, _) => vm.WorkspaceId = workspace.Text;
+                    stack.Children.Add(new TextBlock { Text = "Workspace ID (optional)", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold });
+                    stack.Children.Add(new TextBlock { Text = "Overrides workspace auto-detection.", Opacity = 0.6, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
+                    stack.Children.Add(workspace);
+                }
             }
 
             var saveBtn = new Button { Content = "Save & Refresh", Style = (Style)Application.Current.Resources["AccentButtonStyle"], Margin = new Thickness(0, 4, 0, 0) };
@@ -311,10 +326,10 @@ namespace TaskbarQuota.Views
                 "Paste a cursor.com Cookie header to override browser detection.",
                 CredentialKind.Cookie),
             ProviderId.OpenCode => new ProviderCredentialViewModel(id, "OpenCode",
-                "Paste an opencode.ai Cookie header to override browser detection.",
+                "Paste an opencode.ai Cookie header and optionally select a workspace.",
                 CredentialKind.Cookie),
             ProviderId.OpenCodeGo => new ProviderCredentialViewModel(id, "OpenCode Go",
-                "Paste an opencode.ai Cookie header to override browser detection.",
+                "Paste an opencode.ai Cookie header and optionally select a workspace.",
                 CredentialKind.Cookie),
             ProviderId.Kimi => new ProviderCredentialViewModel(id, "Kimi Code",
                 "Paste your Kimi Code API key (KIMI_CODE_API_KEY) to fetch Coding Plan usage without CLI login.",

--- a/tests/TaskbarQuota.Tests/OpenCodeGoProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/OpenCodeGoProviderTests.cs
@@ -129,4 +129,16 @@ public class OpenCodeGoProviderTests
         var html = "<html><head><meta http-equiv=\"refresh\" content=\"0;url=/auth/authorize?redirect=/workspace/wrk_123/go\"></head></html>";
         Assert.True(OpenCodeProvider.LooksSignedOut(html));
     }
+
+    [Fact]
+    public void GoPagePayload_ParsesCurrentCodexBarStyleEmbeddedUsage()
+    {
+        var html = "<script>window.__data={rollingUsage:{usagePercent:37.5,resetInSec:7200}," +
+                   "weeklyUsage:{usagePercent:51,resetInSec:172800}," +
+                   "monthlyUsage:{usagePercent:12,resetInSec:1209600}}</script>";
+
+        Assert.Equal(37.5, OpenCodeProvider.ExtractWindow(html, 300, "rollingUsage")!.UsedPercent, 1);
+        Assert.Equal(51, OpenCodeProvider.ExtractWindow(html, 10080, "weeklyUsage")!.UsedPercent, 1);
+        Assert.Equal(12, OpenCodeProvider.ExtractWindow(html, 43200, "monthlyUsage")!.UsedPercent, 1);
+    }
 }

--- a/tests/TaskbarQuota.Tests/OpenCodeGoProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/OpenCodeGoProviderTests.cs
@@ -21,10 +21,10 @@ public class OpenCodeGoProviderTests
     }
 
     [Fact]
-    public void Provider_HasCorrectSessionLabel()
+    public void Provider_HasCorrectRollingLabel()
     {
         var provider = new OpenCodeGoProvider();
-        Assert.Equal("Session", provider.SessionLabel);
+        Assert.Equal("Rolling", provider.SessionLabel);
     }
 
     [Fact]
@@ -129,6 +129,13 @@ public class OpenCodeGoProviderTests
         var html = "<html><head><meta http-equiv=\"refresh\" content=\"0;url=/auth/authorize?redirect=/workspace/wrk_123/go\"></head></html>";
         Assert.True(OpenCodeProvider.LooksSignedOut(html));
     }
+
+    [Theory]
+    [InlineData("<title>OpenAuth</title>")]
+    [InlineData("<button>Continue with GitHub</button>")]
+    [InlineData("<button>Continue with Google</button>")]
+    public void LooksSignedOut_WithOpenAuthPage_ReturnsTrue(string html)
+        => Assert.True(OpenCodeProvider.LooksSignedOut(html));
 
     [Fact]
     public void GoPagePayload_ParsesCurrentCodexBarStyleEmbeddedUsage()

--- a/tests/TaskbarQuota.Tests/OpenCodeProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/OpenCodeProviderTests.cs
@@ -41,6 +41,40 @@ public class OpenCodeProviderTests
             OpenCodeProvider.WorkspacePageUrl("wrk_abc123", "/usage"));
     }
 
+    [Theory]
+    [InlineData("wrk_abc123", "wrk_abc123")]
+    [InlineData("https://opencode.ai/workspace/wrk_abc123/go", "wrk_abc123")]
+    [InlineData("  wrk_team-123  ", "wrk_team-123")]
+    [InlineData("not-a-workspace", null)]
+    public void NormalizeWorkspaceId_AcceptsIdsAndWorkspaceUrls(string input, string? expected)
+        => Assert.Equal(expected, OpenCodeProvider.NormalizeWorkspaceId(input));
+
+    [Fact]
+    public void ParseWorkspaceIds_DeduplicatesStructuredAndJsonOccurrences()
+    {
+        var ids = OpenCodeProvider.ParseWorkspaceIds(
+            "id: \"wrk_first\", data: { workspace: \"wrk_second\", again: \"wrk_first\" }");
+
+        Assert.Equal(new[] { "wrk_first", "wrk_second" }, ids);
+    }
+
+    [Fact]
+    public void ParseBillingBalance_ConvertsRawBillingUnitsToUsd()
+    {
+        var balance = OpenCodeProvider.ParseBillingBalance(
+            "{\"customerID\":\"cus_123\",\"balance\":4250000000}");
+
+        Assert.Equal(42.5, balance);
+    }
+
+    [Fact]
+    public void ParseBillingBalance_IgnoresUnscopedBalanceFields()
+    {
+        var balance = OpenCodeProvider.ParseBillingBalance("{\"balance\":4250000000}");
+
+        Assert.Null(balance);
+    }
+
     [Fact]
     public void LooksSignedOut_WithNormalContent_ReturnsFalse()
     {


### PR DESCRIPTION
## Summary
- replace the obsolete OpenCode Go server-function request with the current workspace /go page flow
- add resilient OpenCode workspace discovery with GET-to-POST fallback and manual workspace ID/URL overrides
- fetch Zen balance from OpenCode's authoritative billing server response while preserving Usage and Balance presentation
- add parser and workspace normalization coverage

Fixes #43

## Testing
- dotnet test tests/TaskbarQuota.Tests/TaskbarQuota.Tests.csproj --no-restore (495 passed)
- focused OpenCode provider suite (52 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional workspace ID configuration for OpenCode and OpenCode Go credentials.
  * Added workspace selection and discovery for more accurate usage tracking.
  * Added OpenCode Zen balance reporting, including support for multiple billing formats.

* **Bug Fixes**
  * Improved parsing of OpenCode Go usage limits across rolling, weekly, and monthly periods.
  * Improved workspace ID normalization and handling of duplicate or unscoped billing data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->