### PR TITLE
Fix missing XBF files in unpackaged publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,29 +104,16 @@ jobs:
               throw "Publish output not found for $($target.Arch)."
             }
 
-            $priPath = Join-Path $publishDirRel 'TaskbarQuota.pri'
-            if (-not (Test-Path $priPath)) {
-              throw "Publish output is missing TaskbarQuota.pri (WinUI XAML resources). Installer would crash on launch."
+            $priPath = @('TaskbarQuota.pri', 'resources.pri') |
+              ForEach-Object { Join-Path $publishDirRel $_ } |
+              Where-Object { Test-Path $_ } |
+              Select-Object -First 1
+            if (-not $priPath) {
+              throw "Publish output is missing the WinUI PRI resource file. Installer would crash on launch."
             }
 
             $publishDir = (Resolve-Path -LiteralPath $publishDirRel).Path
-            $binDir = (Resolve-Path -LiteralPath "src/TaskbarQuota.App/bin/$($target.Platform)/Release/net10.0-windows10.0.19041.0/$($target.Rid)").Path
-
-            # dotnet publish often omits loose .xbf even with DisableEmbeddedXbf; copy from build output.
-            $xbfFiles = Get-ChildItem -Path $binDir -Filter '*.xbf' -Recurse -File
-            if ($xbfFiles.Count -eq 0) {
-              throw "No .xbf files in $binDir — WinUI markup did not compile."
-            }
-
-            foreach ($xbf in $xbfFiles) {
-              $relative = $xbf.FullName.Substring($binDir.Length).TrimStart('\', '/')
-              $dest = Join-Path $publishDir $relative
-              $destDir = Split-Path $dest -Parent
-              if ($destDir -and -not (Test-Path $destDir)) {
-                New-Item -ItemType Directory -Path $destDir -Force | Out-Null
-              }
-              Copy-Item -LiteralPath $xbf.FullName -Destination $dest -Force
-            }
+            # The project copies loose .xbf files into the publish directory after publishing.
 
             $requiredXbf = @(
               'MainWindow.xbf',
@@ -140,7 +127,7 @@ jobs:
               }
             }
 
-            Write-Host "Copied $($xbfFiles.Count) .xbf file(s) into publish directory."
+            Write-Host "Verified loose XBF files in publish directory."
             $outputDir = (Resolve-Path -LiteralPath artifacts).Path
 
             Write-Host "Publish directory: $publishDir"

--- a/src/TaskbarQuota.App/TaskbarQuota.App.csproj
+++ b/src/TaskbarQuota.App/TaskbarQuota.App.csproj
@@ -71,10 +71,24 @@
     <InternalsVisibleTo Include="TaskbarQuota.Tests" />
   </ItemGroup>
 
-  <Target Name="AddLooseXbfToPublish" Condition="'$(WindowsPackageType)' == 'None'" AfterTargets="AssignTargetPaths" BeforeTargets="GetCopyToPublishDirectoryItems">
+  <!--
+    The XAML compiler emits loose .xbf files as part of the build. They are not
+    represented by project items, so collecting them during AssignTargetPaths
+    happens before the files exist in a clean dotnet publish. Copy them after
+    Publish has built the app and produced the final publish directory.
+  -->
+  <Target Name="AddLooseXbfToPublish"
+          Condition="'$(WindowsPackageType)' == 'None' and '$(PublishDir)' != ''"
+          AfterTargets="Publish">
     <ItemGroup>
-      <_LooseXbf Include="$(OutputPath)**\*.xbf" />
-      <Content Include="@(_LooseXbf)" CopyToPublishDirectory="PreserveNewest" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+      <_LooseXbf Include="$(TargetDir)**\*.xbf"
+                 Exclude="$(TargetDir)publish\**\*.xbf;$(PublishDir)**\*.xbf" />
     </ItemGroup>
+
+    <Error Condition="'@(_LooseXbf)' == ''"
+           Text="No loose XBF files were generated in '$(TargetDir)'. Unpackaged WinUI publish cannot start without them." />
+    <Copy SourceFiles="@(_LooseXbf)"
+          DestinationFiles="@(_LooseXbf->'$(PublishDir)%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary
- copy loose WinUI .xbf files after dotnet publish from the resolved build output
- preserve nested XBF paths and fail clearly when XBF generation is missing
- remove the CI-side manual copy workaround and validate the publish output directly
- accept both supported PRI resource filenames in the release check

## Validation
- clean x64 publish produced all 8 .xbf files and TaskbarQuota.exe
- incremental publish produced no nested publish\\publish artifacts
- 486 tests passed when excluding the unrelated existing Zai widget-row failure

Discovered while testing PR #44.

Fixes #47