### PR TITLE
Fix stale OpenCode widget values when cookies are missing

### DIFF
--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -228,6 +228,20 @@ namespace TaskbarQuota.Controls
                     return;
                 }
 
+                // OpenCode auth failures are not quota data. Render a neutral cookie status instead of
+                // the generic warning bar, which can be mistaken for a stale usage value.
+                if (result.Id is ProviderId.OpenCode or ProviderId.OpenCodeGo
+                    && result.ErrorKind == ProviderErrorKind.AuthRequired)
+                {
+                    _rows = new() { new WidgetUsageRow("Cookies", 0, "needed", HasBar: false) };
+                    RenderRows();
+                    AnimateRender(isFirstReveal, providerSwitch: providerChanged);
+                    var opencodeSourceText = result.Source.IsKnown ? $" {result.Source.ShortViaText}" : "";
+                    ToolTipService.SetToolTip(this,
+                        $"{widgetName}{opencodeSourceText}: {result.Error ?? "No cookies detected. Manual cookie insertion is needed."}");
+                    return;
+                }
+
                 _rows = new()
                 {
                     new WidgetUsageRow(CompactLabel(result.Provider?.SessionLabel ?? "Usage"), 0, "--"),

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -272,10 +272,13 @@ namespace TaskbarQuota.Taskbar
         /// </summary>
         private static UsageResult? HydrateResult(UsageCoordinator coordinator, ProviderId provider)
         {
-            if (coordinator.LastState is { } last && last.Id == provider)
-                return last;
             if (coordinator.Service.TryGetCached(provider, out var cached))
                 return cached;
+            // A failed refresh is cached deliberately. Prefer that current failure over LastState,
+            // which may still contain the previous successful snapshot and would resurrect stale quota
+            // values when the widget is recreated (especially after cookie/auth failures).
+            if (coordinator.LastState is { } last && last.Id == provider)
+                return last;
             if (coordinator.Service.TryGetLastSuccessfulLiveResult(provider, out var lastSuccess))
                 return lastSuccess;
             if (coordinator.Service.Get(provider) is { } usageProvider)

--- a/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
@@ -38,6 +38,13 @@ namespace TaskbarQuota.Usage.Providers
                 var h = CookieExtractor.GetCookieHeader(d);
                 if (!string.IsNullOrEmpty(h)) return h!;
             }
+
+            if (id is ProviderId.OpenCode or ProviderId.OpenCodeGo)
+            {
+                throw new ProviderException(ProviderErrorKind.AuthRequired,
+                    $"No {id switch { ProviderId.OpenCode => "OpenCode", _ => "OpenCode Go" }} cookies detected. Manual cookie insertion is needed. Paste the opencode.ai Cookie header in Fix.");
+            }
+
             throw new ProviderException(ProviderErrorKind.AuthRequired,
                 $"No cookies found for {string.Join("/", domains)}. Sign in via Edge/Chrome or paste a cookie header in credentials.json.");
         }


### PR DESCRIPTION
## Summary
- show a neutral Cookies-needed state for OpenCode auth failures instead of a quota warning bar
- explain that manual opencode.ai Cookie header insertion is required
- prefer the current failure cache over an older successful widget snapshot during hydration

## Verification
- dotnet test tests/TaskbarQuota.Tests/TaskbarQuota.Tests.csproj --no-restore --verbosity minimal (537 passed)
- packaged app launched with winapp run (PID 429548)