### PR TITLE
Do not show a provider before startup detection

### DIFF
--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -93,17 +93,18 @@ namespace TaskbarQuota
         public ProviderSource ActiveProviderSource => _activeProviderSource;
 
         /// <summary>
-        /// The provider the taskbar widget should display: the active provider when its widget is enabled,
-        /// otherwise the first enabled-and-available provider (most recently active first, then enum order).
-        /// Null when no provider qualifies, in which case the widget hides instead of falling back to a
-        /// hidden default. Fixes the "widget disappears when Codex is disabled / only Cursor enabled" bug
-        /// (the old code hard-coded <see cref="ProviderId.Codex"/> as the fallback). See issue #7.
+        /// The provider the taskbar widget should display when an active provider is known. A missing active
+        /// provider returns null; the widget must not invent one from the installed-provider enum order.
+        /// Pinned providers are handled separately by <see cref="WidgetDisplayProviders"/>.
         /// </summary>
         public ProviderId? WidgetDisplayProvider
         {
             get
             {
-                if (_lastActive is { } active && WidgetSettingsService.IsProviderVisible(active))
+                if (_lastActive is not { } active)
+                    return null;
+
+                if (WidgetSettingsService.IsProviderVisible(active))
                     return active;
                 foreach (var p in RecentProviders)
                     if (WidgetSettingsService.IsProviderVisible(p) && IsProviderAvailable(p))
@@ -128,8 +129,8 @@ namespace TaskbarQuota
         /// So with Claude pinned + Z.AI pinned and Codex active you get "Codex | Claude | Z.AI", and
         /// focusing Claude re-orders to "Claude | Z.AI" + whatever else is pinned — the active provider
         /// keeps the leading slot while the pinned tiles stay put behind it (issue #25).
-        /// With nothing pinned this returns exactly <see cref="WidgetDisplayProvider"/>, so the existing
-        /// single-tile behavior is unchanged.
+        /// With no active provider this returns only pinned providers; with neither an active nor pinned
+        /// provider it is empty, so the taskbar stays clear until detection selects a provider.
         /// </summary>
         public IReadOnlyList<ProviderId> WidgetDisplayProviders
             => ComputeWidgetDisplayProviders(
@@ -139,8 +140,7 @@ namespace TaskbarQuota
                 Enum.GetValues<ProviderId>(),
                 WidgetSettingsService.IsProviderPinned,
                 WidgetSettingsService.IsProviderVisible,
-                IsProviderAvailable,
-                WidgetDisplayProvider);
+                IsProviderAvailable);
 
         /// <summary>Pure, testable core of <see cref="WidgetDisplayProviders"/>.</summary>
         internal static IReadOnlyList<ProviderId> ComputeWidgetDisplayProviders(
@@ -150,8 +150,7 @@ namespace TaskbarQuota
             IReadOnlyList<ProviderId> ordered,
             Func<ProviderId, bool> isPinned,
             Func<ProviderId, bool> isVisible,
-            Func<ProviderId, bool> isAvailable,
-            ProviderId? fallback)
+            Func<ProviderId, bool> isAvailable)
         {
             var result = new List<ProviderId>();
 
@@ -169,11 +168,6 @@ namespace TaskbarQuota
                 .OrderBy(p => recentIndex.TryGetValue(p, out int index) ? index : int.MaxValue)
                 .ToList();
             result.AddRange(pinned);
-
-            // Nothing active and nothing pinned: keep today's single-tile fallback so users with no pins
-            // still see the last-used / first-enabled provider.
-            if (result.Count == 0 && present && fallback is { } fb)
-                result.Add(fb);
 
             if (result.Count > MaxWidgetTiles)
                 result.RemoveRange(MaxWidgetTiles, result.Count - MaxWidgetTiles);

--- a/tests/TaskbarQuota.Tests/WidgetDisplayProvidersTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetDisplayProvidersTests.cs
@@ -16,7 +16,6 @@ public class WidgetDisplayProvidersTests
         IReadOnlyList<ProviderId> pinned,
         IReadOnlyList<ProviderId>? recent = null,
         bool present = true,
-        ProviderId? fallback = null,
         Func<ProviderId, bool>? isVisible = null,
         Func<ProviderId, bool>? isAvailable = null)
         => UsageCoordinator.ComputeWidgetDisplayProviders(
@@ -26,8 +25,7 @@ public class WidgetDisplayProvidersTests
             Enum.GetValues<ProviderId>(),
             p => pinned.Contains(p),
             isVisible ?? (_ => true),
-            isAvailable ?? (_ => true),
-            fallback);
+            isAvailable ?? (_ => true));
 
     [Fact]
     public void ActiveProviderLeadsAndPinnedTrailInRecencyOrder()
@@ -64,14 +62,14 @@ public class WidgetDisplayProvidersTests
     }
 
     [Fact]
-    public void WithoutPinsFallsBackToTheSingleDisplayProvider()
+    public void WithoutActiveProviderOrPins_IsEmptyEvenWhenAToolIsPresent()
     {
         var result = Compute(
             active: null,
             pinned: Array.Empty<ProviderId>(),
-            fallback: ProviderId.Codex);
+            present: true);
 
-        Assert.Equal(new[] { ProviderId.Codex }, result);
+        Assert.Empty(result);
     }
 
     [Fact]
@@ -118,8 +116,7 @@ public class WidgetDisplayProvidersTests
         var result = Compute(
             active: null,
             pinned: Array.Empty<ProviderId>(),
-            present: false,
-            fallback: ProviderId.Codex);
+            present: false);
 
         Assert.Empty(result);
     }


### PR DESCRIPTION
This pull request updates the logic for determining which providers appear in the taskbar widget, especially when no active or pinned providers are present. The main change is to prevent the widget from displaying a fallback provider when there are no active or pinned providers, so the widget remains empty until a provider is selected. Related tests and comments have been updated to match this new behavior.

### Widget display logic changes

* The `WidgetDisplayProvider` property now returns `null` if there is no active provider, and does not invent a fallback provider from the enum order. Pinned providers are handled separately.
* The `WidgetDisplayProviders` property and its computation logic were updated so that, with no active or pinned providers, the widget is empty instead of falling back to a default provider. [[1]](diffhunk://#diff-8dcfbeefd640f71b49b5022e5f6fb42db54a104213a29409f5bdce6e3908f69bL131-R133) [[2]](diffhunk://#diff-8dcfbeefd640f71b49b5022e5f6fb42db54a104213a29409f5bdce6e3908f69bL142-R143) [[3]](diffhunk://#diff-8dcfbeefd640f71b49b5022e5f6fb42db54a104213a29409f5bdce6e3908f69bL153-R153) [[4]](diffhunk://#diff-8dcfbeefd640f71b49b5022e5f6fb42db54a104213a29409f5bdce6e3908f69bL173-L177)

### Test updates

* Tests in `WidgetDisplayProvidersTests.cs` were updated to remove the fallback provider parameter and to check that the widget is empty when there are no active or pinned providers, even if providers are present. [[1]](diffhunk://#diff-d9d658918736cd0080ac7596e83774947f902ac4f2e298a7e30d88927c7b7b2bL19) [[2]](diffhunk://#diff-d9d658918736cd0080ac7596e83774947f902ac4f2e298a7e30d88927c7b7b2bL29-R28) [[3]](diffhunk://#diff-d9d658918736cd0080ac7596e83774947f902ac4f2e298a7e30d88927c7b7b2bL67-R72) [[4]](diffhunk://#diff-d9d658918736cd0080ac7596e83774947f902ac4f2e298a7e30d88927c7b7b2bL121-R119)