### PR TITLE
fix: stop OpenCode state writes from flickering widget

### DIFF
--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -30,6 +30,7 @@ namespace TaskbarQuota
         // fetch for one that is still running — a slow or offline endpoint would otherwise accumulate
         // concurrent requests and could publish an older snapshot out of order.
         private readonly HashSet<ProviderId> _widgetRefreshInFlight = new();
+        private readonly object _openCodeModelStateLock = new();
         private Timer? _timer;
         // Synara persists provider switches through a 300 ms-debounced localStorage writer, and Chromium
         // then flushes that to its on-disk LevelDB on its own (variable, sometimes >1 s) cadence. The
@@ -67,6 +68,8 @@ namespace TaskbarQuota
         private bool? _lastHasDetectedTool;
         private DateTime _lastPresenceProbeAt = DateTime.MinValue;
         private ProviderSource _activeProviderSource = ProviderSource.Unknown;
+        private ProviderId? _lastObservedOpenCodeProvider;
+        private bool _hasObservedOpenCodeProvider;
 
         public UsageService Service => _service;
         public ProviderId? ActiveProvider => _lastActive;
@@ -481,13 +484,20 @@ namespace TaskbarQuota
 
             if (!ShouldReactToOpenCodeModelChange(foreground))
             {
-                if (modelProvider is ProviderId backgroundProvider)
+                if (modelProvider is ProviderId backgroundProvider
+                    && ShouldRefreshOpenCodeProvider(backgroundProvider))
                     await RefreshProviderCacheSilentlyAsync(backgroundProvider).ConfigureAwait(false);
                 return;
             }
 
             var target = modelProvider ?? foreground!.Value;
             if (!IsOpenCodeProvider(target))
+                return;
+
+            // OpenCode rewrites its model/state files while the user types. The file event only matters
+            // when it changes the quota surface (Zen vs Go); republishing the same provider forces a
+            // network fetch and restarts the taskbar widget's refresh animation on every keystroke.
+            if (!ShouldRefreshOpenCodeProvider(target))
                 return;
 
             await _gate.WaitAsync().ConfigureAwait(false);
@@ -560,6 +570,25 @@ namespace TaskbarQuota
 
         internal static bool IsOpenCodeProvider(ProviderId provider)
             => provider is ProviderId.OpenCode or ProviderId.OpenCodeGo;
+
+        internal bool ShouldRefreshOpenCodeProvider(ProviderId provider)
+        {
+            lock (_openCodeModelStateLock)
+            {
+                if (!ShouldRefreshOpenCodeProvider(_lastObservedOpenCodeProvider, _hasObservedOpenCodeProvider, provider))
+                    return false;
+
+                _hasObservedOpenCodeProvider = true;
+                _lastObservedOpenCodeProvider = provider;
+                return true;
+            }
+        }
+
+        internal static bool ShouldRefreshOpenCodeProvider(
+            ProviderId? lastObservedProvider,
+            bool hasObservedProvider,
+            ProviderId provider)
+            => !hasObservedProvider || lastObservedProvider != provider;
 
         private void OnClineProviderStateChanged() => _ = HandleClineProviderSwitchAsync();
 

--- a/tests/TaskbarQuota.Tests/UsageCoordinatorOrderingTests.cs
+++ b/tests/TaskbarQuota.Tests/UsageCoordinatorOrderingTests.cs
@@ -60,6 +60,14 @@ public class UsageCoordinatorOrderingTests
     public void ShouldReactToOpenCodeModelChange_ReturnsFalseWhenNothingDetected()
         => Assert.False(UsageCoordinator.ShouldReactToOpenCodeModelChange(null));
 
+    [Fact]
+    public void ShouldRefreshOpenCodeProvider_DeduplicatesRepeatedStateWrites()
+    {
+        Assert.True(UsageCoordinator.ShouldRefreshOpenCodeProvider(null, false, ProviderId.OpenCode));
+        Assert.False(UsageCoordinator.ShouldRefreshOpenCodeProvider(ProviderId.OpenCode, true, ProviderId.OpenCode));
+        Assert.True(UsageCoordinator.ShouldRefreshOpenCodeProvider(ProviderId.OpenCode, true, ProviderId.OpenCodeGo));
+    }
+
     private static IReadOnlyList<UsageResult> Results(params ProviderId[] ids)
         => ids.Select(id => UsageResult.Pending(id, new TestProvider(id), "Loading")).ToArray();
 


### PR DESCRIPTION
Fixes #45

## What changed
- Deduplicate OpenCode model-state refreshes when repeated file writes resolve to the same quota surface.
- Preserve immediate refreshes when switching between OpenCode Zen and OpenCode Go.
- Apply the same deduplication to background refreshes.
- Add regression coverage for repeated writes and Zen/Go transitions.

## Root cause
OpenCode rewrites its model/state files while typing. Each debounced watcher event previously forced a usage fetch and published StateChanged, restarting the taskbar widget refresh animation even when the provider had not changed.

This is intentionally separate from #44: #44 changes OpenCode fetching, while this fixes the independent refresh/repaint behavior.

## Validation
- dotnet test tests/TaskbarQuota.Tests/TaskbarQuota.Tests.csproj --no-restore
- 488 tests passed