### PR TITLE
fix: stop browser cookie temp file flooding

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ TaskBarManager → WidgetSummary (taskbar) + Dashboard + Flyout
 ```
 
 1. **Detection** — `ActiveAppDetector` maps the foreground process (or CLI child of a known terminal) to a `ProviderId`.
-2. **Fetch** — the matching `IUsageProvider` loads tokens from CLI config files, environment variables, TaskbarQuota credentials, Cursor's local database, or `CookieExtractor` (Chromium / Firefox profiles, copied to `%TEMP%` for locked DBs).
+2. **Fetch** — the matching `IUsageProvider` loads tokens from CLI config files, environment variables, TaskbarQuota credentials, Cursor's local database, or `CookieExtractor` (Chromium / Firefox profiles, opened directly with a read-only SQLite connection).
 3. **Normalize** — results become a `UsageSnapshot` with `RateWindow` rows and optional `CostSnapshot`.
 4. **Display** — `UsageCoordinator` raises `StateChanged`; the taskbar widget and dashboard apply the snapshot. Fetches are cached so providers are not hammered on every tick.
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,20 @@ This is the core behavior — everything else (widget, flyout, fetch cache) hang
 
 Each provider card on the dashboard shows plan name, reset times, rate windows, and optional cost or balance when the API returns it. Use **Fix** on a card when auto-detection fails to paste tokens or cookie headers into `%LOCALAPPDATA%\TaskbarQuota\credentials.json`.
 
+### OpenCode browser-cookie fallback (Windows)
+
+OpenCode automatic cookie detection reads each browser profile separately. It supports Firefox, Zen, Waterfox, LibreWolf, and Floorp, plus Chromium profiles whose cookies are still decryptable with the Windows user key (typically Chrome/Edge/Brave versions below 127). Profiles are never merged, so a stale readable Chrome session cannot overwrite a valid Gecko session.
+
+Chromium 127 and newer use App-Bound Encryption, which a normal desktop app cannot decrypt with the user DPAPI key. If OpenCode is signed in only there:
+
+1. Open `https://opencode.ai` and open Developer Tools (`F12`).
+2. Select **Network**, reload the page, and select an OpenCode request.
+3. Use **Copy → Copy as cURL**, then copy only the value after the request's `Cookie:` header.
+4. Open TaskbarQuota's **Fix** action for **OpenCode** or **OpenCode Go** and paste that value into **Cookie header**.
+5. If workspace detection also fails, paste the `wrk_...` value from the OpenCode URL (or the full workspace URL) into **Workspace ID**.
+
+Cookie headers are session credentials. Keep them private and do not paste them into issues or chat. The saved manual value is stored locally in `%LOCALAPPDATA%\TaskbarQuota\credentials.json`.
+
 ### Dashboard & shell
 
 - **Full dashboard** — all registered providers at once with refresh, error states, and detail cards.

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ Chromium 127 and newer use App-Bound Encryption, which a normal desktop app cann
 
 1. Open `https://opencode.ai` and open Developer Tools (`F12`).
 2. Select **Network**, reload the page, and select an OpenCode request.
-3. Use **Copy → Copy as cURL**, then copy only the value after the request's `Cookie:` header.
-4. Open TaskbarQuota's **Fix** action for **OpenCode** or **OpenCode Go** and paste that value into **Cookie header**.
+3. Use **Copy → Copy as cURL**. You may paste the full cURL command, or only the value after the request's `Cookie:` header; TaskbarQuota extracts the cookie automatically.
+4. Open TaskbarQuota's **Fix** action for **OpenCode** or **OpenCode Go** and paste it into **Cookie header**.
 5. If workspace detection also fails, paste the `wrk_...` value from the OpenCode URL (or the full workspace URL) into **Workspace ID**.
 
 Cookie headers are session credentials. Keep them private and do not paste them into issues or chat. The saved manual value is stored locally in `%LOCALAPPDATA%\TaskbarQuota\credentials.json`.

--- a/src/TaskbarQuota.App/Browser/CookieExtractor.cs
+++ b/src/TaskbarQuota.App/Browser/CookieExtractor.cs
@@ -27,6 +27,19 @@ namespace TaskbarQuota.Browser
         private sealed record Browser(string Name, string UserDataDir);
         private sealed record FirefoxBrowser(string Name, string ProfilesDir);
 
+        /// <summary>
+        /// Cookies collected from one browser profile. Keeping profiles separate is important:
+        /// combining cookies from different browsers can create a request made from a stale or
+        /// mixed session when one Chromium profile cannot be decrypted.
+        /// </summary>
+        internal sealed record CookieSource(
+            string BrowserName,
+            string ProfileName,
+            IReadOnlyList<(string Name, string Value)> Cookies)
+        {
+            public string Header => string.Join("; ", Cookies.Select(cookie => $"{cookie.Name}={cookie.Value}"));
+        }
+
         private static IEnumerable<Browser> ChromiumBrowsers()
         {
             string local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
@@ -83,6 +96,97 @@ namespace TaskbarQuota.Browser
 
             if (jar.Count == 0) return null;
             return string.Join("; ", jar.Select(kv => $"{kv.Key}={kv.Value}"));
+        }
+
+        /// <summary>
+        /// Returns cookie jars separately for each browser profile. Unlike <see cref="GetCookieHeader"/>,
+        /// this method never combines cookies from different profiles and preserves Firefox cookie
+        /// chunks. OpenCode uses it to choose a complete, decryptable session instead of accepting
+        /// a hybrid made from stale and current browser cookies.
+        /// </summary>
+        internal static IReadOnlyList<CookieSource> GetCookieSources(params string[] domains)
+        {
+            var requestedDomains = domains
+                .Where(domain => !string.IsNullOrWhiteSpace(domain))
+                .Select(domain => domain.Trim().TrimStart('.'))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (requestedDomains.Length == 0)
+                return Array.Empty<CookieSource>();
+
+            var sources = new List<CookieSource>();
+
+            foreach (var browser in ChromiumBrowsers())
+            {
+                if (!Directory.Exists(browser.UserDataDir)) continue;
+
+                byte[] key;
+                try { key = GetEncryptionKey(Path.Combine(browser.UserDataDir, "Local State")); }
+                catch (Exception ex)
+                {
+                    Log.Debug($"{browser.Name} key error: {ex.Message}");
+                    continue;
+                }
+
+                try
+                {
+                    foreach (var profile in EnumerateChromiumProfiles(browser.UserDataDir)
+                        .Distinct(StringComparer.OrdinalIgnoreCase))
+                    {
+                        var cookiesDb = FindChromiumCookiesDb(profile);
+                        if (cookiesDb == null) continue;
+
+                        var jar = new Dictionary<string, string>(StringComparer.Ordinal);
+                        foreach (var domain in requestedDomains)
+                        {
+                            foreach (var (name, value) in ReadChromiumCookies(cookiesDb, key, domain))
+                                jar[name] = value;
+                        }
+
+                        if (jar.Count > 0)
+                        {
+                            sources.Add(new CookieSource(
+                                browser.Name,
+                                Path.GetFileName(profile),
+                                jar.Select(cookie => (cookie.Key, cookie.Value)).ToList()));
+                        }
+                    }
+                }
+                catch (Exception ex) { Log.Debug($"Cookie source scan failed for {browser.Name}: {ex.Message}"); }
+            }
+
+            foreach (var browser in FirefoxBrowsers())
+            {
+                if (!Directory.Exists(browser.ProfilesDir)) continue;
+
+                try
+                {
+                    foreach (var profile in EnumerateFirefoxProfiles(browser.ProfilesDir)
+                        .Distinct(StringComparer.OrdinalIgnoreCase))
+                    {
+                        var cookiesDb = Path.Combine(profile, "cookies.sqlite");
+                        if (!File.Exists(cookiesDb)) continue;
+
+                        var cookies = new Dictionary<string, string>(StringComparer.Ordinal);
+                        foreach (var domain in requestedDomains)
+                        {
+                            foreach (var (name, value) in ReadFirefoxCookiesRaw(cookiesDb, domain))
+                                cookies[name] = value;
+                        }
+
+                        if (cookies.Count > 0)
+                        {
+                            sources.Add(new CookieSource(
+                                browser.Name,
+                                Path.GetFileName(profile),
+                                cookies.Select(cookie => (cookie.Key, cookie.Value)).ToList()));
+                        }
+                    }
+                }
+                catch (Exception ex) { Log.Debug($"Cookie source scan failed for {browser.Name}: {ex.Message}"); }
+            }
+
+            return sources;
         }
 
         /// <summary>
@@ -144,6 +248,15 @@ namespace TaskbarQuota.Browser
                 foreach (var c in ReadChromiumCookies(cookiesDb, key, domain))
                     yield return c;
             }
+        }
+
+        private static string? FindChromiumCookiesDb(string profile)
+        {
+            var networkCookies = Path.Combine(profile, "Network", "Cookies");
+            if (File.Exists(networkCookies)) return networkCookies;
+
+            var legacyCookies = Path.Combine(profile, "Cookies");
+            return File.Exists(legacyCookies) ? legacyCookies : null;
         }
 
         private static IEnumerable<(string name, string value)> ExtractFromFirefox(FirefoxBrowser browser, string domain)
@@ -337,6 +450,10 @@ namespace TaskbarQuota.Browser
                 }
                 catch { return null; } // ABE / wrong key
             }
+            // Chromium's newer app-bound formats (for example v20) require browser-process
+            // mediation and must not be mistaken for the legacy DPAPI format below.
+            if (enc.Length >= 3 && enc[0] == 'v' && enc[1] == '1' && enc[2] != '0' && enc[2] != '1')
+                return null;
             // Legacy DPAPI-encrypted value (pre-v10)
             try { return Encoding.UTF8.GetString(ProtectedData.Unprotect(enc, null, DataProtectionScope.CurrentUser)); }
             catch { return null; }

--- a/src/TaskbarQuota.App/Browser/CookieExtractor.cs
+++ b/src/TaskbarQuota.App/Browser/CookieExtractor.cs
@@ -306,57 +306,90 @@ namespace TaskbarQuota.Browser
         private static List<(string name, string value)> ReadChromiumCookies(string cookiesDb, byte[] key, string domain)
         {
             var results = new List<(string, string)>();
-            try
+            for (int attempt = 0; attempt < 2; attempt++)
             {
-                // Read the live browser database without copying it to %TEMP%; the copy operation
-                // created TaskbarQuota_* SQLite/journal files and could race the browser's writes.
-                using var conn = OpenReadOnlyConnection(cookiesDb);
-                conn.Open();
-                using var cmd = conn.CreateCommand();
-                cmd.CommandText =
-                    "SELECT name, encrypted_value, host_key FROM cookies " +
-                    "WHERE host_key = $exact OR host_key = $subdomain OR host_key LIKE $suffix";
-                cmd.Parameters.AddWithValue("$exact", domain);
-                cmd.Parameters.AddWithValue("$subdomain", "." + domain);
-                cmd.Parameters.AddWithValue("$suffix", "%." + domain);
-                using var reader = cmd.ExecuteReader();
-                while (reader.Read())
+                try
                 {
-                    string name = reader.GetString(0);
-                    byte[] enc = (byte[])reader[1];
-                    var val = DecryptCookie(enc, key);
-                    if (val != null) results.Add((name, val));
+                    // Read the live browser database without copying it to %TEMP%; the copy operation
+                    // created TaskbarQuota_* SQLite/journal files and could race the browser's writes.
+                    // SQLite permits a read-only connection while the browser owns the write connection.
+                    using var conn = OpenReadOnlyConnection(cookiesDb);
+                    conn.Open();
+                    using var cmd = conn.CreateCommand();
+                    cmd.CommandText =
+                        "SELECT name, encrypted_value, host_key FROM cookies " +
+                        "WHERE host_key = $exact OR host_key = $subdomain OR host_key LIKE $suffix";
+                    cmd.Parameters.AddWithValue("$exact", domain);
+                    cmd.Parameters.AddWithValue("$subdomain", "." + domain);
+                    cmd.Parameters.AddWithValue("$suffix", "%." + domain);
+                    using var reader = cmd.ExecuteReader();
+                    while (reader.Read())
+                    {
+                        string name = reader.GetString(0);
+                        byte[] enc = (byte[])reader[1];
+                        var val = DecryptCookie(enc, key);
+                        if (val != null) results.Add((name, val));
+                    }
+                    return results;
+                }
+                catch (Exception ex) when (attempt == 0 && IsTransientSqliteLock(ex))
+                {
+                    System.Threading.Thread.Sleep(50);
+                }
+                catch (Exception ex)
+                {
+                    Log.Debug($"chromium cookie db read failed: {ex.Message}");
+                    break;
                 }
             }
-            catch (Exception ex) { Log.Debug($"chromium cookie db read failed: {ex.Message}"); }
             return results;
         }
 
         private static List<(string name, string value)> ReadFirefoxCookiesRaw(string cookiesDb, string domain)
         {
             var raw = new List<(string name, string value)>();
-            try
+            for (int attempt = 0; attempt < 2; attempt++)
             {
-                using var conn = OpenReadOnlyConnection(cookiesDb);
-                conn.Open();
-                using var cmd = conn.CreateCommand();
-                cmd.CommandText =
-                    "SELECT name, value, host FROM moz_cookies " +
-                    "WHERE host = $exact OR host = $subdomain OR host LIKE $suffix";
-                cmd.Parameters.AddWithValue("$exact", domain);
-                cmd.Parameters.AddWithValue("$subdomain", "." + domain);
-                cmd.Parameters.AddWithValue("$suffix", "%." + domain);
-                using var reader = cmd.ExecuteReader();
-                while (reader.Read())
+                try
                 {
-                    string name = reader.GetString(0);
-                    string value = reader.IsDBNull(1) ? "" : reader.GetString(1);
-                    if (!string.IsNullOrEmpty(name))
-                        raw.Add((name, value));
+                    // Use the browser's database in read-only mode; never create a temp SQLite copy.
+                    using var conn = OpenReadOnlyConnection(cookiesDb);
+                    conn.Open();
+                    using var cmd = conn.CreateCommand();
+                    cmd.CommandText =
+                        "SELECT name, value, host FROM moz_cookies " +
+                        "WHERE host = $exact OR host = $subdomain OR host LIKE $suffix";
+                    cmd.Parameters.AddWithValue("$exact", domain);
+                    cmd.Parameters.AddWithValue("$subdomain", "." + domain);
+                    cmd.Parameters.AddWithValue("$suffix", "%." + domain);
+                    using var reader = cmd.ExecuteReader();
+                    while (reader.Read())
+                    {
+                        string name = reader.GetString(0);
+                        string value = reader.IsDBNull(1) ? "" : reader.GetString(1);
+                        if (!string.IsNullOrEmpty(name))
+                            raw.Add((name, value));
+                    }
+                    return raw;
+                }
+                catch (Exception ex) when (attempt == 0 && IsTransientSqliteLock(ex))
+                {
+                    System.Threading.Thread.Sleep(50);
+                }
+                catch (Exception ex)
+                {
+                    Log.Debug($"firefox cookie db read failed: {ex.Message}");
+                    break;
                 }
             }
-            catch (Exception ex) { Log.Debug($"firefox cookie db read failed: {ex.Message}"); }
             return raw;
+        }
+
+        private static bool IsTransientSqliteLock(Exception ex)
+        {
+            var message = ex.Message;
+            return message.Contains("locked", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("busy", StringComparison.OrdinalIgnoreCase);
         }
 
         private static List<(string name, string value)> ReadFirefoxCookies(string cookiesDb, string domain)

--- a/src/TaskbarQuota.App/Browser/CookieExtractor.cs
+++ b/src/TaskbarQuota.App/Browser/CookieExtractor.cs
@@ -306,18 +306,19 @@ namespace TaskbarQuota.Browser
         private static List<(string name, string value)> ReadChromiumCookies(string cookiesDb, byte[] key, string domain)
         {
             var results = new List<(string, string)>();
-            // Browser keeps the DB locked; copy to temp first.
-            string temp = Path.Combine(Path.GetTempPath(), $"TaskbarQuota_cookies_{Guid.NewGuid():N}.db");
             try
             {
-                CopyPossiblyLockedFile(cookiesDb, temp);
-                using var conn = new SqliteConnection($"Data Source={temp};Mode=ReadOnly;Cache=Private");
+                // Read the live browser database without copying it to %TEMP%; the copy operation
+                // created TaskbarQuota_* SQLite/journal files and could race the browser's writes.
+                using var conn = OpenReadOnlyConnection(cookiesDb);
                 conn.Open();
                 using var cmd = conn.CreateCommand();
                 cmd.CommandText =
-                    "SELECT name, encrypted_value, host_key FROM cookies WHERE host_key LIKE $a OR host_key LIKE $b";
-                cmd.Parameters.AddWithValue("$a", "%" + domain);
-                cmd.Parameters.AddWithValue("$b", "." + domain);
+                    "SELECT name, encrypted_value, host_key FROM cookies " +
+                    "WHERE host_key = $exact OR host_key = $subdomain OR host_key LIKE $suffix";
+                cmd.Parameters.AddWithValue("$exact", domain);
+                cmd.Parameters.AddWithValue("$subdomain", "." + domain);
+                cmd.Parameters.AddWithValue("$suffix", "%." + domain);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
@@ -328,25 +329,23 @@ namespace TaskbarQuota.Browser
                 }
             }
             catch (Exception ex) { Log.Debug($"chromium cookie db read failed: {ex.Message}"); }
-            finally { try { File.Delete(temp); } catch { } }
             return results;
         }
 
         private static List<(string name, string value)> ReadFirefoxCookiesRaw(string cookiesDb, string domain)
         {
             var raw = new List<(string name, string value)>();
-            string temp = Path.Combine(Path.GetTempPath(), $"TaskbarQuota_ff_cookies_{Guid.NewGuid():N}.db");
             try
             {
-                CopyPossiblyLockedFile(cookiesDb, temp);
-                using var conn = new SqliteConnection($"Data Source={temp};Mode=ReadOnly;Cache=Private");
+                using var conn = OpenReadOnlyConnection(cookiesDb);
                 conn.Open();
                 using var cmd = conn.CreateCommand();
                 cmd.CommandText =
-                    "SELECT name, value, host FROM moz_cookies WHERE host LIKE $a OR host LIKE $b OR host LIKE $c";
-                cmd.Parameters.AddWithValue("$a", domain);
-                cmd.Parameters.AddWithValue("$b", "." + domain);
-                cmd.Parameters.AddWithValue("$c", "%" + domain);
+                    "SELECT name, value, host FROM moz_cookies " +
+                    "WHERE host = $exact OR host = $subdomain OR host LIKE $suffix";
+                cmd.Parameters.AddWithValue("$exact", domain);
+                cmd.Parameters.AddWithValue("$subdomain", "." + domain);
+                cmd.Parameters.AddWithValue("$suffix", "%." + domain);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
@@ -357,7 +356,6 @@ namespace TaskbarQuota.Browser
                 }
             }
             catch (Exception ex) { Log.Debug($"firefox cookie db read failed: {ex.Message}"); }
-            finally { try { File.Delete(temp); } catch { } }
             return raw;
         }
 
@@ -411,11 +409,15 @@ namespace TaskbarQuota.Browser
             return results;
         }
 
-        private static void CopyPossiblyLockedFile(string source, string destination)
+        private static SqliteConnection OpenReadOnlyConnection(string databasePath)
         {
-            using var input = new FileStream(source, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-            using var output = new FileStream(destination, FileMode.Create, FileAccess.Write, FileShare.None);
-            input.CopyTo(output);
+            return new SqliteConnection(new SqliteConnectionStringBuilder
+            {
+                DataSource = databasePath,
+                Mode = SqliteOpenMode.ReadOnly,
+                Pooling = false,
+                DefaultTimeout = 1,
+            }.ToString());
         }
 
         private static byte[] GetEncryptionKey(string localStatePath)

--- a/src/TaskbarQuota.App/Browser/CookieExtractor.cs
+++ b/src/TaskbarQuota.App/Browser/CookieExtractor.cs
@@ -240,10 +240,8 @@ namespace TaskbarQuota.Browser
 
             foreach (var profile in EnumerateChromiumProfiles(browser.UserDataDir))
             {
-                var cookiesDb = File.Exists(Path.Combine(profile, "Network", "Cookies"))
-                    ? Path.Combine(profile, "Network", "Cookies")
-                    : Path.Combine(profile, "Cookies");
-                if (!File.Exists(cookiesDb)) continue;
+                var cookiesDb = FindChromiumCookiesDb(profile);
+                if (cookiesDb == null) continue;
 
                 foreach (var c in ReadChromiumCookies(cookiesDb, key, domain))
                     yield return c;
@@ -452,7 +450,11 @@ namespace TaskbarQuota.Browser
             }
             // Chromium's newer app-bound formats (for example v20) require browser-process
             // mediation and must not be mistaken for the legacy DPAPI format below.
-            if (enc.Length >= 3 && enc[0] == 'v' && enc[1] == '1' && enc[2] != '0' && enc[2] != '1')
+            if (enc.Length >= 3
+                && enc[0] == 'v'
+                && enc[1] >= '0' && enc[1] <= '9'
+                && enc[2] >= '0' && enc[2] <= '9'
+                && !(enc[1] == '1' && (enc[2] == '0' || enc[2] == '1')))
                 return null;
             // Legacy DPAPI-encrypted value (pre-v10)
             try { return Encoding.UTF8.GetString(ProtectedData.Unprotect(enc, null, DataProtectionScope.CurrentUser)); }

--- a/src/TaskbarQuota.App/Usage/CredentialStore.cs
+++ b/src/TaskbarQuota.App/Usage/CredentialStore.cs
@@ -25,6 +25,7 @@ namespace TaskbarQuota.Usage
         {
             public string? ApiKey { get; set; }
             public string? CookieHeader { get; set; }
+            public string? WorkspaceId { get; set; }
             public string? Extra { get; set; } // provider-specific (e.g. MiniMax group id)
         }
 
@@ -66,6 +67,12 @@ namespace TaskbarQuota.Usage
         {
             var v = For(id).CookieHeader;
             return string.IsNullOrWhiteSpace(v) ? null : v!.Trim();
+        }
+
+        public string? WorkspaceId(ProviderId id)
+        {
+            var value = For(id).WorkspaceId;
+            return string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
         }
 
         public void Save()

--- a/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using TaskbarQuota.Browser;
+using TaskbarQuota.Diagnostics;
 
 namespace TaskbarQuota.Usage.Providers
 {
@@ -85,6 +86,31 @@ namespace TaskbarQuota.Usage.Providers
                 "Encryption; paste the opencode.ai Cookie header and, if needed, the workspace ID in Fix.");
         }
 
+        internal static async Task<ProviderFetchResult> FetchWithCandidatesAsync(
+            ProviderId id,
+            string expirationMessage,
+            Func<string, CancellationToken, Task<ProviderFetchResult>> fetch,
+            CancellationToken ct,
+            params string[] domains)
+        {
+            var candidates = ResolveOpenCodeCandidates(id, domains);
+            ProviderException? lastError = null;
+
+            foreach (var candidate in candidates)
+            {
+                try
+                {
+                    return await fetch(candidate.Header, ct).ConfigureAwait(false);
+                }
+                catch (ProviderException ex) when (!candidate.IsManual)
+                {
+                    lastError = ex;
+                }
+            }
+
+            throw lastError ?? new ProviderException(ProviderErrorKind.AuthRequired, expirationMessage);
+        }
+
         private static bool IsGecko(string browserName)
             => browserName is "Zen" or "Firefox" or "Waterfox" or "LibreWolf" or "Floorp";
 
@@ -155,27 +181,14 @@ namespace TaskbarQuota.Usage.Providers
         public string WeeklyLabel => "Balance";
         public BillingKind Billing => BillingKind.Api;
 
-        public async Task<ProviderFetchResult> FetchUsageAsync(CancellationToken ct = default)
-        {
-            var candidates = CookieHelper.ResolveOpenCodeCandidates(Id, "opencode.ai", "app.opencode.ai");
-            ProviderException? lastError = null;
-
-            foreach (var candidate in candidates)
-            {
-                try
-                {
-                    return await FetchUsageAsync(candidate.Header, ct).ConfigureAwait(false);
-                }
-                catch (ProviderException ex) when (!candidate.IsManual)
-                {
-                    // A readable browser cookie can still be stale. Try the next complete
-                    // profile before surfacing the final error.
-                    lastError = ex;
-                }
-            }
-
-            throw lastError ?? new ProviderException(ProviderErrorKind.AuthRequired, "OpenCode cookies expired.");
-        }
+        public Task<ProviderFetchResult> FetchUsageAsync(CancellationToken ct = default)
+            => CookieHelper.FetchWithCandidatesAsync(
+                Id,
+                "OpenCode cookies expired.",
+                (cookie, token) => FetchUsageAsync(cookie, token),
+                ct,
+                "opencode.ai",
+                "app.opencode.ai");
 
         private async Task<ProviderFetchResult> FetchUsageAsync(string cookie, CancellationToken ct)
         {
@@ -261,14 +274,23 @@ namespace TaskbarQuota.Usage.Providers
             if (text != null)
             {
                 var getIds = ParseWorkspaceIds(text);
-                if (getIds.Count > 0) return getIds[0];
+                if (getIds.Count > 0) return SelectWorkspaceId(providerName, "GET", getIds);
             }
 
             text = await GetText(ServerUrl, WorkspacesServerId, "https://opencode.ai", cookie, ct,
                 HttpMethod.Post, "[]").ConfigureAwait(false);
             var ids = ParseWorkspaceIds(text);
-            if (ids.Count > 0) return ids[0];
+            if (ids.Count > 0) return SelectWorkspaceId(providerName, "POST", ids);
             throw new ProviderException(ProviderErrorKind.Parse, $"{providerName}: no workspace id found.");
+        }
+
+        private static string SelectWorkspaceId(string providerName, string transport, IReadOnlyList<string> ids)
+        {
+            if (ids.Count > 1)
+                Log.Debug($"{providerName}: {transport} workspace lookup found {ids.Count} workspaces " +
+                          $"[{string.Join(", ", ids)}]; selecting {ids[0]}. " +
+                          "Use the Workspace ID override in Fix if this is not the intended workspace.");
+            return ids[0];
         }
 
         private static async Task<string?> TryGetBillingText(string workspaceId, string cookie, CancellationToken ct)
@@ -380,9 +402,8 @@ namespace TaskbarQuota.Usage.Providers
             var lower = text.ToLowerInvariant();
             return lower.Contains("auth/authorize")
                 || lower.Contains("\"signin\"")
-                || lower.Contains("please sign in")
-                || lower.Contains("sign in")
-                || lower.Contains("openauth")
+                || lower.Contains("please sign in to continue")
+                || lower.Contains("<title>openauth</title>")
                 || lower.Contains("continue with github")
                 || lower.Contains("continue with google")
                 || (lower.Contains("actor of type") && lower.Contains("not associated with an account"));
@@ -601,25 +622,14 @@ namespace TaskbarQuota.Usage.Providers
         public string WeeklyLabel => "Weekly";
         public BillingKind Billing => BillingKind.Subscription;
 
-        public async Task<ProviderFetchResult> FetchUsageAsync(CancellationToken ct = default)
-        {
-            var candidates = CookieHelper.ResolveOpenCodeCandidates(Id, "opencode.ai", "app.opencode.ai");
-            ProviderException? lastError = null;
-
-            foreach (var candidate in candidates)
-            {
-                try
-                {
-                    return await FetchUsageAsync(candidate.Header, ct).ConfigureAwait(false);
-                }
-                catch (ProviderException ex) when (!candidate.IsManual)
-                {
-                    lastError = ex;
-                }
-            }
-
-            throw lastError ?? new ProviderException(ProviderErrorKind.AuthRequired, "OpenCode Go cookies expired.");
-        }
+        public Task<ProviderFetchResult> FetchUsageAsync(CancellationToken ct = default)
+            => CookieHelper.FetchWithCandidatesAsync(
+                Id,
+                "OpenCode Go cookies expired.",
+                (cookie, token) => FetchUsageAsync(cookie, token),
+                ct,
+                "opencode.ai",
+                "app.opencode.ai");
 
         private async Task<ProviderFetchResult> FetchUsageAsync(string cookie, CancellationToken ct)
         {

--- a/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
@@ -187,8 +187,9 @@ namespace TaskbarQuota.Usage.Providers
                 "OpenCode cookies expired.",
                 (cookie, token) => FetchUsageAsync(cookie, token),
                 ct,
-                "opencode.ai",
-                "app.opencode.ai");
+                // Every request is sent to opencode.ai. Do not merge cookies scoped only to the
+                // app subdomain into that request's Cookie header.
+                "opencode.ai");
 
         private async Task<ProviderFetchResult> FetchUsageAsync(string cookie, CancellationToken ct)
         {
@@ -628,8 +629,7 @@ namespace TaskbarQuota.Usage.Providers
                 "OpenCode Go cookies expired.",
                 (cookie, token) => FetchUsageAsync(cookie, token),
                 ct,
-                "opencode.ai",
-                "app.opencode.ai");
+                "opencode.ai");
 
         private async Task<ProviderFetchResult> FetchUsageAsync(string cookie, CancellationToken ct)
         {

--- a/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -13,6 +15,18 @@ namespace TaskbarQuota.Usage.Providers
 {
     internal static class CookieHelper
     {
+        internal sealed record CookieCandidate(string Header, string SourceLabel, bool IsManual);
+
+        private static readonly HashSet<string> OpenCodeAuthCookieNames = new(StringComparer.Ordinal)
+        {
+            "auth",
+            "__Host-auth",
+        };
+
+        private static readonly Regex CurlCookieOption = new(
+            @"(?:^|\s)(?<option>-H|--header|--cookie|--cookie-raw|-b)(?:=|\s+)(?:""(?<value>[^""]*)""|'(?<value>[^']*)'|(?<value>[^\s^]+))",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
         public static string Resolve(ProviderId id, params string[] domains)
         {
             var manual = CredentialStore.Instance.ManualCookieHeader(id);
@@ -25,6 +39,96 @@ namespace TaskbarQuota.Usage.Providers
             throw new ProviderException(ProviderErrorKind.AuthRequired,
                 $"No cookies found for {string.Join("/", domains)}. Sign in via Edge/Chrome or paste a cookie header in credentials.json.");
         }
+
+        /// <summary>
+        /// Resolves OpenCode cookies without merging browser profiles. Gecko profiles keep their
+        /// plaintext cookies, while Chromium profiles are returned only when at least one cookie
+        /// decrypted successfully. This makes pre-127 Chromium and Gecko automatic detection work
+        /// without allowing an unreadable modern Chromium profile to mask another session.
+        /// </summary>
+        public static IReadOnlyList<CookieCandidate> ResolveOpenCodeCandidates(ProviderId id, params string[] domains)
+        {
+            var manual = NormalizeCookieHeader(CredentialStore.Instance.ManualCookieHeader(id));
+            if (manual != null)
+                return new[] { new CookieCandidate(manual, "manual", true) };
+
+            if (id == ProviderId.OpenCodeGo)
+            {
+                manual = NormalizeCookieHeader(CredentialStore.Instance.ManualCookieHeader(ProviderId.OpenCode));
+                if (manual != null)
+                    return new[] { new CookieCandidate(manual, "manual (OpenCode)", true) };
+            }
+
+            var candidates = CookieExtractor.GetCookieSources(domains)
+                .Where(source => source.Cookies.Any(cookie =>
+                    OpenCodeAuthCookieNames.Contains(cookie.Name) && !string.IsNullOrWhiteSpace(cookie.Value)))
+                // Prefer Gecko sources so a readable current Gecko session wins over a stale,
+                // readable Chromium profile. Any remaining candidate is still tried if its
+                // session is rejected by OpenCode.
+                .OrderBy(source => IsGecko(source.BrowserName) ? 0 : 1)
+                .ThenBy(source => source.BrowserName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(source => source.ProfileName, StringComparer.OrdinalIgnoreCase)
+                .Select(source => new CookieCandidate(
+                    source.Header,
+                    $"{source.BrowserName}/{source.ProfileName}",
+                    false))
+                .DistinctBy(candidate => candidate.Header, StringComparer.Ordinal)
+                .ToList();
+
+            if (candidates.Count > 0)
+                return candidates;
+
+            throw new ProviderException(
+                ProviderErrorKind.AuthRequired,
+                "OpenCode cookies could not be read automatically. Firefox/Zen and Chromium profiles " +
+                "with decryptable pre-127 cookies are supported. Chromium 127+ uses App-Bound " +
+                "Encryption; paste the opencode.ai Cookie header and, if needed, the workspace ID in Fix.");
+        }
+
+        private static bool IsGecko(string browserName)
+            => browserName is "Zen" or "Firefox" or "Waterfox" or "LibreWolf" or "Floorp";
+
+        internal static string? NormalizeCookieHeader(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw)) return null;
+            var header = raw.Trim();
+
+            if (LooksLikeCurlCommand(header))
+            {
+                foreach (Match match in CurlCookieOption.Matches(header))
+                {
+                    var value = match.Groups["value"].Value.Trim();
+                    if (value.StartsWith("Cookie:", StringComparison.OrdinalIgnoreCase))
+                        return TrimCookiePrefix(value);
+
+                    var option = match.Groups["option"].Value;
+                    if ((option.Equals("-b", StringComparison.OrdinalIgnoreCase)
+                         || option.Equals("--cookie", StringComparison.OrdinalIgnoreCase)
+                         || option.Equals("--cookie-raw", StringComparison.OrdinalIgnoreCase))
+                        && value.Contains('='))
+                        return value;
+                }
+
+                return null;
+            }
+
+            return TrimCookiePrefix(header);
+        }
+
+        private static bool LooksLikeCurlCommand(string value)
+        {
+            if (!value.StartsWith("curl", StringComparison.OrdinalIgnoreCase)) return false;
+            if (value.Length == 4 || char.IsWhiteSpace(value[4])) return true;
+            return value.StartsWith("curl.exe", StringComparison.OrdinalIgnoreCase)
+                && (value.Length == 8 || char.IsWhiteSpace(value[8]));
+        }
+
+        private static string? TrimCookiePrefix(string header)
+        {
+            if (header.StartsWith("Cookie:", StringComparison.OrdinalIgnoreCase))
+                header = header["Cookie:".Length..].Trim();
+            return string.IsNullOrWhiteSpace(header) ? null : header;
+        }
     }
 
     /// <summary>
@@ -35,7 +139,7 @@ namespace TaskbarQuota.Usage.Providers
     {
         private const string ServerUrl = "https://opencode.ai/_server";
         private const string WorkspacesServerId = "def39973159c7f0483d8793a822b8dbb10d067e12c65455fcb4608459ba0234f";
-        private const string SubscriptionServerId = "7abeebee372f304e050aaaf92be863f4a86490e382f8c79db68fd94040d691b4";
+        private const string BillingServerId = "c83b78a614689c38ebee981f9b39a8b377716db85c1fd7dbab604adc02d3313d";
         private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(30) };
         private static readonly Regex WorkspaceRe = new(@"wrk_[A-Za-z0-9_-]+", RegexOptions.Compiled);
 
@@ -53,14 +157,32 @@ namespace TaskbarQuota.Usage.Providers
 
         public async Task<ProviderFetchResult> FetchUsageAsync(CancellationToken ct = default)
         {
-            var cookie = CookieHelper.Resolve(Id, "opencode.ai");
+            var candidates = CookieHelper.ResolveOpenCodeCandidates(Id, "opencode.ai", "app.opencode.ai");
+            ProviderException? lastError = null;
 
-            string wsText = await GetText($"{ServerUrl}?id={WorkspacesServerId}", WorkspacesServerId, "https://opencode.ai", cookie, ct).ConfigureAwait(false);
-            var ws = WorkspaceRe.Match(wsText);
-            if (!ws.Success) throw new ProviderException(ProviderErrorKind.Parse, "OpenCode: no workspace id found.");
-            string workspaceId = ws.Value;
+            foreach (var candidate in candidates)
+            {
+                try
+                {
+                    return await FetchUsageAsync(candidate.Header, ct).ConfigureAwait(false);
+                }
+                catch (ProviderException ex) when (!candidate.IsManual)
+                {
+                    // A readable browser cookie can still be stale. Try the next complete
+                    // profile before surfacing the final error.
+                    lastError = ex;
+                }
+            }
 
-            var texts = new List<string> { wsText };
+            throw lastError ?? new ProviderException(ProviderErrorKind.AuthRequired, "OpenCode cookies expired.");
+        }
+
+        private async Task<ProviderFetchResult> FetchUsageAsync(string cookie, CancellationToken ct)
+        {
+            string workspaceId = NormalizeWorkspaceId(CredentialStore.Instance.WorkspaceId(Id))
+                ?? await FetchWorkspaceId(cookie, ct, "OpenCode").ConfigureAwait(false);
+
+            var texts = new List<string>();
             var pageTasks = new[]
             {
                 $"https://opencode.ai/workspace/{workspaceId}",
@@ -74,9 +196,14 @@ namespace TaskbarQuota.Usage.Providers
                 if (!string.IsNullOrEmpty(text))
                     texts.Add(text);
 
+            var billingText = await TryGetBillingText(workspaceId, cookie, ct).ConfigureAwait(false);
+            if (!string.IsNullOrEmpty(billingText))
+                texts.Add(billingText);
+
             var combined = string.Join("\n", texts);
             var monthlyUsage = FindMoneyValue(combined, "monthlyUsage", "monthly_usage", "currentUsage", "usage");
-            var balance = FindMoneyValue(combined, "balance", "currentBalance", "current_balance");
+            var balance = ParseBillingBalance(combined)
+                ?? FindMoneyValue(combined, "zenBalance", "currentBalance", "current_balance", "balance");
             var monthlyLimit = FindMoneyValue(combined, "monthlyLimit", "monthly_limit");
 
             if (monthlyUsage is null && balance is null)
@@ -97,9 +224,114 @@ namespace TaskbarQuota.Usage.Providers
             return new ProviderFetchResult(usage, "web");
         }
 
-        private static async Task<string> GetText(string url, string serverId, string referer, string cookie, CancellationToken ct)
+        internal static string? NormalizeWorkspaceId(string? raw)
         {
-            using var req = new HttpRequestMessage(HttpMethod.Get, url);
+            if (string.IsNullOrWhiteSpace(raw)) return null;
+            var match = WorkspaceRe.Match(raw.Trim());
+            return match.Success ? match.Value : null;
+        }
+
+        internal static IReadOnlyList<string> ParseWorkspaceIds(string text)
+        {
+            var results = new List<string>();
+            foreach (Match match in WorkspaceRe.Matches(text))
+                if (!results.Contains(match.Value, StringComparer.Ordinal))
+                    results.Add(match.Value);
+            return results;
+        }
+
+        internal static async Task<string> FetchWorkspaceId(string cookie, CancellationToken ct, string providerName)
+        {
+            string? text = null;
+            try
+            {
+                text = await GetText($"{ServerUrl}?id={WorkspacesServerId}", WorkspacesServerId,
+                    "https://opencode.ai", cookie, ct).ConfigureAwait(false);
+            }
+            catch (ProviderException ex) when (ex.Kind != ProviderErrorKind.AuthRequired)
+            {
+                // The server function can reject GET after a deployment changes its transport.
+                // Preserve auth errors, but let the POST form handle status/transport failures.
+            }
+            catch (HttpRequestException)
+            {
+                // A connection-level GET failure may still succeed through the POST route.
+            }
+
+            if (text != null)
+            {
+                var getIds = ParseWorkspaceIds(text);
+                if (getIds.Count > 0) return getIds[0];
+            }
+
+            text = await GetText(ServerUrl, WorkspacesServerId, "https://opencode.ai", cookie, ct,
+                HttpMethod.Post, "[]").ConfigureAwait(false);
+            var ids = ParseWorkspaceIds(text);
+            if (ids.Count > 0) return ids[0];
+            throw new ProviderException(ProviderErrorKind.Parse, $"{providerName}: no workspace id found.");
+        }
+
+        private static async Task<string?> TryGetBillingText(string workspaceId, string cookie, CancellationToken ct)
+        {
+            try
+            {
+                var args = JsonSerializer.Serialize(new[] { workspaceId });
+                return await GetText($"{ServerUrl}?id={BillingServerId}&args={Uri.EscapeDataString(args)}",
+                    BillingServerId, WorkspacePageUrl(workspaceId), cookie, ct).ConfigureAwait(false);
+            }
+            catch (ProviderException ex) when (ex.Kind == ProviderErrorKind.AuthRequired) { throw; }
+            catch (OperationCanceledException) { throw; }
+            catch { return null; }
+        }
+
+        internal static double? ParseBillingBalance(string text)
+        {
+            using var doc = TryJson(text);
+            if (doc != null && TryFindBillingBalance(doc.RootElement, out var raw))
+                return raw / 100_000_000d;
+
+            if (!Regex.IsMatch(text, "(?:\\\"customerID\\\"|customerID)\\s*:\\s*(?:\\$R\\[\\d+\\]\\s*=\\s*)?\\\"[^\\\"]+\\\""))
+                return null;
+            var match = Regex.Match(text, "(?:\\\"balance\\\"|balance)\\s*:\\s*(?:\\$R\\[\\d+\\]\\s*=\\s*)?(-?[0-9]+(?:\\.[0-9]+)?)");
+            return match.Success && double.TryParse(match.Groups[1].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out raw)
+                ? raw / 100_000_000d
+                : null;
+        }
+
+        private static bool TryFindBillingBalance(JsonElement element, out double balance)
+        {
+            if (element.ValueKind == JsonValueKind.Object)
+            {
+                if (element.TryGetProperty("customerID", out var customer) && customer.ValueKind == JsonValueKind.String
+                    && !string.IsNullOrEmpty(customer.GetString()) && element.TryGetProperty("balance", out var value)
+                    && TryJsonDouble(value, out balance))
+                    return true;
+                foreach (var property in element.EnumerateObject())
+                    if (TryFindBillingBalance(property.Value, out balance)) return true;
+            }
+            else if (element.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in element.EnumerateArray())
+                    if (TryFindBillingBalance(item, out balance)) return true;
+            }
+
+            balance = 0;
+            return false;
+        }
+
+        private static bool TryJsonDouble(JsonElement value, out double result)
+        {
+            if (value.ValueKind == JsonValueKind.Number) return value.TryGetDouble(out result);
+            if (value.ValueKind == JsonValueKind.String)
+                return double.TryParse(value.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out result);
+            result = 0;
+            return false;
+        }
+
+        private static async Task<string> GetText(string url, string serverId, string referer, string cookie,
+            CancellationToken ct, HttpMethod? method = null, string? body = null)
+        {
+            using var req = new HttpRequestMessage(method ?? HttpMethod.Get, url);
             req.Headers.TryAddWithoutValidation("Cookie", cookie);
             req.Headers.TryAddWithoutValidation("X-Server-Id", serverId);
             req.Headers.TryAddWithoutValidation("X-Server-Instance", $"server-fn:{Guid.NewGuid()}");
@@ -107,12 +339,15 @@ namespace TaskbarQuota.Usage.Providers
             req.Headers.TryAddWithoutValidation("Origin", "https://opencode.ai");
             req.Headers.TryAddWithoutValidation("Referer", referer);
             req.Headers.TryAddWithoutValidation("Accept", "text/javascript, application/json;q=0.9, */*;q=0.8");
+            if (body != null)
+                req.Content = new StringContent(body, Encoding.UTF8, "application/json");
             using var resp = await Http.SendAsync(req, ct).ConfigureAwait(false);
-            if (resp.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+            var text = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            if (resp.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden || LooksSignedOut(text))
                 throw new ProviderException(ProviderErrorKind.AuthRequired, "OpenCode cookies expired.");
             if (!resp.IsSuccessStatusCode)
                 throw new ProviderException(ProviderErrorKind.Other, $"OpenCode API {(int)resp.StatusCode}");
-            return await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            return text;
         }
 
         private static async Task<string> GetPageText(string url, string referer, string cookie, CancellationToken ct)
@@ -135,13 +370,22 @@ namespace TaskbarQuota.Usage.Providers
         private static async Task<string?> TryGetPageText(string url, string referer, string cookie, CancellationToken ct)
         {
             try { return await GetPageText(url, referer, cookie, ct).ConfigureAwait(false); }
+            catch (ProviderException ex) when (ex.Kind == ProviderErrorKind.AuthRequired) { throw; }
+            catch (OperationCanceledException) { throw; }
             catch { return null; }
         }
 
         internal static bool LooksSignedOut(string text)
         {
             var lower = text.ToLowerInvariant();
-            return lower.Contains("auth/authorize") || lower.Contains("\"signin\"") || lower.Contains("please sign in") || lower.Contains("sign in");
+            return lower.Contains("auth/authorize")
+                || lower.Contains("\"signin\"")
+                || lower.Contains("please sign in")
+                || lower.Contains("sign in")
+                || lower.Contains("openauth")
+                || lower.Contains("continue with github")
+                || lower.Contains("continue with google")
+                || (lower.Contains("actor of type") && lower.Contains("not associated with an account"));
         }
 
         internal static double? FindMoneyValue(string text, params string[] keys)
@@ -349,33 +593,44 @@ namespace TaskbarQuota.Usage.Providers
     /// <summary>OpenCode Go subscription usage from the workspace /go page: rolling, weekly and monthly windows.</summary>
     public sealed class OpenCodeGoProvider : IUsageProvider
     {
-        private const string ServerUrl = "https://opencode.ai/_server";
-        private const string WorkspacesServerId = "def39973159c7f0483d8793a822b8dbb10d067e12c65455fcb4608459ba0234f";
-        private const string LiteSubscriptionServerId = "c7389bd0e731f80f49593e5ee53835475f4e28594dd6bd83eb229bab753498cd";
         private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(30) };
-        private static readonly Regex WorkspaceRe = new(@"wrk_[A-Za-z0-9_-]+", RegexOptions.Compiled);
 
         public ProviderId Id => ProviderId.OpenCodeGo;
         public string DisplayName => "OpenCode Go";
-        public string SessionLabel => "Session";
+        public string SessionLabel => "Rolling";
         public string WeeklyLabel => "Weekly";
         public BillingKind Billing => BillingKind.Subscription;
 
         public async Task<ProviderFetchResult> FetchUsageAsync(CancellationToken ct = default)
         {
-            var cookie = CredentialStore.Instance.ManualCookieHeader(Id)
-                ?? CredentialStore.Instance.ManualCookieHeader(ProviderId.OpenCode)
-                ?? CookieHelper.Resolve(Id, "opencode.ai");
-            string wsText = await GetText($"{ServerUrl}?id={WorkspacesServerId}", "https://opencode.ai", cookie, ct).ConfigureAwait(false);
-            var ws = WorkspaceRe.Match(wsText);
-            if (!ws.Success) throw new ProviderException(ProviderErrorKind.Parse, "OpenCode Go: no workspace id found.");
+            var candidates = CookieHelper.ResolveOpenCodeCandidates(Id, "opencode.ai", "app.opencode.ai");
+            ProviderException? lastError = null;
 
-            string usageText = await GetText(
-                $"{ServerUrl}?id={LiteSubscriptionServerId}&args={ServerStringArg(ws.Value)}",
-                $"https://opencode.ai/workspace/{ws.Value}/go",
+            foreach (var candidate in candidates)
+            {
+                try
+                {
+                    return await FetchUsageAsync(candidate.Header, ct).ConfigureAwait(false);
+                }
+                catch (ProviderException ex) when (!candidate.IsManual)
+                {
+                    lastError = ex;
+                }
+            }
+
+            throw lastError ?? new ProviderException(ProviderErrorKind.AuthRequired, "OpenCode Go cookies expired.");
+        }
+
+        private async Task<ProviderFetchResult> FetchUsageAsync(string cookie, CancellationToken ct)
+        {
+            string workspaceId = OpenCodeProvider.NormalizeWorkspaceId(CredentialStore.Instance.WorkspaceId(Id))
+                ?? OpenCodeProvider.NormalizeWorkspaceId(CredentialStore.Instance.WorkspaceId(ProviderId.OpenCode))
+                ?? await OpenCodeProvider.FetchWorkspaceId(cookie, ct, "OpenCode Go").ConfigureAwait(false);
+
+            string usageText = await GetPageText(
+                OpenCodeProvider.WorkspacePageUrl(workspaceId, "go"),
                 cookie,
-                ct,
-                LiteSubscriptionServerId).ConfigureAwait(false);
+                ct).ConfigureAwait(false);
             if (OpenCodeProvider.LooksSignedOut(usageText)) throw new ProviderException(ProviderErrorKind.AuthRequired, "OpenCode Go cookies expired.");
 
             var rolling = OpenCodeProvider.ExtractWindow(usageText, 300, "rollingUsage", "rolling_usage", "rolling")
@@ -388,43 +643,20 @@ namespace TaskbarQuota.Usage.Providers
                 Secondary = weekly,
                 Monthly = monthly,
                 LoginMethod = "Go",
-                UsageDashboardUrl = OpenCodeProvider.WorkspacePageUrl(ws.Value, "go"),
+                UsageDashboardUrl = OpenCodeProvider.WorkspacePageUrl(workspaceId, "go"),
             };
 
             return new ProviderFetchResult(usage, "opencode");
         }
 
-        private static string ServerStringArg(string value)
-        {
-            var payload = new
-            {
-                t = new
-                {
-                    t = 9,
-                    i = 0,
-                    l = 1,
-                    a = new[] { new { t = 1, s = value } },
-                    o = 0,
-                },
-                f = 31,
-                m = Array.Empty<object>(),
-            };
-            return Uri.EscapeDataString(JsonSerializer.Serialize(payload));
-        }
-
-        private static async Task<string> GetText(string url, string referer, string cookie, CancellationToken ct, string serverId = WorkspacesServerId)
+        private static async Task<string> GetPageText(string url, string cookie, CancellationToken ct)
         {
             using var req = new HttpRequestMessage(HttpMethod.Get, url);
             req.Headers.TryAddWithoutValidation("Cookie", cookie);
-            if (url.StartsWith(ServerUrl, StringComparison.OrdinalIgnoreCase))
-            {
-                req.Headers.TryAddWithoutValidation("X-Server-Id", serverId);
-                req.Headers.TryAddWithoutValidation("X-Server-Instance", $"server-fn:{Guid.NewGuid()}");
-            }
             req.Headers.TryAddWithoutValidation("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
             req.Headers.TryAddWithoutValidation("Origin", "https://opencode.ai");
-            req.Headers.TryAddWithoutValidation("Referer", referer);
-            req.Headers.TryAddWithoutValidation("Accept", "text/javascript, application/json;q=0.9, */*;q=0.8");
+            req.Headers.TryAddWithoutValidation("Referer", url);
+            req.Headers.TryAddWithoutValidation("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,text/javascript,application/json;q=0.8,*/*;q=0.7");
             using var resp = await Http.SendAsync(req, ct).ConfigureAwait(false);
             var text = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             if (resp.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden || OpenCodeProvider.LooksSignedOut(text))

--- a/src/TaskbarQuota.App/ViewModels/SettingsViewModel.cs
+++ b/src/TaskbarQuota.App/ViewModels/SettingsViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using TaskbarQuota.Usage;
+using TaskbarQuota.Usage.Providers;
 
 namespace TaskbarQuota.ViewModels
 {
@@ -45,6 +46,7 @@ namespace TaskbarQuota.ViewModels
     {
         private readonly ProviderId _id;
 
+        public ProviderId Id => _id;
         public string Title { get; }
         public string Description { get; }
         public CredentialKind Kind { get; }
@@ -52,6 +54,7 @@ namespace TaskbarQuota.ViewModels
 
         [ObservableProperty] public partial string ApiKey { get; set; }
         [ObservableProperty] public partial string CookieHeader { get; set; }
+        [ObservableProperty] public partial string WorkspaceId { get; set; }
         [ObservableProperty] public partial bool Saved { get; set; }
 
         public bool IsApiKey => Kind == CredentialKind.ApiKey;
@@ -75,6 +78,7 @@ namespace TaskbarQuota.ViewModels
             var e = CredentialStore.Instance.For(id);
             ApiKey = e.ApiKey ?? "";
             CookieHeader = e.CookieHeader ?? "";
+            WorkspaceId = e.WorkspaceId ?? "";
         }
 
         [RelayCommand]
@@ -82,7 +86,14 @@ namespace TaskbarQuota.ViewModels
         {
             var e = CredentialStore.Instance.For(_id);
             e.ApiKey = string.IsNullOrWhiteSpace(ApiKey) ? null : ApiKey.Trim();
-            e.CookieHeader = string.IsNullOrWhiteSpace(CookieHeader) ? null : CookieHeader.Trim();
+            var cookieInput = string.IsNullOrWhiteSpace(CookieHeader) ? null : CookieHeader.Trim();
+            var normalizedCookie = _id is ProviderId.OpenCode or ProviderId.OpenCodeGo
+                ? CookieHelper.NormalizeCookieHeader(cookieInput)
+                : cookieInput;
+            e.CookieHeader = normalizedCookie ?? cookieInput;
+            if (normalizedCookie != null)
+                CookieHeader = normalizedCookie;
+            e.WorkspaceId = string.IsNullOrWhiteSpace(WorkspaceId) ? null : WorkspaceId.Trim();
             CredentialStore.Instance.Save();
             Saved = true;
         }

--- a/src/TaskbarQuota.App/ViewModels/SettingsViewModel.cs
+++ b/src/TaskbarQuota.App/ViewModels/SettingsViewModel.cs
@@ -87,12 +87,13 @@ namespace TaskbarQuota.ViewModels
             var e = CredentialStore.Instance.For(_id);
             e.ApiKey = string.IsNullOrWhiteSpace(ApiKey) ? null : ApiKey.Trim();
             var cookieInput = string.IsNullOrWhiteSpace(CookieHeader) ? null : CookieHeader.Trim();
-            var normalizedCookie = _id is ProviderId.OpenCode or ProviderId.OpenCodeGo
+            bool isOpenCode = _id is ProviderId.OpenCode or ProviderId.OpenCodeGo;
+            var normalizedCookie = isOpenCode
                 ? CookieHelper.NormalizeCookieHeader(cookieInput)
                 : cookieInput;
-            e.CookieHeader = normalizedCookie ?? cookieInput;
-            if (normalizedCookie != null)
-                CookieHeader = normalizedCookie;
+            e.CookieHeader = isOpenCode ? normalizedCookie : cookieInput;
+            if (isOpenCode)
+                CookieHeader = normalizedCookie ?? "";
             e.WorkspaceId = string.IsNullOrWhiteSpace(WorkspaceId) ? null : WorkspaceId.Trim();
             CredentialStore.Instance.Save();
             Saved = true;

--- a/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
@@ -175,7 +175,7 @@ namespace TaskbarQuota.Views
             var vm = CreateCredentialVm(id);
             var flyout = new Flyout { Placement = FlyoutPlacementMode.Bottom };
 
-            var stack = new StackPanel { Spacing = 12, MaxWidth = 340 };
+            var stack = new StackPanel { Spacing = 12, MaxWidth = 380 };
 
             if (vm.IsApiKey)
             {
@@ -188,12 +188,84 @@ namespace TaskbarQuota.Views
             }
             else
             {
-                var tb = new TextBox { Text = vm.CookieHeader, MinWidth = 280, PlaceholderText = "name1=value1; name2=value2", AcceptsReturn = false };
+                bool isOpenCode = vm.Id is ProviderId.OpenCode or ProviderId.OpenCodeGo;
+                var tb = new TextBox
+                {
+                    Text = vm.CookieHeader,
+                    MinWidth = 280,
+                    PlaceholderText = isOpenCode ? "Cookie value or full copied cURL command" : "name1=value1; name2=value2",
+                    AcceptsReturn = isOpenCode,
+                    TextWrapping = isOpenCode ? TextWrapping.Wrap : TextWrapping.NoWrap,
+                    MaxHeight = isOpenCode ? 120 : double.PositiveInfinity,
+                };
                 tb.TextChanged += (_, _) => vm.CookieHeader = tb.Text;
 
                 stack.Children.Add(new TextBlock { Text = "Cookie header", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold });
                 stack.Children.Add(new TextBlock { Text = "Leave blank to keep auto-detection.", Opacity = 0.6, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
                 stack.Children.Add(tb);
+
+                if (isOpenCode)
+                {
+                    stack.Children.Add(new TextBlock
+                    {
+                        Text = "Chromium 127+ manual setup",
+                        FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+                    });
+                    stack.Children.Add(new TextBlock
+                    {
+                        Text = "Chrome, Edge, and Brave 127+ protect cookies with App-Bound Encryption, so TaskbarQuota may not be able to read them automatically.",
+                        Opacity = 0.6,
+                        TextWrapping = TextWrapping.Wrap,
+                        Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                    });
+                    stack.Children.Add(new TextBlock
+                    {
+                        Text = "1. Open opencode.ai in the browser where you are signed in. Press F12, choose Network, and reload the page.",
+                        Opacity = 0.6,
+                        TextWrapping = TextWrapping.Wrap,
+                        Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                    });
+                    stack.Children.Add(new TextBlock
+                    {
+                        Text = "2. Click an opencode.ai request, right-click it, then choose Copy → Copy as cURL.",
+                        Opacity = 0.6,
+                        TextWrapping = TextWrapping.Wrap,
+                        Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                    });
+                    stack.Children.Add(new TextBlock
+                    {
+                        Text = "3. Paste either the full copied cURL command or only the text after Cookie:. TaskbarQuota extracts the cookie automatically; it should include auth=... or __Host-auth=....",
+                        Opacity = 0.6,
+                        TextWrapping = TextWrapping.Wrap,
+                        Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                    });
+
+                    var workspace = new TextBox
+                    {
+                        Text = vm.WorkspaceId,
+                        MinWidth = 280,
+                        PlaceholderText = "wrk_... or workspace URL",
+                        AcceptsReturn = false,
+                    };
+                    workspace.TextChanged += (_, _) => vm.WorkspaceId = workspace.Text;
+                    stack.Children.Add(new TextBlock { Text = "Workspace ID (optional; usually auto-detected)", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold });
+                    stack.Children.Add(new TextBlock
+                    {
+                        Text = "Only fill this when detection fails or you have multiple workspaces. Copy the wrk_... part from the OpenCode workspace URL; a full workspace URL also works.",
+                        Opacity = 0.6,
+                        TextWrapping = TextWrapping.Wrap,
+                        Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                    });
+                    stack.Children.Add(workspace);
+
+                    stack.Children.Add(new TextBlock
+                    {
+                        Text = "Cookie headers are session credentials. Keep them private.",
+                        Opacity = 0.6,
+                        TextWrapping = TextWrapping.Wrap,
+                        Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                    });
+                }
             }
 
             var saveBtn = new Button { Content = "Save & Refresh", Style = (Style)Application.Current.Resources["AccentButtonStyle"], Margin = new Thickness(0, 4, 0, 0) };
@@ -311,10 +383,10 @@ namespace TaskbarQuota.Views
                 "Paste a cursor.com Cookie header to override browser detection.",
                 CredentialKind.Cookie),
             ProviderId.OpenCode => new ProviderCredentialViewModel(id, "OpenCode",
-                "Paste an opencode.ai Cookie header to override browser detection.",
+                "Paste an opencode.ai Cookie header and optionally select a workspace.",
                 CredentialKind.Cookie),
             ProviderId.OpenCodeGo => new ProviderCredentialViewModel(id, "OpenCode Go",
-                "Paste an opencode.ai Cookie header to override browser detection.",
+                "Paste an opencode.ai Cookie header and optionally select a workspace.",
                 CredentialKind.Cookie),
             ProviderId.Kimi => new ProviderCredentialViewModel(id, "Kimi Code",
                 "Paste your Kimi Code API key (KIMI_CODE_API_KEY) to fetch Coding Plan usage without CLI login.",

--- a/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
@@ -176,6 +176,13 @@ namespace TaskbarQuota.Views
             var flyout = new Flyout { Placement = FlyoutPlacementMode.Bottom };
 
             var stack = new StackPanel { Spacing = 12, MaxWidth = 380 };
+            TextBlock Caption(string text) => new()
+            {
+                Text = text,
+                Opacity = 0.6,
+                TextWrapping = TextWrapping.Wrap,
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            };
 
             if (vm.IsApiKey)
             {
@@ -183,7 +190,7 @@ namespace TaskbarQuota.Views
                 pwd.PasswordChanged += (_, _) => vm.ApiKey = pwd.Password;
 
                 stack.Children.Add(new TextBlock { Text = "API key", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold });
-                stack.Children.Add(new TextBlock { Text = vm.ApiKeyHeader, Opacity = 0.6, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
+                stack.Children.Add(Caption(vm.ApiKeyHeader));
                 stack.Children.Add(pwd);
             }
             else
@@ -201,7 +208,7 @@ namespace TaskbarQuota.Views
                 tb.TextChanged += (_, _) => vm.CookieHeader = tb.Text;
 
                 stack.Children.Add(new TextBlock { Text = "Cookie header", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold });
-                stack.Children.Add(new TextBlock { Text = "Leave blank to keep auto-detection.", Opacity = 0.6, Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"] });
+                stack.Children.Add(Caption("Leave blank to keep auto-detection."));
                 stack.Children.Add(tb);
 
                 if (isOpenCode)
@@ -211,34 +218,10 @@ namespace TaskbarQuota.Views
                         Text = "Chromium 127+ manual setup",
                         FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
                     });
-                    stack.Children.Add(new TextBlock
-                    {
-                        Text = "Chrome, Edge, and Brave 127+ protect cookies with App-Bound Encryption, so TaskbarQuota may not be able to read them automatically.",
-                        Opacity = 0.6,
-                        TextWrapping = TextWrapping.Wrap,
-                        Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-                    });
-                    stack.Children.Add(new TextBlock
-                    {
-                        Text = "1. Open opencode.ai in the browser where you are signed in. Press F12, choose Network, and reload the page.",
-                        Opacity = 0.6,
-                        TextWrapping = TextWrapping.Wrap,
-                        Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-                    });
-                    stack.Children.Add(new TextBlock
-                    {
-                        Text = "2. Click an opencode.ai request, right-click it, then choose Copy → Copy as cURL.",
-                        Opacity = 0.6,
-                        TextWrapping = TextWrapping.Wrap,
-                        Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-                    });
-                    stack.Children.Add(new TextBlock
-                    {
-                        Text = "3. Paste either the full copied cURL command or only the text after Cookie:. TaskbarQuota extracts the cookie automatically; it should include auth=... or __Host-auth=....",
-                        Opacity = 0.6,
-                        TextWrapping = TextWrapping.Wrap,
-                        Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-                    });
+                    stack.Children.Add(Caption("Chrome, Edge, and Brave 127+ protect cookies with App-Bound Encryption, so TaskbarQuota may not be able to read them automatically."));
+                    stack.Children.Add(Caption("1. Open opencode.ai in the browser where you are signed in. Press F12, choose Network, and reload the page."));
+                    stack.Children.Add(Caption("2. Click an opencode.ai request, right-click it, then choose Copy → Copy as cURL."));
+                    stack.Children.Add(Caption("3. Paste either the full copied cURL command or only the text after Cookie:. TaskbarQuota extracts the cookie automatically; it should include auth=... or __Host-auth=...."));
 
                     var workspace = new TextBox
                     {
@@ -249,22 +232,10 @@ namespace TaskbarQuota.Views
                     };
                     workspace.TextChanged += (_, _) => vm.WorkspaceId = workspace.Text;
                     stack.Children.Add(new TextBlock { Text = "Workspace ID (optional; usually auto-detected)", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold });
-                    stack.Children.Add(new TextBlock
-                    {
-                        Text = "Only fill this when detection fails or you have multiple workspaces. Copy the wrk_... part from the OpenCode workspace URL; a full workspace URL also works.",
-                        Opacity = 0.6,
-                        TextWrapping = TextWrapping.Wrap,
-                        Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-                    });
+                    stack.Children.Add(Caption("Only fill this when detection fails or you have multiple workspaces. Copy the wrk_... part from the OpenCode workspace URL; a full workspace URL also works."));
                     stack.Children.Add(workspace);
 
-                    stack.Children.Add(new TextBlock
-                    {
-                        Text = "Cookie headers are session credentials. Keep them private.",
-                        Opacity = 0.6,
-                        TextWrapping = TextWrapping.Wrap,
-                        Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-                    });
+                    stack.Children.Add(Caption("Cookie headers are session credentials. Keep them private."));
                 }
             }
 
@@ -277,7 +248,14 @@ namespace TaskbarQuota.Views
             };
             stack.Children.Add(saveBtn);
 
-            flyout.Content = stack;
+            var maxFlyoutHeight = Math.Min(600, Math.Max(120, (button.XamlRoot?.Size.Height ?? 800) - 40));
+            flyout.Content = new ScrollViewer
+            {
+                Content = stack,
+                MaxHeight = maxFlyoutHeight,
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+            };
             flyout.ShowAt(button);
         }
 
@@ -383,10 +361,10 @@ namespace TaskbarQuota.Views
                 "Paste a cursor.com Cookie header to override browser detection.",
                 CredentialKind.Cookie),
             ProviderId.OpenCode => new ProviderCredentialViewModel(id, "OpenCode",
-                "Paste an opencode.ai Cookie header and optionally select a workspace.",
+                "Paste an opencode.ai Cookie header and optionally enter a Workspace ID (wrk_...).",
                 CredentialKind.Cookie),
             ProviderId.OpenCodeGo => new ProviderCredentialViewModel(id, "OpenCode Go",
-                "Paste an opencode.ai Cookie header and optionally select a workspace.",
+                "Paste an opencode.ai Cookie header and optionally enter a Workspace ID (wrk_...).",
                 CredentialKind.Cookie),
             ProviderId.Kimi => new ProviderCredentialViewModel(id, "Kimi Code",
                 "Paste your Kimi Code API key (KIMI_CODE_API_KEY) to fetch Coding Plan usage without CLI login.",

--- a/tests/TaskbarQuota.Tests/CookieExtractorTests.cs
+++ b/tests/TaskbarQuota.Tests/CookieExtractorTests.cs
@@ -1,0 +1,22 @@
+using TaskbarQuota.Browser;
+
+namespace TaskbarQuota.Tests;
+
+public class CookieExtractorTests
+{
+    [Fact]
+    public void CookieSource_HeaderPreservesSeparateCookiePairs()
+    {
+        var source = new CookieExtractor.CookieSource(
+            "Firefox",
+            "default-release",
+            new[]
+            {
+                (Name: "auth", Value: "session-token"),
+                (Name: "auth.0", Value: "chunk-a"),
+                (Name: "auth.1", Value: "chunk-b"),
+            });
+
+        Assert.Equal("auth=session-token; auth.0=chunk-a; auth.1=chunk-b", source.Header);
+    }
+}

--- a/tests/TaskbarQuota.Tests/OpenCodeGoProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/OpenCodeGoProviderTests.cs
@@ -130,13 +130,6 @@ public class OpenCodeGoProviderTests
         Assert.True(OpenCodeProvider.LooksSignedOut(html));
     }
 
-    [Theory]
-    [InlineData("<title>OpenAuth</title>")]
-    [InlineData("<button>Continue with GitHub</button>")]
-    [InlineData("<button>Continue with Google</button>")]
-    public void LooksSignedOut_WithOpenAuthPage_ReturnsTrue(string html)
-        => Assert.True(OpenCodeProvider.LooksSignedOut(html));
-
     [Fact]
     public void GoPagePayload_ParsesEmbeddedUsageWindows()
     {

--- a/tests/TaskbarQuota.Tests/OpenCodeGoProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/OpenCodeGoProviderTests.cs
@@ -21,10 +21,10 @@ public class OpenCodeGoProviderTests
     }
 
     [Fact]
-    public void Provider_HasCorrectSessionLabel()
+    public void Provider_HasCorrectRollingLabel()
     {
         var provider = new OpenCodeGoProvider();
-        Assert.Equal("Session", provider.SessionLabel);
+        Assert.Equal("Rolling", provider.SessionLabel);
     }
 
     [Fact]
@@ -128,5 +128,24 @@ public class OpenCodeGoProviderTests
     {
         var html = "<html><head><meta http-equiv=\"refresh\" content=\"0;url=/auth/authorize?redirect=/workspace/wrk_123/go\"></head></html>";
         Assert.True(OpenCodeProvider.LooksSignedOut(html));
+    }
+
+    [Theory]
+    [InlineData("<title>OpenAuth</title>")]
+    [InlineData("<button>Continue with GitHub</button>")]
+    [InlineData("<button>Continue with Google</button>")]
+    public void LooksSignedOut_WithOpenAuthPage_ReturnsTrue(string html)
+        => Assert.True(OpenCodeProvider.LooksSignedOut(html));
+
+    [Fact]
+    public void GoPagePayload_ParsesEmbeddedUsageWindows()
+    {
+        var html = "<script>window.__data={rollingUsage:{usagePercent:37.5,resetInSec:7200}," +
+                   "weeklyUsage:{usagePercent:51,resetInSec:172800}," +
+                   "monthlyUsage:{usagePercent:12,resetInSec:1209600}}</script>";
+
+        Assert.Equal(37.5, OpenCodeProvider.ExtractWindow(html, 300, "rollingUsage")!.UsedPercent, 1);
+        Assert.Equal(51, OpenCodeProvider.ExtractWindow(html, 10080, "weeklyUsage")!.UsedPercent, 1);
+        Assert.Equal(12, OpenCodeProvider.ExtractWindow(html, 43200, "monthlyUsage")!.UsedPercent, 1);
     }
 }

--- a/tests/TaskbarQuota.Tests/OpenCodeProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/OpenCodeProviderTests.cs
@@ -6,6 +6,19 @@ namespace TaskbarQuota.Tests;
 
 public class OpenCodeProviderTests
 {
+    [Theory]
+    [InlineData("auth=abc; other=value", "auth=abc; other=value")]
+    [InlineData("Cookie: auth=abc; other=value", "auth=abc; other=value")]
+    [InlineData("curl 'https://opencode.ai/workspace/wrk_abc' -H 'accept: text/html' -H 'cookie: auth=abc; other=value'", "auth=abc; other=value")]
+    [InlineData("curl.exe \"https://opencode.ai\" --header=\"Cookie: __Host-auth=abc; other=value\"", "__Host-auth=abc; other=value")]
+    [InlineData("curl https://opencode.ai --cookie 'auth=abc; other=value'", "auth=abc; other=value")]
+    public void NormalizeCookieHeader_AcceptsRawHeaderOrCopiedCurl(string input, string expected)
+        => Assert.Equal(expected, CookieHelper.NormalizeCookieHeader(input));
+
+    [Fact]
+    public void NormalizeCookieHeader_RejectsCurlWithoutCookies()
+        => Assert.Null(CookieHelper.NormalizeCookieHeader("curl https://opencode.ai/workspace/wrk_abc"));
+
     [Fact]
     public void LooksSignedOut_WithAuthAuthorize_ReturnsTrue()
     {
@@ -41,6 +54,40 @@ public class OpenCodeProviderTests
             OpenCodeProvider.WorkspacePageUrl("wrk_abc123", "/usage"));
     }
 
+    [Theory]
+    [InlineData("wrk_abc123", "wrk_abc123")]
+    [InlineData("https://opencode.ai/workspace/wrk_abc123/go", "wrk_abc123")]
+    [InlineData("  wrk_team-123  ", "wrk_team-123")]
+    [InlineData("not-a-workspace", null)]
+    public void NormalizeWorkspaceId_AcceptsIdsAndWorkspaceUrls(string input, string? expected)
+        => Assert.Equal(expected, OpenCodeProvider.NormalizeWorkspaceId(input));
+
+    [Fact]
+    public void ParseWorkspaceIds_DeduplicatesOccurrences()
+    {
+        var ids = OpenCodeProvider.ParseWorkspaceIds(
+            "id: \"wrk_first\", data: { workspace: \"wrk_second\", again: \"wrk_first\" }");
+
+        Assert.Equal(new[] { "wrk_first", "wrk_second" }, ids);
+    }
+
+    [Fact]
+    public void ParseBillingBalance_ConvertsRawBillingUnitsToUsd()
+    {
+        var balance = OpenCodeProvider.ParseBillingBalance(
+            "{\"customerID\":\"cus_123\",\"balance\":4250000000}");
+
+        Assert.Equal(42.5, balance);
+    }
+
+    [Fact]
+    public void ParseBillingBalance_IgnoresUnscopedBalanceFields()
+    {
+        var balance = OpenCodeProvider.ParseBillingBalance("{\"balance\":4250000000}");
+
+        Assert.Null(balance);
+    }
+
     [Fact]
     public void LooksSignedOut_WithNormalContent_ReturnsFalse()
     {
@@ -53,6 +100,13 @@ public class OpenCodeProviderTests
     {
         Assert.False(OpenCodeProvider.LooksSignedOut(""));
     }
+
+    [Theory]
+    [InlineData("<title>OpenAuth</title>")]
+    [InlineData("<button>Continue with GitHub</button>")]
+    [InlineData("<button>Continue with Google</button>")]
+    public void LooksSignedOut_WithOpenAuthPage_ReturnsTrue(string html)
+        => Assert.True(OpenCodeProvider.LooksSignedOut(html));
 
     [Fact]
     public void FindMoneyValue_WithJsonNumber_ReturnsValue()


### PR DESCRIPTION
## Summary
- read Chromium and Firefox cookie databases directly with SQLite read-only/shared-cache connections
- remove per-read GUID temp database copies and their orphaned journal sidecars
- update the architecture documentation

Fixes #51

## Verification
- dotnet build src/TaskbarQuota.App/TaskbarQuota.App.csproj --no-restore --configuration Debug --runtime win-x64 -p:NodeReuse=false
- full test run builds successfully; one pre-existing CodexProviderTests failure remains
- git diff --check passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Chromium and Firefox cookie data can now be read directly from locked browser databases without creating temporary copies.
  * Existing cookie filtering, decryption, and error handling remain unchanged.
* **Documentation**
  * Updated fetch behavior documentation to reflect direct read-only database access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->