### PR TITLE
Add optional floating always-on-top usage window

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,8 +118,10 @@ jobs:
             $requiredXbf = @(
               'MainWindow.xbf',
               'FlyoutWindow.xbf',
+              'FloatingUsageWindow.xbf',
               'Views\DashboardPage.xbf',
-              'Controls\WidgetSummary.xbf'
+              'Controls\WidgetSummary.xbf',
+              'Controls\QuotaWidgetContent.xbf'
             )
             foreach ($rel in $requiredXbf) {
               if (-not (Test-Path (Join-Path $publishDir $rel))) {

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ After detection, usage is fetched from **local credentials** or **provider APIs*
 ### Taskbar widget
 
 - **In-taskbar compact UI** — usage bars and/or percentages injected beside the system tray (reparents a layered WinUI island into `Shell_TrayWnd`).
+- **Floating window option** — alternatively, show the same compact layout in a single semi-transparent always-on-top window (Settings → Usage display). Modes are exclusive; layout, rows, pins, and agent activity apply to both.
 - **All taskbars** — creates a widget on the primary taskbar and every Windows secondary taskbar, with a separately saved drag position for each display.
 - **Follows taskbar layout** — recenters when the taskbar moves, centers, or when Widgets / tray geometry changes.
 - **Draggable placement** — drag to reposition; offset is saved under `%LOCALAPPDATA%\TaskbarQuota\`.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ After detection, usage is fetched from **local credentials** or **provider APIs*
 ### Taskbar widget
 
 - **In-taskbar compact UI** — usage bars and/or percentages injected beside the system tray (reparents a layered WinUI island into `Shell_TrayWnd`).
-- **Floating window option** — alternatively, show the same compact layout in a single semi-transparent always-on-top window (Settings → Appearance → Where to show usage). Modes are exclusive; layout, rows, pins, and agent activity apply to both.
+- **Floating window option** — alternatively, show the same compact layout in a native Desktop Acrylic always-on-top window (Settings → Appearance → Where to show usage). Modes are exclusive; layout, rows, pins, and agent activity apply to both. On the floating window: **scroll wheel** adjusts Acrylic strength; **right-click** returns the widget to the taskbar.
 - **All taskbars** — creates a widget on the primary taskbar and every Windows secondary taskbar, with a separately saved drag position for each display.
 - **Follows taskbar layout** — recenters when the taskbar moves, centers, or when Widgets / tray geometry changes.
 - **Draggable placement** — drag to reposition; offset is saved under `%LOCALAPPDATA%\TaskbarQuota\`.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ After detection, usage is fetched from **local credentials** or **provider APIs*
 ### Taskbar widget
 
 - **In-taskbar compact UI** — usage bars and/or percentages injected beside the system tray (reparents a layered WinUI island into `Shell_TrayWnd`).
-- **Floating window option** — alternatively, show the same compact layout in a single semi-transparent always-on-top window (Settings → Usage display). Modes are exclusive; layout, rows, pins, and agent activity apply to both.
+- **Floating window option** — alternatively, show the same compact layout in a single semi-transparent always-on-top window (Settings → Appearance → Where to show usage). Modes are exclusive; layout, rows, pins, and agent activity apply to both.
 - **All taskbars** — creates a widget on the primary taskbar and every Windows secondary taskbar, with a separately saved drag position for each display.
 - **Follows taskbar layout** — recenters when the taskbar moves, centers, or when Widgets / tray geometry changes.
 - **Draggable placement** — drag to reposition; offset is saved under `%LOCALAPPDATA%\TaskbarQuota\`.

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityModels.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityModels.cs
@@ -44,8 +44,6 @@ public sealed record AgentActivityItem(
 public sealed record AgentActivitySnapshot(IReadOnlyList<AgentActivityItem> Items, IReadOnlyList<AgentActivityItem>? RunItems = null)
 {
     public static readonly TimeSpan CompletedRetention = TimeSpan.FromMinutes(1);
-    public static readonly TimeSpan IdleWaitingRetention = TimeSpan.FromSeconds(90);
-    public static readonly TimeSpan IdleCompletedRetention = TimeSpan.FromSeconds(120);
     public static readonly TimeSpan FailedRetention = TimeSpan.FromMinutes(5);
 
     private IReadOnlyList<AgentActivityItem> SourceItems => RunItems is { Count: > 0 } ? RunItems : Items;
@@ -80,19 +78,13 @@ public sealed record AgentActivitySnapshot(IReadOnlyList<AgentActivityItem> Item
 
     private static AgentActivityItem? ToCompactItem(AgentActivityItem item)
     {
-        if (item.Status is AgentActivityStatus.Working or AgentActivityStatus.Waiting)
+        // Every live state is process-backed. The scanner changes an item to Completed when its process
+        // disappears, so expiring Idle by transcript age hid a still-running agent until it happened to
+        // emit another recognized event.
+        if (item.IsLive)
             return item;
 
         var age = DateTimeOffset.UtcNow - item.UpdatedAt.ToUniversalTime();
-        if (item.Status == AgentActivityStatus.Idle)
-        {
-            if (age <= IdleWaitingRetention)
-                return item;
-            if (age <= IdleCompletedRetention)
-                return item with { Status = AgentActivityStatus.Completed, Step = "Completed" };
-            return null;
-        }
-
         var retention = item.Status switch
         {
             AgentActivityStatus.Failed => FailedRetention,

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -38,7 +38,6 @@ internal sealed class AgentActivityScanner
         var desktopApps = ScanDesktopAgentApps();
         var terminalAgents = ScanTerminalAgentCommands();
         var liveProviders = MergeLiveProviders(desktopApps, terminalAgents);
-        Log.Debug($"[activity] agent discovery: desktop={desktopApps.Values.Sum()}, terminal={terminalAgents.Values.Sum()}");
         var files = new List<(ProviderId Provider, string Path, DateTimeOffset Modified)>();
         bool discoverCandidates = DateTimeOffset.UtcNow - _lastCandidateDiscovery >= CandidateDiscoveryInterval;
         // Process discovery is intentionally the gate for transcript/database work. Most agent
@@ -147,11 +146,15 @@ internal sealed class AgentActivityScanner
             parsed.AddRange(candidateItems);
         }
 
-        return ApplyActiveHostFallback(GroupSessions(parsed))
+        var result = ApplyActiveHostFallback(GroupSessions(parsed))
             .Where(item => item.IsLive || DateTimeOffset.Now - item.UpdatedAt < RecentWindow)
             .OrderByDescending(item => item.IsLive)
             .ThenByDescending(item => item.UpdatedAt)
             .ToArray();
+        var compactCount = new AgentActivitySnapshot(result).CompactItems.Count;
+        Log.Debug($"[activity] scan: desktop={desktopApps.Values.Sum()}, terminal={terminalAgents.Values.Sum()}, "
+            + $"sessions={result.Length}, live={result.Count(item => item.IsLive)}, compact={compactCount}");
+        return result;
     }
 
     private void AddRememberedCandidates(

--- a/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
+++ b/src/TaskbarQuota.App/AgentActivity/AgentActivityScanner.cs
@@ -84,7 +84,7 @@ internal sealed class AgentActivityScanner
         files.RemoveAll(file => file.Provider == ProviderId.Copilot);
         files.AddRange(copilotFiles);
 
-        AddRememberedCandidates(files);
+        AddRememberedCandidates(files, liveProviders);
         var candidates = SelectCandidates(files);
         RememberCandidates(candidates);
 
@@ -158,7 +158,8 @@ internal sealed class AgentActivityScanner
     }
 
     private void AddRememberedCandidates(
-        List<(ProviderId Provider, string Path, DateTimeOffset Modified)> files)
+        List<(ProviderId Provider, string Path, DateTimeOffset Modified)> files,
+        IReadOnlyDictionary<ProviderId, int> liveProviders)
     {
         lock (_candidateGate)
         {
@@ -172,7 +173,8 @@ internal sealed class AgentActivityScanner
                 }
                 var modifiedUtc = File.GetLastWriteTimeUtc(path);
                 var modified = new DateTimeOffset(modifiedUtc, TimeSpan.Zero).ToLocalTime();
-                if (DateTimeOffset.Now - modified > RecentWindow)
+                if (DateTimeOffset.Now - modified > RecentWindow
+                    && !liveProviders.ContainsKey(candidate.Provider))
                 {
                     _knownCandidates.Remove(path);
                     continue;
@@ -218,24 +220,55 @@ internal sealed class AgentActivityScanner
             .OrderByDescending(file => file.Modified)
             .ToArray();
 
+    private sealed class ProcessBackedCandidateAccumulator
+    {
+        private readonly List<(ProviderId Provider, string Path, DateTimeOffset Modified)> _output;
+        private (ProviderId Provider, string Path, DateTimeOffset Modified)? _latest;
+        private bool _addedRecent;
+
+        public ProcessBackedCandidateAccumulator(
+            List<(ProviderId Provider, string Path, DateTimeOffset Modified)> output)
+            => _output = output;
+
+        public void Add(ProviderId provider, string path, DateTime modifiedUtc)
+        {
+            var candidate = (provider, path,
+                new DateTimeOffset(modifiedUtc, TimeSpan.Zero).ToLocalTime());
+            if (_latest is null || candidate.Item3 > _latest.Value.Modified)
+                _latest = candidate;
+            if (DateTime.UtcNow - modifiedUtc <= RecentWindow)
+            {
+                _output.Add(candidate);
+                _addedRecent = true;
+            }
+        }
+
+        public void Complete()
+        {
+            if (!_addedRecent && _latest is { } latest)
+                _output.Add(latest);
+        }
+    }
+
     private void AddRecent(List<(ProviderId, string, DateTimeOffset)> output, string root,
         ProviderId provider, CancellationToken cancellationToken)
     {
         if (!Directory.Exists(root))
             return;
 
+        var candidates = new ProcessBackedCandidateAccumulator(output);
         try
         {
             foreach (var path in Directory.EnumerateFiles(root, "*.jsonl", SearchOption.AllDirectories))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var modified = File.GetLastWriteTimeUtc(path);
-                if (DateTime.UtcNow - modified <= RecentWindow)
-                    output.Add((provider, path, new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
+                candidates.Add(provider, path, modified);
             }
         }
         catch (IOException) { }
         catch (UnauthorizedAccessException) { }
+        candidates.Complete();
     }
 
     private void AddClineSessions(List<(ProviderId, string, DateTimeOffset)> output,
@@ -249,6 +282,7 @@ internal sealed class AgentActivityScanner
         if (!Directory.Exists(sessions))
             return;
 
+        var candidates = new ProcessBackedCandidateAccumulator(output);
         try
         {
             foreach (var path in Directory.EnumerateFiles(sessions, "*.json", SearchOption.AllDirectories))
@@ -268,18 +302,18 @@ internal sealed class AgentActivityScanner
                         modified = messagesModified;
                 }
 
-                if (DateTime.UtcNow - modified <= RecentWindow)
-                    output.Add((ProviderId.Cline, path,
-                        new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
+                candidates.Add(ProviderId.Cline, path, modified);
             }
         }
         catch (IOException) { }
         catch (UnauthorizedAccessException) { }
+        candidates.Complete();
     }
 
     private void AddKimiSessions(List<(ProviderId, string, DateTimeOffset)> output,
         CancellationToken cancellationToken)
     {
+        var candidates = new ProcessBackedCandidateAccumulator(output);
         foreach (var root in KimiHomeCandidates())
         {
             var sessions = Path.Combine(root, "sessions");
@@ -318,14 +352,13 @@ internal sealed class AgentActivityScanner
                         }
                     }
 
-                    if (DateTime.UtcNow - modified <= RecentWindow)
-                        output.Add((ProviderId.Kimi, statePath,
-                            new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
+                    candidates.Add(ProviderId.Kimi, statePath, modified);
                 }
             }
             catch (IOException) { }
             catch (UnauthorizedAccessException) { }
         }
+        candidates.Complete();
     }
 
     private IEnumerable<string> KimiHomeCandidates()
@@ -345,6 +378,7 @@ internal sealed class AgentActivityScanner
     private void AddCopilotSessions(List<(ProviderId, string, DateTimeOffset)> output,
         CancellationToken cancellationToken)
     {
+        var candidates = new ProcessBackedCandidateAccumulator(output);
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
         var configuredUserData = Environment.GetEnvironmentVariable("VSCODE_USER_DATA_DIR");
         var userRoots = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -394,17 +428,14 @@ internal sealed class AgentActivityScanner
                             continue;
 
                         var modified = File.GetLastWriteTimeUtc(path);
-                        if (DateTime.UtcNow - modified <= RecentWindow)
-                        {
-                            output.Add((ProviderId.Copilot, path,
-                                new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
-                        }
+                        candidates.Add(ProviderId.Copilot, path, modified);
                     }
                 }
             }
         }
         catch (IOException) { }
         catch (UnauthorizedAccessException) { }
+        candidates.Complete();
     }
 
     internal static bool TryReadCopilotSession(string path, DateTimeOffset modified, bool claimLive,
@@ -693,6 +724,7 @@ internal sealed class AgentActivityScanner
         if (!Directory.Exists(root))
             return;
 
+        var candidates = new ProcessBackedCandidateAccumulator(output);
         try
         {
             foreach (var summaryPath in Directory.EnumerateFiles(root, "summary.json", SearchOption.AllDirectories))
@@ -714,13 +746,12 @@ internal sealed class AgentActivityScanner
                     }
                 }
 
-                if (DateTime.UtcNow - modified <= RecentWindow)
-                    output.Add((ProviderId.Grok, summaryPath,
-                        new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
+                candidates.Add(ProviderId.Grok, summaryPath, modified);
             }
         }
         catch (IOException) { }
         catch (UnauthorizedAccessException) { }
+        candidates.Complete();
     }
 
     private void AddAntigravityDatabases(List<(ProviderId, string, DateTimeOffset)> output,
@@ -731,6 +762,7 @@ internal sealed class AgentActivityScanner
         if (!Directory.Exists(conversations))
             return;
 
+        var candidates = new ProcessBackedCandidateAccumulator(output);
         try
         {
             foreach (var path in Directory.EnumerateFiles(conversations, "*.db", SearchOption.TopDirectoryOnly))
@@ -745,13 +777,12 @@ internal sealed class AgentActivityScanner
                         modified = walModified;
                 }
 
-                if (DateTime.UtcNow - modified <= RecentWindow)
-                    output.Add((ProviderId.Antigravity, path,
-                        new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
+                candidates.Add(ProviderId.Antigravity, path, modified);
             }
         }
         catch (IOException) { }
         catch (UnauthorizedAccessException) { }
+        candidates.Complete();
     }
 
     private static string GetAntigravityCliHome()
@@ -777,19 +808,19 @@ internal sealed class AgentActivityScanner
         if (!Directory.Exists(root))
             return;
 
+        var candidates = new ProcessBackedCandidateAccumulator(output);
         try
         {
             foreach (var path in Directory.EnumerateFiles(root, "transcript.jsonl", SearchOption.AllDirectories))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var modified = File.GetLastWriteTimeUtc(path);
-                if (DateTime.UtcNow - modified <= RecentWindow)
-                    output.Add((ProviderId.Antigravity, path,
-                        new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
+                candidates.Add(ProviderId.Antigravity, path, modified);
             }
         }
         catch (IOException) { }
         catch (UnauthorizedAccessException) { }
+        candidates.Complete();
     }
 
     private static bool IsAntigravityGuiTranscript(string path)
@@ -894,7 +925,7 @@ internal sealed class AgentActivityScanner
                 "parent_conversation_id", "parentConversationId", "parent_thread_id");
             var lastActivity = Max(modified, metadata?.UpdatedAt ?? modified);
             var fresh = DateTimeOffset.Now - lastActivity < BusyWindow;
-            var live = claimLive && modified > DateTimeOffset.Now - RecentWindow;
+            var live = claimLive;
             var waiting = AntigravityContainsAny(rows.Select(row => row.Permissions),
                 "permission", "approval", "confirmation", "waiting_for_user", "request_user_input")
                 || AntigravityContainsAny(blobs,
@@ -966,7 +997,7 @@ internal sealed class AgentActivityScanner
 
             var lastActivity = Max(modified, info.LastActivity ?? modified);
             var fresh = DateTimeOffset.Now - lastActivity < BusyWindow;
-            var live = claimLive && modified > DateTimeOffset.Now - RecentWindow;
+            var live = claimLive;
             var status = !live
                 ? info.State == TranscriptState.Failed ? AgentActivityStatus.Failed : AgentActivityStatus.Completed
                 : info.State == TranscriptState.Waiting
@@ -1424,8 +1455,8 @@ internal sealed class AgentActivityScanner
                             modified = companionModified;
                     }
                 }
-                if (DateTime.UtcNow - modified <= RecentWindow)
-                    output.Add((ProviderId.Zai, path, new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
+                output.Add((ProviderId.Zai, path,
+                    new DateTimeOffset(modified, TimeSpan.Zero).ToLocalTime()));
             }
             catch (IOException) { }
             catch (UnauthorizedAccessException) { }
@@ -1453,11 +1484,12 @@ internal sealed class AgentActivityScanner
                 SELECT id, parent_id, title, time_created, time_updated,
                        COALESCE((SELECT status FROM session_target st WHERE st.session_id = session.id), '')
                 FROM session
-                WHERE COALESCE(time_updated, time_created, 0) >= $cutoff
+                WHERE $claimLive = 1 OR COALESCE(time_updated, time_created, 0) >= $cutoff
                 ORDER BY time_updated DESC, time_created DESC
                 LIMIT 80;
                 """;
             command.Parameters.AddWithValue("$cutoff", DateTimeOffset.Now.Add(-RecentWindow).ToUnixTimeMilliseconds());
+            command.Parameters.AddWithValue("$claimLive", claimLive ? 1 : 0);
 
             var sessions = new List<ZcodeSessionRow>();
             using (var reader = command.ExecuteReader())
@@ -1609,7 +1641,7 @@ internal sealed class AgentActivityScanner
             bool freshAgentEvent = info.LastActivity is { } activity && DateTimeOffset.Now - activity < BusyWindow;
             // One desktop provider process can host several concurrent threads. The process claim marks
             // the session live; transcript timestamps then distinguish working from quiet/idle.
-            bool live = claimLive && modified > DateTimeOffset.Now - RecentWindow;
+            bool live = claimLive;
             bool busy = live && freshAgentEvent;
             // Process liveness is authoritative: a quiet live process is idle, not completed. This is the
             // same busy/idle/done model used by agent-notch and avoids treating Claude's interactive shell
@@ -1693,7 +1725,7 @@ internal sealed class AgentActivityScanner
             title = FirstNonEmpty(title, SummarizeTitle(prompt) ?? "Cline");
             model = FirstNonEmpty(model, tail.Model);
             var lastActivity = Max(modified, tail.LastActivity ?? modified);
-            var live = claimLive && modified > DateTimeOffset.Now - RecentWindow;
+            var live = claimLive;
             var fresh = DateTimeOffset.Now - lastActivity < BusyWindow;
             var failed = statusText.Contains("fail", StringComparison.Ordinal)
                 || statusText.Contains("error", StringComparison.Ordinal)
@@ -1871,7 +1903,7 @@ internal sealed class AgentActivityScanner
                 SummarizeTitle(tail.Prompt) ?? "",
                 "Kimi");
             var lastActivity = Max(modified, tail.LastActivity ?? modified);
-            var live = claimLive && modified > DateTimeOffset.Now - RecentWindow;
+            var live = claimLive;
             var fresh = DateTimeOffset.Now - lastActivity < BusyWindow;
             var status = !live
                 ? tail.State == TranscriptState.Failed ? AgentActivityStatus.Failed : AgentActivityStatus.Completed
@@ -2040,7 +2072,7 @@ internal sealed class AgentActivityScanner
             var lastActivity = Max(modified, summaryUpdatedAt ?? modified,
                 historyInfo.LastActivity ?? modified, eventInfo.LastActivity ?? modified);
             var fresh = DateTimeOffset.Now - lastActivity < BusyWindow;
-            var live = claimLive && modified > DateTimeOffset.Now - RecentWindow;
+            var live = claimLive;
             var state = eventInfo.State != TranscriptState.Unknown ? eventInfo.State : historyInfo.State;
             var status = !live
                 ? state == TranscriptState.Failed ? AgentActivityStatus.Failed : AgentActivityStatus.Completed
@@ -2443,11 +2475,12 @@ internal sealed class AgentActivityScanner
             command.CommandText = """
                 SELECT id, parent_id, title, model, time_created, time_updated
                 FROM session
-                WHERE COALESCE(time_updated, time_created, 0) >= $cutoff
+                WHERE $claimLive = 1 OR COALESCE(time_updated, time_created, 0) >= $cutoff
                 ORDER BY time_updated DESC, time_created DESC
                 LIMIT 80;
                 """;
             command.Parameters.AddWithValue("$cutoff", DateTimeOffset.Now.Add(-RecentWindow).ToUnixTimeMilliseconds());
+            command.Parameters.AddWithValue("$claimLive", claimLive ? 1 : 0);
 
             var sessions = new List<OpenCodeSessionRow>();
             using (var reader = command.ExecuteReader())

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -26,6 +26,11 @@ public sealed partial class AgentActivitySummary : UserControl
     public const int MinimumLogicalWidth = 120;
     public event Action<AgentActivityItem?>? Clicked;
     public bool SuppressNextClick { get; set; }
+
+    /// <summary>
+    /// When true, colors follow the app/window theme (floating HUD) instead of the system taskbar palette.
+    /// </summary>
+    public bool UseApplicationChromeColors { get; set; }
     public AgentActivityItem? FollowedItem { get; private set; }
     private string? _followedId;
     private AgentActivitySnapshot _snapshot = new(Array.Empty<AgentActivityItem>());
@@ -52,6 +57,7 @@ public sealed partial class AgentActivitySummary : UserControl
             _wheelGestureActive = false;
         };
         Loaded += (_, _) => ApplyForeground();
+        ActualThemeChanged += (_, _) => ApplyForeground();
         PointerWheelChanged += AgentActivitySummary_PointerWheelChanged;
     }
 
@@ -308,9 +314,12 @@ public sealed partial class AgentActivitySummary : UserControl
 
     private void ApplyForeground()
     {
-        bool light = Interop.SystemInfos.IsSystemLightThemeUsed() == true;
+        bool light = UseApplicationChromeColors
+            ? ThemeService.IsLightChrome(this)
+            : Interop.SystemInfos.IsSystemLightThemeUsed() == true;
         var brush = new SolidColorBrush(light ? Color.FromArgb(255, 28, 28, 28) : Colors.White);
         StepText.Foreground = brush;
         TitleText.Foreground = brush;
+        AgentPositionText.Foreground = brush;
     }
 }

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -26,6 +26,11 @@ public sealed partial class AgentActivitySummary : UserControl
     public const int MinimumLogicalWidth = 120;
     public event Action<AgentActivityItem?>? Clicked;
     public bool SuppressNextClick { get; set; }
+    /// <summary>
+    /// Whether vertical wheel input moves between agents. Floating mode disables this because its host
+    /// owns the wheel gesture for Acrylic strength; the Previous/Next buttons remain available.
+    /// </summary>
+    public bool IsWheelNavigationEnabled { get; set; } = true;
 
     /// <summary>
     /// When true, colors follow the app/window theme (floating HUD) instead of the system taskbar palette.
@@ -122,6 +127,9 @@ public sealed partial class AgentActivitySummary : UserControl
 
     private void AgentActivitySummary_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
     {
+        if (!IsWheelNavigationEnabled)
+            return;
+
         var properties = e.GetCurrentPoint(this).Properties;
         int delta = properties.MouseWheelDelta;
         if (delta == 0 || properties.IsHorizontalMouseWheel)

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -26,11 +26,6 @@ public sealed partial class AgentActivitySummary : UserControl
     public const int MinimumLogicalWidth = 120;
     public event Action<AgentActivityItem?>? Clicked;
     public bool SuppressNextClick { get; set; }
-    /// <summary>
-    /// Whether vertical wheel input moves between agents. Floating mode disables this because its host
-    /// owns the wheel gesture for Acrylic strength; the Previous/Next buttons remain available.
-    /// </summary>
-    public bool IsWheelNavigationEnabled { get; set; } = true;
 
     /// <summary>
     /// When true, colors follow the app/window theme (floating HUD) instead of the system taskbar palette.
@@ -127,9 +122,6 @@ public sealed partial class AgentActivitySummary : UserControl
 
     private void AgentActivitySummary_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
     {
-        if (!IsWheelNavigationEnabled)
-            return;
-
         var properties = e.GetCurrentPoint(this).Properties;
         int delta = properties.MouseWheelDelta;
         if (delta == 0 || properties.IsHorizontalMouseWheel)

--- a/src/TaskbarQuota.App/Controls/QuotaWidgetContent.xaml
+++ b/src/TaskbarQuota.App/Controls/QuotaWidgetContent.xaml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="TaskbarQuota.Controls.QuotaWidgetContent"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:TaskbarQuota.Controls">
+
+    <Grid x:Name="Root" Background="Transparent" MinHeight="40" VerticalAlignment="Center">
+        <StackPanel x:Name="Row"
+                    Orientation="Horizontal"
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Left"
+                    Spacing="0">
+            <StackPanel x:Name="QuotaPanel"
+                        Orientation="Horizontal"
+                        VerticalAlignment="Center"
+                        Spacing="0"/>
+            <controls:AgentActivitySummary x:Name="ActivitySummary"
+                                           Margin="8,0,0,0"
+                                           VerticalAlignment="Center"
+                                           Visibility="Collapsed"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/TaskbarQuota.App/Controls/QuotaWidgetContent.xaml
+++ b/src/TaskbarQuota.App/Controls/QuotaWidgetContent.xaml
@@ -5,7 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:TaskbarQuota.Controls">
 
-    <Grid x:Name="Root" Background="Transparent" MinHeight="40" VerticalAlignment="Center">
+    <Grid x:Name="Root" Background="Transparent" MinHeight="48" VerticalAlignment="Center">
         <StackPanel x:Name="Row"
                     Orientation="Horizontal"
                     VerticalAlignment="Center"

--- a/src/TaskbarQuota.App/Controls/QuotaWidgetContent.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/QuotaWidgetContent.xaml.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using TaskbarQuota.AgentActivity;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.Controls;
+
+/// <summary>
+/// Multi-tile usage strip (and optional agent-activity summary) for the floating always-on-top window.
+/// Mirrors the taskbar widget's tile pool, separators, and width math without taskbar gap fitting.
+/// </summary>
+public sealed partial class QuotaWidgetContent : UserControl
+{
+    private const int TileHorizontalMarginLogicalPx = 4;
+    private const int TileSeparatorLogicalPx = 7;
+    private const int ActivitySummaryMarginLogicalPx = 8;
+    private const int DefaultHostLogicalWidth = 172;
+    private const int HostLogicalHeight = 40;
+    private const int ActivityLogicalWidth = 200;
+
+    private readonly WidgetSummary[] _tiles = new WidgetSummary[UsageCoordinator.MaxWidgetTiles];
+    private readonly TextBlock[] _separators = new TextBlock[UsageCoordinator.MaxWidgetTiles - 1];
+    private readonly ProviderId?[] _tileProviders = new ProviderId?[UsageCoordinator.MaxWidgetTiles];
+    private ProviderId? _activeProvider;
+    private AgentActivitySnapshot _activitySnapshot = new(Array.Empty<AgentActivityItem>());
+    private int _desiredLogicalWidth = DefaultHostLogicalWidth;
+    private bool _built;
+
+    public event Action? Clicked;
+    public event Action<AgentActivityItem?>? ActivityClicked;
+    public event Action<int, int>? DesiredSizeChanged;
+
+    /// <summary>Supplies a seed snapshot when a slot is reassigned so the tile paints immediately.</summary>
+    public Func<ProviderId, UsageResult?>? HydrateProvider { get; set; }
+
+    public int DesiredLogicalWidth => _desiredLogicalWidth;
+    public int DesiredLogicalHeight => HostLogicalHeight;
+
+    public QuotaWidgetContent()
+    {
+        InitializeComponent();
+        ActivitySummary.UseApplicationChromeColors = true;
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        BuildTiles();
+        // Subscribe once per load; Unloaded tears these down.
+        ActivitySummary.Clicked -= OnActivityClicked;
+        ActivitySummary.Clicked += OnActivityClicked;
+        WidgetSettingsService.Changed -= OnWidgetSettingsChanged;
+        WidgetSettingsService.Changed += OnWidgetSettingsChanged;
+        // A hide/show cycle of the floating window can fire Unloaded without clearing tile state.
+        // Re-assert visibility so activity + quota tiles never stay stuck at Opacity 0.
+        EnsureVisibleContent();
+        RecomputeLayout();
+    }
+
+    /// <summary>Forces every assigned tile (and activity, when shown) back onto the screen.</summary>
+    public void EnsureVisibleContent()
+    {
+        if (!_built)
+            BuildTiles();
+
+        for (int i = 0; i < _tiles.Length; i++)
+        {
+            if (_tileProviders[i] is null || _tiles[i] is null)
+                continue;
+
+            _tiles[i].Visibility = Visibility.Visible;
+            _tiles[i].SetActiveToolVisible(true);
+        }
+
+        bool showActivity = WidgetSettingsService.ShowAgentActivityInWidget
+            && _activitySnapshot.Primary is not null;
+        ActivitySummary.Visibility = showActivity ? Visibility.Visible : Visibility.Collapsed;
+        if (showActivity)
+            ActivitySummary.Apply(_activitySnapshot, _activeProvider);
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        WidgetSettingsService.Changed -= OnWidgetSettingsChanged;
+        ActivitySummary.Clicked -= OnActivityClicked;
+    }
+
+    private void OnWidgetSettingsChanged(object? sender, EventArgs e)
+        => DispatcherQueue.TryEnqueue(() =>
+        {
+            EnsureVisibleContent();
+            RecomputeLayout();
+        });
+
+    private void BuildTiles()
+    {
+        if (_built)
+            return;
+
+        QuotaPanel.Children.Clear();
+        for (int i = 0; i < _tiles.Length; i++)
+        {
+            if (i > 0)
+            {
+                var separator = CreateSeparator();
+                _separators[i - 1] = separator;
+                QuotaPanel.Children.Add(separator);
+            }
+
+            var tile = CreateTile();
+            _tiles[i] = tile;
+            QuotaPanel.Children.Add(tile);
+        }
+
+        _built = true;
+    }
+
+    private WidgetSummary CreateTile()
+    {
+        var summary = new WidgetSummary
+        {
+            Margin = new Thickness(2, 0, 2, 0),
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Visibility = Visibility.Collapsed,
+            UseApplicationChromeColors = true,
+        };
+        summary.DesiredHostWidthChanged += _ => RecomputeLayout();
+        summary.Clicked += () => Clicked?.Invoke();
+        return summary;
+    }
+
+    private static TextBlock CreateSeparator() => new()
+    {
+        Text = "|",
+        Width = TileSeparatorLogicalPx,
+        FontSize = 12,
+        Opacity = 0.35,
+        TextAlignment = TextAlignment.Center,
+        HorizontalAlignment = HorizontalAlignment.Center,
+        VerticalAlignment = VerticalAlignment.Center,
+        Visibility = Visibility.Collapsed,
+        IsHitTestVisible = false,
+        Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+    };
+
+    private void OnActivityClicked(AgentActivityItem? item) => ActivityClicked?.Invoke(item);
+
+    public void SetDisplayProviders(IReadOnlyList<ProviderId> providers, ProviderId? activeProvider)
+    {
+        providers = providers.Distinct().Take(UsageCoordinator.MaxWidgetTiles).ToArray();
+        _activeProvider = activeProvider;
+
+        if (!_built)
+            BuildTiles();
+
+        for (int i = 0; i < _tiles.Length; i++)
+        {
+            ProviderId? desired = i < providers.Count ? providers[i] : null;
+            if (_tileProviders[i] == desired)
+                continue;
+
+            _tileProviders[i] = desired;
+            if (desired is { } provider && HydrateProvider?.Invoke(provider) is { } seed)
+            {
+                _tiles[i].SuppressNextTransition = true;
+                _tiles[i].Apply(seed, force: true);
+            }
+        }
+
+        ActivitySummary.Apply(_activitySnapshot, _activeProvider);
+        RecomputeLayout();
+    }
+
+    public void ApplyResult(UsageResult result, bool force = false)
+    {
+        for (int i = 0; i < _tiles.Length; i++)
+        {
+            if (_tileProviders[i] != result.Id)
+                continue;
+
+            _tiles[i].Apply(result, force);
+            _tiles[i].SetActiveToolVisible(true);
+            RecomputeLayout();
+            return;
+        }
+    }
+
+    public void SetActivitySnapshot(AgentActivitySnapshot snapshot)
+    {
+        _activitySnapshot = snapshot;
+        ActivitySummary.Apply(snapshot, _activeProvider);
+        foreach (var tile in _tiles)
+            tile?.SetAgentActivity(snapshot);
+        RecomputeLayout();
+    }
+
+    public void MeasureDesiredSize(out int logicalWidth, out int logicalHeight)
+    {
+        RecomputeLayout();
+        logicalWidth = _desiredLogicalWidth;
+        logicalHeight = HostLogicalHeight;
+    }
+
+    private void RecomputeLayout()
+    {
+        if (!_built)
+            return;
+
+        bool showActivity = WidgetSettingsService.ShowAgentActivityInWidget
+            && _activitySnapshot.Primary is not null;
+
+        int total = 0;
+        int shownCount = 0;
+        for (int i = 0; i < _tiles.Length; i++)
+        {
+            bool shown = _tileProviders[i] is not null;
+            _tiles[i].Visibility = shown ? Visibility.Visible : Visibility.Collapsed;
+            _tiles[i].SetActiveToolVisible(shown);
+            if (!shown)
+                continue;
+
+            int width = _tiles[i].MeasureDesiredWidth();
+            if (_tileProviders[i] is { } provider)
+                Taskbar.TaskbarSpace.RecordTileWidth(provider, width);
+
+            total += width + TileHorizontalMarginLogicalPx + (shownCount > 0 ? TileSeparatorLogicalPx : 0);
+            shownCount++;
+        }
+
+        for (int i = 0; i < _separators.Length; i++)
+        {
+            bool showSep = _tileProviders[i] is not null && _tileProviders[i + 1] is not null;
+            _separators[i].Visibility = showSep ? Visibility.Visible : Visibility.Collapsed;
+            _separators[i].Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"];
+        }
+
+        if (showActivity)
+        {
+            ActivitySummary.Visibility = Visibility.Visible;
+            ActivitySummary.SetLogicalWidth(ActivityLogicalWidth);
+            total += ActivityLogicalWidth + ActivitySummaryMarginLogicalPx;
+        }
+        else
+        {
+            ActivitySummary.Visibility = Visibility.Collapsed;
+        }
+
+        if (total <= 0)
+            total = DefaultHostLogicalWidth;
+
+        if (total == _desiredLogicalWidth)
+            return;
+
+        _desiredLogicalWidth = total;
+        DesiredSizeChanged?.Invoke(_desiredLogicalWidth, HostLogicalHeight);
+    }
+}

--- a/src/TaskbarQuota.App/Controls/QuotaWidgetContent.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/QuotaWidgetContent.xaml.cs
@@ -69,6 +69,7 @@ public sealed partial class QuotaWidgetContent : UserControl
     {
         InitializeComponent();
         ActivitySummary.UseApplicationChromeColors = true;
+        ActivitySummary.IsWheelNavigationEnabled = false;
         _activityEmptySnapshotTimer = new DispatcherTimer { Interval = EmptyActivityGrace };
         _activityEmptySnapshotTimer.Tick += ActivityEmptySnapshotTimer_Tick;
         Loaded += OnLoaded;

--- a/src/TaskbarQuota.App/Controls/QuotaWidgetContent.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/QuotaWidgetContent.xaml.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using Windows.UI;
 using TaskbarQuota.AgentActivity;
 using TaskbarQuota.Usage;
 
@@ -135,7 +137,7 @@ public sealed partial class QuotaWidgetContent : UserControl
         return summary;
     }
 
-    private static TextBlock CreateSeparator() => new()
+    private TextBlock CreateSeparator() => new()
     {
         Text = "|",
         Width = TileSeparatorLogicalPx,
@@ -146,8 +148,17 @@ public sealed partial class QuotaWidgetContent : UserControl
         VerticalAlignment = VerticalAlignment.Center,
         Visibility = Visibility.Collapsed,
         IsHitTestVisible = false,
-        Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+        Foreground = SeparatorBrush(),
     };
+
+    /// <summary>
+    /// Separator color from the floating window chrome theme — not Application.Current resources,
+    /// which resolve against app/system theme and go light-on-light when the HUD is light.
+    /// </summary>
+    private Brush SeparatorBrush()
+        => new SolidColorBrush(ThemeService.IsLightChrome(this)
+            ? Color.FromArgb(255, 28, 28, 28)
+            : Colors.White);
 
     private void OnActivityClicked(AgentActivityItem? item) => ActivityClicked?.Invoke(item);
 
@@ -233,11 +244,12 @@ public sealed partial class QuotaWidgetContent : UserControl
             shownCount++;
         }
 
+        var separatorBrush = SeparatorBrush();
         for (int i = 0; i < _separators.Length; i++)
         {
             bool showSep = _tileProviders[i] is not null && _tileProviders[i + 1] is not null;
             _separators[i].Visibility = showSep ? Visibility.Visible : Visibility.Collapsed;
-            _separators[i].Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"];
+            _separators[i].Foreground = separatorBrush;
         }
 
         if (showActivity)

--- a/src/TaskbarQuota.App/Controls/QuotaWidgetContent.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/QuotaWidgetContent.xaml.cs
@@ -69,7 +69,6 @@ public sealed partial class QuotaWidgetContent : UserControl
     {
         InitializeComponent();
         ActivitySummary.UseApplicationChromeColors = true;
-        ActivitySummary.IsWheelNavigationEnabled = false;
         _activityEmptySnapshotTimer = new DispatcherTimer { Interval = EmptyActivityGrace };
         _activityEmptySnapshotTimer.Tick += ActivityEmptySnapshotTimer_Tick;
         ActualThemeChanged += (_, _) => RecomputeLayout();

--- a/src/TaskbarQuota.App/Controls/QuotaWidgetContent.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/QuotaWidgetContent.xaml.cs
@@ -21,15 +21,29 @@ public sealed partial class QuotaWidgetContent : UserControl
     private const int TileSeparatorLogicalPx = 7;
     private const int ActivitySummaryMarginLogicalPx = 8;
     private const int DefaultHostLogicalWidth = 172;
-    private const int HostLogicalHeight = 40;
-    private const int ActivityLogicalWidth = 200;
+    /// <summary>Floating host has room for multi-row tiles + activity lines; taskbar stays ~40.</summary>
+    private const int HostLogicalHeight = 48;
+    /// <summary>Slack so measured glyphs/separators are not flush against the chrome edge.</summary>
+    private const int ContentWidthSlackLogicalPx = 8;
+    /// <summary>
+    /// Floating mode is not gap-constrained — use the full preferred activity width so text is not cut.
+    /// </summary>
+    private const int ActivityLogicalWidth = AgentActivitySummary.DesiredLogicalWidth;
+    /// <summary>
+    /// Discovery can publish an empty intermediate snapshot while rescanning. Match the taskbar
+    /// widget: keep the last non-empty activity visible briefly instead of blinking out.
+    /// </summary>
+    private static readonly TimeSpan EmptyActivityGrace = TimeSpan.FromMilliseconds(900);
 
     private readonly WidgetSummary[] _tiles = new WidgetSummary[UsageCoordinator.MaxWidgetTiles];
     private readonly TextBlock[] _separators = new TextBlock[UsageCoordinator.MaxWidgetTiles - 1];
     private readonly ProviderId?[] _tileProviders = new ProviderId?[UsageCoordinator.MaxWidgetTiles];
     private ProviderId? _activeProvider;
     private AgentActivitySnapshot _activitySnapshot = new(Array.Empty<AgentActivityItem>());
+    private AgentActivitySnapshot? _pendingEmptyActivitySnapshot;
+    private readonly DispatcherTimer _activityEmptySnapshotTimer;
     private int _desiredLogicalWidth = DefaultHostLogicalWidth;
+    private int _desiredLogicalHeight = HostLogicalHeight;
     private bool _built;
 
     public event Action? Clicked;
@@ -40,12 +54,23 @@ public sealed partial class QuotaWidgetContent : UserControl
     public Func<ProviderId, UsageResult?>? HydrateProvider { get; set; }
 
     public int DesiredLogicalWidth => _desiredLogicalWidth;
-    public int DesiredLogicalHeight => HostLogicalHeight;
+    public int DesiredLogicalHeight => _desiredLogicalHeight;
+    /// <summary>
+    /// True when the activity strip is backed by the snapshot currently applied to the control. This may
+    /// intentionally remain true during <see cref="EmptyActivityGrace"/> even when the latest service
+    /// snapshot is empty.
+    /// </summary>
+    public bool HasVisibleActivity => WidgetSettingsService.ShowAgentActivityInWidget
+        && _activitySnapshot.Primary is not null;
+    public bool HasVisibleContent => _tileProviders.Any(provider => provider is not null)
+        || HasVisibleActivity;
 
     public QuotaWidgetContent()
     {
         InitializeComponent();
         ActivitySummary.UseApplicationChromeColors = true;
+        _activityEmptySnapshotTimer = new DispatcherTimer { Interval = EmptyActivityGrace };
+        _activityEmptySnapshotTimer.Tick += ActivityEmptySnapshotTimer_Tick;
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
     }
@@ -79,17 +104,16 @@ public sealed partial class QuotaWidgetContent : UserControl
             _tiles[i].SetActiveToolVisible(true);
         }
 
-        bool showActivity = WidgetSettingsService.ShowAgentActivityInWidget
-            && _activitySnapshot.Primary is not null;
-        ActivitySummary.Visibility = showActivity ? Visibility.Visible : Visibility.Collapsed;
-        if (showActivity)
-            ActivitySummary.Apply(_activitySnapshot, _activeProvider);
+        ApplyActivityToControl();
+        // First show / hide thrash can leave the host sized to the empty default; re-measure now.
+        RecomputeLayout();
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
         WidgetSettingsService.Changed -= OnWidgetSettingsChanged;
         ActivitySummary.Clicked -= OnActivityClicked;
+        _activityEmptySnapshotTimer.Stop();
     }
 
     private void OnWidgetSettingsChanged(object? sender, EventArgs e)
@@ -162,6 +186,30 @@ public sealed partial class QuotaWidgetContent : UserControl
 
     private void OnActivityClicked(AgentActivityItem? item) => ActivityClicked?.Invoke(item);
 
+    /// <summary>
+    /// Call when a pointer gesture became a drag so child buttons/tiles do not fire Click after release.
+    /// </summary>
+    public void SuppressNextClicks()
+    {
+        ActivitySummary.SuppressNextClick = true;
+        for (int i = 0; i < _tiles.Length; i++)
+        {
+            if (_tiles[i] is { } tile)
+                tile.SuppressNextClick = true;
+        }
+    }
+
+    /// <summary>Clears drag-only click suppression after the release event has finished routing.</summary>
+    public void ClearSuppressedClicks()
+    {
+        ActivitySummary.SuppressNextClick = false;
+        for (int i = 0; i < _tiles.Length; i++)
+        {
+            if (_tiles[i] is { } tile)
+                tile.SuppressNextClick = false;
+        }
+    }
+
     public void SetDisplayProviders(IReadOnlyList<ProviderId> providers, ProviderId? activeProvider)
     {
         providers = providers.Distinct().Take(UsageCoordinator.MaxWidgetTiles).ToArray();
@@ -184,7 +232,7 @@ public sealed partial class QuotaWidgetContent : UserControl
             }
         }
 
-        ActivitySummary.Apply(_activitySnapshot, _activeProvider);
+        ApplyActivityToControl();
         RecomputeLayout();
     }
 
@@ -204,18 +252,91 @@ public sealed partial class QuotaWidgetContent : UserControl
 
     public void SetActivitySnapshot(AgentActivitySnapshot snapshot)
     {
+        if (!_built)
+            BuildTiles();
+
+        // Match TaskBarWidget: discovery can publish an empty intermediate scan. Keep the previous
+        // non-empty activity visible for a short grace period so the strip does not blink out.
+        if (snapshot.Primary is null && _activitySnapshot.Primary is not null)
+        {
+            _pendingEmptyActivitySnapshot = snapshot;
+            _activityEmptySnapshotTimer.Stop();
+            _activityEmptySnapshotTimer.Start();
+            return;
+        }
+
+        _activityEmptySnapshotTimer.Stop();
+        _pendingEmptyActivitySnapshot = null;
+        ApplyActivitySnapshot(snapshot);
+    }
+
+    private void ActivityEmptySnapshotTimer_Tick(object? sender, object e)
+    {
+        _activityEmptySnapshotTimer.Stop();
+        if (_pendingEmptyActivitySnapshot is not { } snapshot)
+            return;
+
+        _pendingEmptyActivitySnapshot = null;
+        ApplyActivitySnapshot(snapshot);
+    }
+
+    private void ApplyActivitySnapshot(AgentActivitySnapshot snapshot)
+    {
         _activitySnapshot = snapshot;
-        ActivitySummary.Apply(snapshot, _activeProvider);
+        ApplyActivityToControl();
         foreach (var tile in _tiles)
             tile?.SetAgentActivity(snapshot);
         RecomputeLayout();
+    }
+
+    private void ApplyActivityToControl()
+    {
+        bool showActivity = HasVisibleActivity;
+
+        if (!showActivity)
+        {
+            ActivitySummary.Visibility = Visibility.Collapsed;
+            // Drop any fixed width so a later measure cannot keep the previous activity reservation.
+            ActivitySummary.ClearValue(FrameworkElement.WidthProperty);
+            return;
+        }
+
+        // Apply first so the control sizes its content, then force Visible in case Apply raced.
+        ActivitySummary.Apply(_activitySnapshot, _activeProvider);
+        ActivitySummary.Visibility = Visibility.Visible;
+        ActivitySummary.SetLogicalWidth(ActivityLogicalWidth);
     }
 
     public void MeasureDesiredSize(out int logicalWidth, out int logicalHeight)
     {
         RecomputeLayout();
         logicalWidth = _desiredLogicalWidth;
-        logicalHeight = HostLogicalHeight;
+        logicalHeight = _desiredLogicalHeight;
+    }
+
+    /// <summary>
+    /// Pure content width for the floating host: tiles + optional activity + slack.
+    /// Does not consult <see cref="FrameworkElement.ActualWidth"/> so hiding activity can shrink the window.
+    /// </summary>
+    internal static int ComputeContentLogicalWidth(
+        IReadOnlyList<int> tileWidths,
+        bool showActivity,
+        int activityLogicalWidth = ActivityLogicalWidth)
+    {
+        int total = 0;
+        for (int i = 0; i < tileWidths.Count; i++)
+        {
+            total += tileWidths[i] + TileHorizontalMarginLogicalPx
+                + (i > 0 ? TileSeparatorLogicalPx : 0);
+        }
+
+        if (showActivity)
+            total += Math.Max(1, activityLogicalWidth) + ActivitySummaryMarginLogicalPx;
+
+        if (total <= 0)
+            total = DefaultHostLogicalWidth;
+
+        return total + ContentWidthSlackLogicalPx;
     }
 
     private void RecomputeLayout()
@@ -223,11 +344,9 @@ public sealed partial class QuotaWidgetContent : UserControl
         if (!_built)
             return;
 
-        bool showActivity = WidgetSettingsService.ShowAgentActivityInWidget
-            && _activitySnapshot.Primary is not null;
+        bool showActivity = HasVisibleActivity;
 
-        int total = 0;
-        int shownCount = 0;
+        var tileWidths = new List<int>(UsageCoordinator.MaxWidgetTiles);
         for (int i = 0; i < _tiles.Length; i++)
         {
             bool shown = _tileProviders[i] is not null;
@@ -240,8 +359,7 @@ public sealed partial class QuotaWidgetContent : UserControl
             if (_tileProviders[i] is { } provider)
                 Taskbar.TaskbarSpace.RecordTileWidth(provider, width);
 
-            total += width + TileHorizontalMarginLogicalPx + (shownCount > 0 ? TileSeparatorLogicalPx : 0);
-            shownCount++;
+            tileWidths.Add(width);
         }
 
         var separatorBrush = SeparatorBrush();
@@ -252,24 +370,20 @@ public sealed partial class QuotaWidgetContent : UserControl
             _separators[i].Foreground = separatorBrush;
         }
 
-        if (showActivity)
-        {
-            ActivitySummary.Visibility = Visibility.Visible;
-            ActivitySummary.SetLogicalWidth(ActivityLogicalWidth);
-            total += ActivityLogicalWidth + ActivitySummaryMarginLogicalPx;
-        }
-        else
-        {
-            ActivitySummary.Visibility = Visibility.Collapsed;
-        }
+        // Keep Apply + size in sync with visibility so the strip never reserves space for a
+        // collapsed control or shows a blank activity host.
+        ApplyActivityToControl();
 
-        if (total <= 0)
-            total = DefaultHostLogicalWidth;
+        // Model width only — never Math.Max against ActualWidth. That kept the previous (wider)
+        // layout after activity was hidden and blocked the floating window from shrinking.
+        int total = ComputeContentLogicalWidth(tileWidths, showActivity, ActivityLogicalWidth);
+        int height = HostLogicalHeight;
 
-        if (total == _desiredLogicalWidth)
+        if (total == _desiredLogicalWidth && height == _desiredLogicalHeight)
             return;
 
         _desiredLogicalWidth = total;
-        DesiredSizeChanged?.Invoke(_desiredLogicalWidth, HostLogicalHeight);
+        _desiredLogicalHeight = height;
+        DesiredSizeChanged?.Invoke(_desiredLogicalWidth, _desiredLogicalHeight);
     }
 }

--- a/src/TaskbarQuota.App/Controls/QuotaWidgetContent.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/QuotaWidgetContent.xaml.cs
@@ -72,6 +72,7 @@ public sealed partial class QuotaWidgetContent : UserControl
         ActivitySummary.IsWheelNavigationEnabled = false;
         _activityEmptySnapshotTimer = new DispatcherTimer { Interval = EmptyActivityGrace };
         _activityEmptySnapshotTimer.Tick += ActivityEmptySnapshotTimer_Tick;
+        ActualThemeChanged += (_, _) => RecomputeLayout();
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
     }

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -164,7 +164,10 @@ namespace TaskbarQuota.Controls
             ActualThemeChanged += (_, _) =>
             {
                 if (UseApplicationChromeColors)
+                {
                     ApplyTaskbarForeground();
+                    SetBars();
+                }
             };
             Tapped += (_, _) =>
             {

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -57,6 +57,12 @@ namespace TaskbarQuota.Controls
         public bool SuppressNextClick { get; set; }
 
         /// <summary>
+        /// When true, tile colors follow the app theme (floating window chrome) instead of the system
+        /// taskbar light/dark palette used by the injected taskbar island.
+        /// </summary>
+        public bool UseApplicationChromeColors { get; set; }
+
+        /// <summary>
         /// Skips the cross-fade on the next render. Set when a tile is taking over another provider as part
         /// of a re-order: the movement is being conveyed by <see cref="AnimateSlide"/>, and fading the
         /// content at the same time turns a clean shift into a flicker.
@@ -133,6 +139,13 @@ namespace TaskbarQuota.Controls
             ApplyTaskbarForeground();
             RenderRows();
             WidgetSettingsService.Changed += OnWidgetSettingsChanged;
+            // App light/dark on the floating HUD changes ActualTheme; re-color so text never stays
+            // white-on-light or dark-on-dark after a theme switch.
+            ActualThemeChanged += (_, _) =>
+            {
+                if (UseApplicationChromeColors)
+                    ApplyTaskbarForeground();
+            };
             Tapped += (_, _) =>
             {
                 if (SuppressNextClick)
@@ -150,7 +163,13 @@ namespace TaskbarQuota.Controls
 
         private void ApplyTaskbarForeground()
         {
-            bool light = Interop.SystemInfos.IsSystemLightThemeUsed() == true;
+            // Never pull theme brushes from Application.Current.Resources for the floating window:
+            // those resolve against Application.RequestedTheme (often system-dark) while the window
+            // RequestedTheme is Light — white text on a light card. Use ActualTheme + solid colors.
+            bool light = UseApplicationChromeColors
+                ? ThemeService.IsLightChrome(this)
+                : Interop.SystemInfos.IsSystemLightThemeUsed() == true;
+
             Foreground = new SolidColorBrush(light ? Color.FromArgb(255, 28, 28, 28) : Colors.White);
             var track = new SolidColorBrush(light ? Color.FromArgb(90, 28, 28, 28) : Color.FromArgb(110, 255, 255, 255));
 
@@ -158,6 +177,18 @@ namespace TaskbarQuota.Controls
             {
                 row.Track.Background = track;
                 row.Value.Foreground = Foreground;
+                if (row.Label is TextBlock labelBlock)
+                    labelBlock.Foreground = Foreground;
+                else if (row.Label is Panel labelPanel)
+                {
+                    foreach (var child in labelPanel.Children)
+                    {
+                        if (child is TextBlock tb)
+                            tb.Foreground = Foreground;
+                    }
+                }
+                if (row.Reset is { } resetBlock)
+                    resetBlock.Foreground = ResetBrush(row.Source.ResetDescription ?? "");
             }
             UpdateBadgeFill();
         }
@@ -408,8 +439,14 @@ namespace TaskbarQuota.Controls
 
         public void SetActiveToolVisible(bool isVisible)
         {
+            // If we already believe we are visible but the root was left at Opacity 0 (interrupted
+            // hide/reveal, first-paint race, or a settings thrash), force a re-show instead of no-op.
             if (_isActiveToolVisible == isVisible)
+            {
+                if (isVisible && Root.Opacity < 0.05)
+                    AnimateVisibility(toOpacity: 1, toOffset: 0, milliseconds: 200);
                 return;
+            }
 
             _isActiveToolVisible = isVisible;
             IsHitTestVisible = isVisible;
@@ -1260,6 +1297,7 @@ namespace TaskbarQuota.Controls
                 0.86,
                 compactTextOnlyValue ? TextAlignment.Left : TextAlignment.Center,
                 textSize);
+            value.Foreground = Foreground;
             var reset = CreateResetText(usageRow, textSize);
 
             FrameworkElement label;
@@ -1339,7 +1377,7 @@ namespace TaskbarQuota.Controls
                     break;
             }
 
-            _renderedRows.Add(new RenderedRow(usageRow, track, bar, barWidth, label, value));
+            _renderedRows.Add(new RenderedRow(usageRow, track, bar, barWidth, label, value, reset));
         }
 
         private static FrameworkElement CreateNormalizedGlyph(
@@ -1413,14 +1451,17 @@ namespace TaskbarQuota.Controls
             VerticalAlignment = VerticalAlignment.Center,
         };
 
-        private static FrameworkElement CreateLabelText(WidgetUsageRow row, WidgetDisplayMode mode, int fontSize = WidgetFontSize)
+        private FrameworkElement CreateLabelText(WidgetUsageRow row, WidgetDisplayMode mode, int fontSize = WidgetFontSize)
         {
             var baseLabel = CreateText(BaseLabelText(row, mode), 0.78, TextAlignment.Left, fontSize);
             baseLabel.TextTrimming = TextTrimming.None;
+            // Explicit brush: inheritance is unreliable once Application theme resources disagree
+            // with the floating window's light/dark chrome.
+            baseLabel.Foreground = Foreground;
             return baseLabel;
         }
 
-        private static TextBlock CreateResetText(WidgetUsageRow row, int fontSize = WidgetFontSize)
+        private TextBlock CreateResetText(WidgetUsageRow row, int fontSize = WidgetFontSize)
         {
             if (string.IsNullOrWhiteSpace(row.ResetDescription))
                 return CreateText("", 0.9, TextAlignment.Left, fontSize);
@@ -1446,18 +1487,38 @@ namespace TaskbarQuota.Controls
                 SetBar(row.Bar, row.Source.Percent, row.BarWidth);
         }
 
-        private static void SetBar(FrameworkElement bar, double percent, double maxWidth)
+        private void SetBar(FrameworkElement bar, double percent, double maxWidth)
         {
             bar.Width = Math.Clamp(percent, 0, 100) * (maxWidth / 100d);
-            string key = WidgetSettingsService.GetUsageBrushResourceKeyForDisplayPercent(percent);
-            if (bar is Border border)
+            if (bar is not Border border)
+                return;
+
+            bool emphasized = WidgetSettingsService.CurrentPercentageMode == PercentageDisplayMode.Remaining
+                ? percent <= 25
+                : percent >= 75;
+            border.Background = UsageBarBrush(percent);
+            border.Opacity = emphasized ? 0.95 : 0.78;
+        }
+
+        private Brush UsageBarBrush(double displayPercent)
+        {
+            if (UseApplicationChromeColors)
             {
-                bool emphasized = WidgetSettingsService.CurrentPercentageMode == PercentageDisplayMode.Remaining
-                    ? percent <= 25
-                    : percent >= 75;
-                border.Background = (Brush)Application.Current.Resources[key];
-                border.Opacity = emphasized ? 0.95 : 0.78;
+                bool light = ThemeService.IsLightChrome(this);
+                // Thresholds match WidgetSettingsService usage colors (critical / caution / normal).
+                displayPercent = Math.Clamp(displayPercent, 0, 100);
+                bool remaining = WidgetSettingsService.CurrentPercentageMode == PercentageDisplayMode.Remaining;
+                bool critical = remaining ? displayPercent <= 10 : displayPercent >= 90;
+                bool caution = remaining ? displayPercent <= 25 : displayPercent >= 75;
+                if (critical)
+                    return new SolidColorBrush(light ? Color.FromArgb(255, 196, 43, 28) : Color.FromArgb(255, 255, 99, 71));
+                if (caution)
+                    return new SolidColorBrush(light ? Color.FromArgb(255, 157, 93, 0) : Color.FromArgb(255, 255, 185, 0));
+                return new SolidColorBrush(light ? Color.FromArgb(255, 0, 103, 192) : Color.FromArgb(255, 96, 205, 255));
             }
+
+            string key = WidgetSettingsService.GetUsageBrushResourceKeyForDisplayPercent(displayPercent);
+            return (Brush)Application.Current.Resources[key];
         }
 
         private static string Abbrev(string name)
@@ -1582,8 +1643,30 @@ namespace TaskbarQuota.Controls
             return $"{local:MMM d h:mm tt}";
         }
 
-        private static Brush ResetBrush(string resetDescription)
+        private Brush ResetBrush(string resetDescription)
         {
+            // Floating HUD uses solid colors from the window chrome theme. Application.Current
+            // theme resources resolve against system/app dark mode and paint light-on-light
+            // secondary text (e.g. "(6h 25m)") when the floating window is in light mode.
+            if (UseApplicationChromeColors)
+            {
+                bool light = ThemeService.IsLightChrome(this);
+                return TryParseResetMinutes(resetDescription) switch
+                {
+                    // Urgent / soon: accent blue, darker on light chrome for contrast.
+                    <= 30 => new SolidColorBrush(light
+                        ? Color.FromArgb(255, 0, 90, 158)
+                        : Color.FromArgb(255, 96, 205, 255)),
+                    <= 120 => new SolidColorBrush(light
+                        ? Color.FromArgb(255, 0, 103, 192)
+                        : Color.FromArgb(255, 80, 180, 255)),
+                    // Normal reset countdown: muted primary, never pure theme secondary.
+                    _ => new SolidColorBrush(light
+                        ? Color.FromArgb(210, 28, 28, 28)
+                        : Color.FromArgb(210, 255, 255, 255)),
+                };
+            }
+
             string key = TryParseResetMinutes(resetDescription) switch
             {
                 <= 30 => "AccentFillColorDefaultBrush",
@@ -1657,7 +1740,8 @@ namespace TaskbarQuota.Controls
             Border Bar,
             double BarWidth,
             FrameworkElement? Label,
-            TextBlock Value);
+            TextBlock Value,
+            TextBlock? Reset = null);
 
         private sealed record WidgetLayoutMetrics(double LabelWidth, double ResetWidth, double ValueWidth);
     }

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -56,11 +56,31 @@ namespace TaskbarQuota.Controls
 
         public bool SuppressNextClick { get; set; }
 
+        private bool _useApplicationChromeColors;
+
         /// <summary>
         /// When true, tile colors follow the app theme (floating window chrome) instead of the system
         /// taskbar light/dark palette used by the injected taskbar island.
         /// </summary>
-        public bool UseApplicationChromeColors { get; set; }
+        public bool UseApplicationChromeColors
+        {
+            get => _useApplicationChromeColors;
+            set
+            {
+                if (_useApplicationChromeColors == value)
+                    return;
+                _useApplicationChromeColors = value;
+                // Re-color if the flag flips after construction (tiles already rendered).
+                if (_hasRevealed || _lastResult is not null || _renderedRows.Count > 0)
+                {
+                    ApplyTaskbarForeground();
+                    if (_lastResult is { } result)
+                        Apply(result, force: true);
+                    else
+                        RenderRows();
+                }
+            }
+        }
 
         /// <summary>
         /// Skips the cross-fade on the next render. Set when a tile is taking over another provider as part

--- a/src/TaskbarQuota.App/DashboardNavigationBinder.cs
+++ b/src/TaskbarQuota.App/DashboardNavigationBinder.cs
@@ -178,7 +178,7 @@ namespace TaskbarQuota
                 }
                 : null;
 
-            ToolTipService.SetToolTip(item, pinned ? $"{displayName} — pinned to the taskbar" : displayName);
+            ToolTipService.SetToolTip(item, pinned ? $"{displayName} — pinned in the usage widget" : displayName);
         }
 
         /// <summary>

--- a/src/TaskbarQuota.App/FloatingUsageWindow.xaml
+++ b/src/TaskbarQuota.App/FloatingUsageWindow.xaml
@@ -6,15 +6,15 @@
     xmlns:controls="using:TaskbarQuota.Controls">
 
     <Grid x:Name="Root" Background="Transparent">
-        <!-- Fill opacity is user-adjustable; content sits above so text stays fully opaque. -->
+        <!-- Solid fallback only. Desktop Acrylic is supplied by the native composition backdrop. -->
         <Border x:Name="ChromeFill"
-                CornerRadius="8"
+                CornerRadius="10"
                 Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
                 IsHitTestVisible="False"/>
         <Border x:Name="Chrome"
-                CornerRadius="8"
+                CornerRadius="10"
                 BorderThickness="1"
-                Padding="6,4"
+                Padding="10,6"
                 Background="Transparent"
                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
             <controls:QuotaWidgetContent x:Name="ContentHost"

--- a/src/TaskbarQuota.App/FloatingUsageWindow.xaml
+++ b/src/TaskbarQuota.App/FloatingUsageWindow.xaml
@@ -17,9 +17,18 @@
                 Padding="10,6"
                 Background="Transparent"
                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
-            <controls:QuotaWidgetContent x:Name="ContentHost"
-                                         VerticalAlignment="Center"
-                                         HorizontalAlignment="Left"/>
+            <ScrollViewer x:Name="ContentScroller"
+                          AutomationProperties.Name="Floating usage content"
+                          IsTabStop="True"
+                          HorizontalScrollMode="Enabled"
+                          HorizontalScrollBarVisibility="Hidden"
+                          VerticalScrollMode="Disabled"
+                          VerticalScrollBarVisibility="Disabled"
+                          ZoomMode="Disabled">
+                <controls:QuotaWidgetContent x:Name="ContentHost"
+                                             VerticalAlignment="Center"
+                                             HorizontalAlignment="Left"/>
+            </ScrollViewer>
         </Border>
     </Grid>
 </Window>

--- a/src/TaskbarQuota.App/FloatingUsageWindow.xaml
+++ b/src/TaskbarQuota.App/FloatingUsageWindow.xaml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="TaskbarQuota.FloatingUsageWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:TaskbarQuota.Controls">
+
+    <Grid x:Name="Root" Background="Transparent">
+        <!-- Fill opacity is user-adjustable; content sits above so text stays fully opaque. -->
+        <Border x:Name="ChromeFill"
+                CornerRadius="8"
+                Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
+                IsHitTestVisible="False"/>
+        <Border x:Name="Chrome"
+                CornerRadius="8"
+                BorderThickness="1"
+                Padding="6,4"
+                Background="Transparent"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
+            <controls:QuotaWidgetContent x:Name="ContentHost"
+                                         VerticalAlignment="Center"
+                                         HorizontalAlignment="Left"/>
+        </Border>
+    </Grid>
+</Window>

--- a/src/TaskbarQuota.App/FloatingUsageWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FloatingUsageWindow.xaml.cs
@@ -13,13 +13,13 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Windows.Graphics;
 using Windows.UI;
-using Windows.UI.ViewManagement;
 using TaskbarQuota.AgentActivity;
 using TaskbarQuota.Controls;
 using TaskbarQuota.Diagnostics;
 using TaskbarQuota.Interop;
 using TaskbarQuota.Usage;
 using WinRT;
+using ThemeSettings = Microsoft.UI.System.ThemeSettings;
 
 namespace TaskbarQuota;
 
@@ -58,7 +58,7 @@ public sealed partial class FloatingUsageWindow : Window
     private bool _hasManualPosition;
     private DesktopAcrylicController? _acrylicController;
     private SystemBackdropConfiguration? _backdropConfiguration;
-    private AccessibilitySettings? _accessibilitySettings;
+    private ThemeSettings? _themeSettings;
 
     // Same instance for AddHandler/RemoveHandler; method-group casts would not match.
     private readonly PointerEventHandler _rootPointerPressed;
@@ -120,7 +120,6 @@ public sealed partial class FloatingUsageWindow : Window
         // non-activating HUD can keep its material active without stealing focus from the user's app.
         SystemBackdrop = null;
         ThemeService.Register(Root);
-        InitializeAcrylicBackdrop();
 
         var presenter = OverlappedPresenter.CreateForContextMenu();
         presenter.IsAlwaysOnTop = true;
@@ -132,6 +131,7 @@ public sealed partial class FloatingUsageWindow : Window
         _appWindow.IsShownInSwitchers = false;
         _appWindow.SetPresenter(presenter);
         _appWindow.Title = "TaskbarQuota";
+        InitializeAcrylicBackdrop();
 
         ContentHost.Clicked += OnContentClicked;
         ContentHost.ActivityClicked += item => ActivityClicked?.Invoke(item);
@@ -175,10 +175,10 @@ public sealed partial class FloatingUsageWindow : Window
         Root.RemoveHandler(UIElement.PointerWheelChangedEvent, _rootPointerWheelChanged);
         Root.RightTapped -= Root_RightTapped;
 
-        if (_accessibilitySettings is not null)
+        if (_themeSettings is not null)
         {
-            _accessibilitySettings.HighContrastChanged -= OnHighContrastChanged;
-            _accessibilitySettings = null;
+            _themeSettings.Changed -= OnThemeSettingsChanged;
+            _themeSettings = null;
         }
 
         if (_acrylicController is not null)
@@ -227,15 +227,15 @@ public sealed partial class FloatingUsageWindow : Window
             controller.SetSystemBackdropConfiguration(configuration);
             _backdropConfiguration = configuration;
 
-            _accessibilitySettings = new AccessibilitySettings();
-            _accessibilitySettings.HighContrastChanged += OnHighContrastChanged;
+            _themeSettings = ThemeSettings.CreateForWindowId(_appWindow!.Id);
+            _themeSettings.Changed += OnThemeSettingsChanged;
         }
         catch (Exception ex)
         {
-            if (_accessibilitySettings is not null)
+            if (_themeSettings is not null)
             {
-                _accessibilitySettings.HighContrastChanged -= OnHighContrastChanged;
-                _accessibilitySettings = null;
+                _themeSettings.Changed -= OnThemeSettingsChanged;
+                _themeSettings = null;
             }
             _acrylicController?.RemoveAllSystemBackdropTargets();
             _acrylicController?.Dispose();
@@ -293,7 +293,7 @@ public sealed partial class FloatingUsageWindow : Window
             ? SystemBackdropTheme.Light
             : SystemBackdropTheme.Dark;
         _backdropConfiguration.IsInputActive = true;
-        _backdropConfiguration.IsHighContrast = _accessibilitySettings?.HighContrast == true;
+        _backdropConfiguration.IsHighContrast = _themeSettings?.HighContrast == true;
         _backdropConfiguration.HighContrastBackgroundColor = tint;
     }
 
@@ -500,7 +500,7 @@ public sealed partial class FloatingUsageWindow : Window
         }
     }
 
-    private void OnHighContrastChanged(AccessibilitySettings sender, object args)
+    private void OnThemeSettingsChanged(ThemeSettings sender, object args)
         => DispatcherQueue.TryEnqueue(ApplyAcrylicMaterial);
 
     private void Root_PointerCaptureLost(object sender, PointerRoutedEventArgs e)

--- a/src/TaskbarQuota.App/FloatingUsageWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FloatingUsageWindow.xaml.cs
@@ -1,0 +1,465 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using Microsoft.UI;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Windows.Graphics;
+using Windows.UI;
+using TaskbarQuota.AgentActivity;
+using TaskbarQuota.Controls;
+using TaskbarQuota.Diagnostics;
+using TaskbarQuota.Interop;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota;
+
+/// <summary>
+/// Semi-transparent always-on-top host for the same compact usage layout as the taskbar widget.
+/// Single window, draggable, position persisted under app data.
+/// </summary>
+public sealed partial class FloatingUsageWindow : Window
+{
+    private static readonly string PositionPath =
+        Path.Combine(AppStorage.AppDataDirectory, "floating-widget-position.txt");
+
+    private const int ChromePaddingLogicalX = 12; // Border padding 6*2
+    private const int ChromePaddingLogicalY = 8;  // Border padding 4*2
+    private const int DefaultLogicalWidth = 184;
+    private const int DefaultLogicalHeight = 48;
+    private const int DragThresholdLogicalPx = 4;
+
+    private AppWindow? _appWindow;
+    private bool _shown;
+    private bool _isDragging;
+    private bool _isPointerTracking;
+    private bool _suppressNextClick;
+    private POINT _pressCursor;
+    private PointInt32 _pressWindowPos;
+    private int _logicalWidth = DefaultLogicalWidth;
+    private int _logicalHeight = DefaultLogicalHeight;
+    private bool _hasManualPosition;
+
+    public event Action? Clicked;
+    public event Action<AgentActivityItem?>? ActivityClicked;
+
+    public bool IsShown => _shown;
+    public bool IsDragging => _isDragging;
+    public bool IsAlive
+    {
+        get
+        {
+            try
+            {
+                var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+                return hwnd != IntPtr.Zero && User32.IsWindow(hwnd);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+
+    public IntPtr Handle
+    {
+        get
+        {
+            try { return WinRT.Interop.WindowNative.GetWindowHandle(this); }
+            catch { return IntPtr.Zero; }
+        }
+    }
+
+    public Func<ProviderId, UsageResult?>? HydrateProvider
+    {
+        get => ContentHost.HydrateProvider;
+        set => ContentHost.HydrateProvider = value;
+    }
+
+    public FloatingUsageWindow()
+    {
+        InitializeComponent();
+
+        // No SystemBackdrop: acrylic paints an opaque composition surface so brush alpha never
+        // shows the desktop. Real transparency comes from WS_EX_LAYERED + SetLayeredWindowAttributes.
+        SystemBackdrop = null;
+        ThemeService.Register(Root);
+
+        var presenter = OverlappedPresenter.CreateForContextMenu();
+        presenter.IsAlwaysOnTop = true;
+        presenter.IsResizable = false;
+        presenter.IsMaximizable = false;
+        presenter.IsMinimizable = false;
+
+        _appWindow = GetAppWindow();
+        _appWindow.IsShownInSwitchers = false;
+        _appWindow.SetPresenter(presenter);
+        _appWindow.Title = "TaskbarQuota";
+
+        ContentHost.Clicked += OnContentClicked;
+        ContentHost.ActivityClicked += item => ActivityClicked?.Invoke(item);
+        ContentHost.DesiredSizeChanged += OnDesiredSizeChanged;
+        WidgetSettingsService.Changed += OnWidgetSettingsChanged;
+        Root.ActualThemeChanged += (_, _) => ApplyChromeOpacity();
+        Root.Loaded += (_, _) => ApplyChromeOpacity();
+
+        Root.PointerPressed += Root_PointerPressed;
+        Root.PointerMoved += Root_PointerMoved;
+        Root.PointerReleased += Root_PointerReleased;
+        Root.PointerCanceled += Root_PointerCanceled;
+        Root.PointerCaptureLost += Root_PointerCanceled;
+
+        Closed += OnClosed;
+        EnsureLayeredWindow();
+        ApplyChromeOpacity();
+        LoadPositionOrDefault();
+        ApplyBounds(forceShow: false);
+    }
+
+    private void OnClosed(object sender, WindowEventArgs args)
+    {
+        Closed -= OnClosed;
+        ThemeService.Unregister(Root);
+        WidgetSettingsService.Changed -= OnWidgetSettingsChanged;
+        ContentHost.Clicked -= OnContentClicked;
+        Root.PointerPressed -= Root_PointerPressed;
+        Root.PointerMoved -= Root_PointerMoved;
+        Root.PointerReleased -= Root_PointerReleased;
+        Root.PointerCanceled -= Root_PointerCanceled;
+        Root.PointerCaptureLost -= Root_PointerCanceled;
+        _shown = false;
+    }
+
+    private void OnWidgetSettingsChanged(object? sender, EventArgs e)
+        => DispatcherQueue.TryEnqueue(ApplyChromeOpacity);
+
+    private void EnsureLayeredWindow()
+    {
+        var hwnd = Handle;
+        if (hwnd == IntPtr.Zero)
+            return;
+
+        int ex = GetExtendedStyle(hwnd);
+        if ((ex & (int)WindowStylesExtended.WS_EX_LAYERED) == 0)
+            SetExtendedStyle(hwnd, ex | (int)WindowStylesExtended.WS_EX_LAYERED);
+    }
+
+    private static int GetExtendedStyle(IntPtr hwnd)
+        => IntPtr.Size == 8
+            ? unchecked((int)User32.GetWindowLongPtr(hwnd, User32.GWL_EXSTYLE).ToInt64())
+            : User32.GetWindowLong(hwnd, User32.GWL_EXSTYLE);
+
+    private static void SetExtendedStyle(IntPtr hwnd, int style)
+    {
+        if (IntPtr.Size == 8)
+            User32.SetWindowLongPtr(hwnd, User32.GWL_EXSTYLE, (IntPtr)style);
+        else
+            User32.SetWindowLong(hwnd, User32.GWL_EXSTYLE, unchecked((uint)style));
+    }
+
+    /// <summary>
+    /// Applies user opacity via true layered-window alpha so the desktop shows through.
+    /// XAML brush alpha alone cannot pierce WinUI's opaque composition surface.
+    /// </summary>
+    private void ApplyChromeOpacity()
+    {
+        EnsureLayeredWindow();
+
+        double opacity = WidgetSettingsService.FloatingOpacity;
+        byte alpha = (byte)Math.Clamp((int)Math.Round(opacity * 255), 1, 255);
+
+        var hwnd = Handle;
+        if (hwnd != IntPtr.Zero)
+            User32.SetLayeredWindowAttributes(hwnd, 0, alpha, User32.LWA_ALPHA);
+
+        // Solid chrome fill (window-level alpha handles see-through). Keeps shape readable
+        // without relying on theme resources that fight layered composition.
+        bool light = ThemeService.IsLightChrome(Root);
+        byte r = light ? (byte)248 : (byte)28;
+        byte g = light ? (byte)248 : (byte)28;
+        byte b = light ? (byte)248 : (byte)28;
+        ChromeFill.Background = new SolidColorBrush(Color.FromArgb(255, r, g, b));
+        ChromeFill.Opacity = 1;
+    }
+
+    private void OnContentClicked()
+    {
+        if (_suppressNextClick)
+        {
+            _suppressNextClick = false;
+            return;
+        }
+        Clicked?.Invoke();
+    }
+
+    private void OnDesiredSizeChanged(int logicalWidth, int logicalHeight)
+    {
+        _logicalWidth = Math.Max(DefaultLogicalWidth, logicalWidth + ChromePaddingLogicalX);
+        _logicalHeight = Math.Max(DefaultLogicalHeight, logicalHeight + ChromePaddingLogicalY);
+        ApplyBounds(forceShow: _shown);
+    }
+
+    public void SetDisplayProviders(IReadOnlyList<ProviderId> providers, ProviderId? activeProvider)
+        => ContentHost.SetDisplayProviders(providers, activeProvider);
+
+    public void ApplyResult(UsageResult result, bool force = false)
+        => ContentHost.ApplyResult(result, force);
+
+    public void SetActivitySnapshot(AgentActivitySnapshot snapshot)
+        => ContentHost.SetActivitySnapshot(snapshot);
+
+    public void SetVisible(bool visible)
+    {
+        if (_appWindow is null)
+            return;
+
+        if (visible)
+        {
+            ApplyBounds(forceShow: true);
+            if (!_appWindow.IsVisible)
+                _appWindow.Show(false);
+            _shown = true;
+            // Layered alpha is sometimes reset after Show; re-apply.
+            ApplyChromeOpacity();
+            // Hide/show and settings thrash can leave tiles at Opacity 0 while still "assigned".
+            ContentHost.EnsureVisibleContent();
+        }
+        else
+        {
+            if (_appWindow.IsVisible)
+                _appWindow.Hide();
+            _shown = false;
+        }
+    }
+
+    public void StartDragging()
+    {
+        // Tray "Move" — nudge the user by ensuring the window is visible; they can then drag.
+        SetVisible(true);
+        try
+        {
+            var hwnd = Handle;
+            if (hwnd != IntPtr.Zero)
+                User32.SetForegroundWindow(hwnd);
+        }
+        catch { }
+    }
+
+    public void ResetPosition()
+    {
+        _hasManualPosition = false;
+        try
+        {
+            if (File.Exists(PositionPath))
+                File.Delete(PositionPath);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Could not clear floating widget position");
+        }
+
+        PlaceAtDefault();
+        ApplyBounds(forceShow: _shown);
+    }
+
+    private void Root_PointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(Root).Properties.IsLeftButtonPressed)
+            return;
+
+        _isPointerTracking = true;
+        _isDragging = false;
+        _suppressNextClick = false;
+        if (!User32.GetCursorPos(out _pressCursor))
+            _pressCursor = default;
+        if (_appWindow is not null)
+            _pressWindowPos = _appWindow.Position;
+        Root.CapturePointer(e.Pointer);
+    }
+
+    private void Root_PointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_isPointerTracking || _appWindow is null)
+            return;
+
+        if (!User32.GetCursorPos(out var cursor))
+            return;
+
+        int dx = cursor.x - _pressCursor.x;
+        int dy = cursor.y - _pressCursor.y;
+        double scale = Root.XamlRoot?.RasterizationScale ?? GetWindowScale();
+        int threshold = Math.Max(1, (int)Math.Round(DragThresholdLogicalPx * scale));
+
+        if (!_isDragging)
+        {
+            if (Math.Abs(dx) < threshold && Math.Abs(dy) < threshold)
+                return;
+
+            _isDragging = true;
+            _suppressNextClick = true;
+        }
+
+        int newX = _pressWindowPos.X + dx;
+        int newY = _pressWindowPos.Y + dy;
+        ClampToWorkArea(ref newX, ref newY, _appWindow.Size.Width, _appWindow.Size.Height);
+        _appWindow.Move(new PointInt32(newX, newY));
+    }
+
+    private void Root_PointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_isPointerTracking)
+            return;
+
+        bool wasDragging = _isDragging;
+        _isPointerTracking = false;
+        _isDragging = false;
+        try { Root.ReleasePointerCapture(e.Pointer); } catch { }
+
+        if (wasDragging && _appWindow is not null)
+        {
+            SavePosition(_appWindow.Position.X, _appWindow.Position.Y);
+            _hasManualPosition = true;
+        }
+    }
+
+    private void Root_PointerCanceled(object sender, PointerRoutedEventArgs e)
+    {
+        _isPointerTracking = false;
+        _isDragging = false;
+        try { Root.ReleasePointerCapture(e.Pointer); } catch { }
+    }
+
+    private void LoadPositionOrDefault()
+    {
+        try
+        {
+            if (File.Exists(PositionPath))
+            {
+                var parts = File.ReadAllText(PositionPath).Split(',');
+                if (parts.Length >= 2
+                    && int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out int x)
+                    && int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out int y))
+                {
+                    _hasManualPosition = true;
+                    // Bounds applied after size is known; stash as window position first.
+                    if (_appWindow is not null)
+                        _appWindow.Move(new PointInt32(x, y));
+                    return;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Could not load floating widget position");
+        }
+
+        PlaceAtDefault();
+    }
+
+    private void PlaceAtDefault()
+    {
+        if (_appWindow is null)
+            return;
+
+        double scale = GetWindowScale();
+        int w = WindowDpi.ToPhysical(_logicalWidth, scale);
+        int h = WindowDpi.ToPhysical(_logicalHeight, scale);
+
+        // Primary work area, bottom-right (tray-adjacent), with a small inset.
+        var monitor = User32.MonitorFromPoint(new POINT { x = 0, y = 0 }, MonitorFromFlags.MONITOR_DEFAULTTOPRIMARY);
+        var info = MONITORINFO.Create();
+        if (monitor != IntPtr.Zero && User32.GetMonitorInfo(monitor, ref info))
+        {
+            int margin = WindowDpi.ToPhysical(12, scale);
+            int x = info.rcWork.right - w - margin;
+            int y = info.rcWork.bottom - h - margin;
+            _appWindow.Move(new PointInt32(x, y));
+            return;
+        }
+
+        _appWindow.Move(new PointInt32(100, 100));
+    }
+
+    private void ApplyBounds(bool forceShow)
+    {
+        if (_appWindow is null)
+            return;
+
+        double scale = Root.XamlRoot?.RasterizationScale ?? GetWindowScale();
+        int w = WindowDpi.ToPhysical(_logicalWidth, scale);
+        int h = WindowDpi.ToPhysical(_logicalHeight, scale);
+
+        var pos = _appWindow.Position;
+        if (!_hasManualPosition && !_shown)
+            PlaceAtDefault();
+        else
+            ClampToWorkArea(ref pos, w, h);
+
+        pos = _appWindow.Position;
+        ClampToWorkArea(ref pos, w, h);
+        _appWindow.MoveAndResize(new RectInt32(pos.X, pos.Y, w, h));
+
+        if (forceShow && !_appWindow.IsVisible)
+            _appWindow.Show(false);
+    }
+
+    private void ClampToWorkArea(ref PointInt32 pos, int width, int height)
+    {
+        int x = pos.X;
+        int y = pos.Y;
+        ClampToWorkArea(ref x, ref y, width, height);
+        pos = new PointInt32(x, y);
+        _appWindow?.Move(pos);
+    }
+
+    private void ClampToWorkArea(ref int x, ref int y, int width, int height)
+    {
+        var hwnd = Handle;
+        var monitor = hwnd != IntPtr.Zero
+            ? User32.MonitorFromWindow(hwnd, MonitorFromFlags.MONITOR_DEFAULTTONEAREST)
+            : User32.MonitorFromPoint(new POINT { x = x, y = y }, MonitorFromFlags.MONITOR_DEFAULTTONEAREST);
+        var info = MONITORINFO.Create();
+        if (monitor == IntPtr.Zero || !User32.GetMonitorInfo(monitor, ref info))
+            return;
+
+        var work = info.rcWork;
+        if (width > work.right - work.left)
+            width = work.right - work.left;
+        if (height > work.bottom - work.top)
+            height = work.bottom - work.top;
+
+        x = Math.Clamp(x, work.left, work.right - width);
+        y = Math.Clamp(y, work.top, work.bottom - height);
+    }
+
+    private static void SavePosition(int x, int y)
+    {
+        try
+        {
+            Directory.CreateDirectory(AppStorage.AppDataDirectory);
+            File.WriteAllText(PositionPath, string.Create(CultureInfo.InvariantCulture, $"{x},{y}"));
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Could not save floating widget position");
+        }
+    }
+
+    private double GetWindowScale()
+    {
+        var hwnd = Handle;
+        if (hwnd == IntPtr.Zero)
+            return 1d;
+        var dpi = User32.GetDpiForWindow(hwnd);
+        return dpi > 0 ? dpi / 96d : 1d;
+    }
+
+    private AppWindow GetAppWindow()
+    {
+        var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+        return AppWindow.GetFromWindowId(Win32Interop.GetWindowIdFromWindow(hwnd));
+    }
+}

--- a/src/TaskbarQuota.App/FloatingUsageWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FloatingUsageWindow.xaml.cs
@@ -3,51 +3,72 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using Microsoft.UI;
+using Microsoft.UI.Composition;
+using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Windows.Graphics;
 using Windows.UI;
+using Windows.UI.ViewManagement;
 using TaskbarQuota.AgentActivity;
 using TaskbarQuota.Controls;
 using TaskbarQuota.Diagnostics;
 using TaskbarQuota.Interop;
 using TaskbarQuota.Usage;
+using WinRT;
 
 namespace TaskbarQuota;
 
 /// <summary>
-/// Semi-transparent always-on-top host for the same compact usage layout as the taskbar widget.
+/// Always-on-top host for the same compact usage layout as the taskbar widget.
 /// Single window, draggable, position persisted under app data.
+/// Scroll wheel adjusts Acrylic strength; right-click returns usage to the taskbar.
 /// </summary>
 public sealed partial class FloatingUsageWindow : Window
 {
     private static readonly string PositionPath =
         Path.Combine(AppStorage.AppDataDirectory, "floating-widget-position.txt");
 
-    private const int ChromePaddingLogicalX = 12; // Border padding 6*2
-    private const int ChromePaddingLogicalY = 8;  // Border padding 4*2
-    private const int DefaultLogicalWidth = 184;
-    private const int DefaultLogicalHeight = 48;
+    private const int ChromePaddingLogicalX = 20; // Border padding 10*2
+    private const int ChromePaddingLogicalY = 12; // Border padding 6*2
+    private const int DefaultLogicalWidth = 200;
+    private const int DefaultLogicalHeight = 60;
     private const int DragThresholdLogicalPx = 4;
+    private const float AcrylicTintOpacityMin = 0.25f;
+    private const float AcrylicTintOpacityMax = 0.80f;
+    private const float AcrylicLuminosityOpacityMin = 0.45f;
+    private const float AcrylicLuminosityOpacityMax = 0.80f;
+    /// <summary>Matches the settings / flyout opacity slider step (5%).</summary>
+    public const double OpacityWheelStep = 0.05;
 
     private AppWindow? _appWindow;
     private bool _shown;
     private bool _isDragging;
     private bool _isPointerTracking;
-    private bool _suppressNextClick;
     private POINT _pressCursor;
     private PointInt32 _pressWindowPos;
     private int _logicalWidth = DefaultLogicalWidth;
     private int _logicalHeight = DefaultLogicalHeight;
     private bool _hasManualPosition;
+    private DesktopAcrylicController? _acrylicController;
+    private SystemBackdropConfiguration? _backdropConfiguration;
+    private AccessibilitySettings? _accessibilitySettings;
+
+    // Same instance for AddHandler/RemoveHandler; method-group casts would not match.
+    private readonly PointerEventHandler _rootPointerPressed;
+    private readonly PointerEventHandler _rootPointerMoved;
+    private readonly PointerEventHandler _rootPointerReleased;
+    private readonly PointerEventHandler _rootPointerCanceled;
+    private readonly PointerEventHandler _rootPointerWheelChanged;
 
     public event Action? Clicked;
     public event Action<AgentActivityItem?>? ActivityClicked;
 
     public bool IsShown => _shown;
     public bool IsDragging => _isDragging;
+    public bool HasVisibleContent => ContentHost.HasVisibleContent;
     public bool IsAlive
     {
         get
@@ -83,10 +104,17 @@ public sealed partial class FloatingUsageWindow : Window
     {
         InitializeComponent();
 
-        // No SystemBackdrop: acrylic paints an opaque composition surface so brush alpha never
-        // shows the desktop. Real transparency comes from WS_EX_LAYERED + SetLayeredWindowAttributes.
+        _rootPointerPressed = Root_PointerPressed;
+        _rootPointerMoved = Root_PointerMoved;
+        _rootPointerReleased = Root_PointerReleased;
+        _rootPointerCanceled = Root_PointerCanceled;
+        _rootPointerWheelChanged = Root_PointerWheelChanged;
+
+        // Use the lower-level native controller rather than DesktopAcrylicBackdrop so this deliberately
+        // non-activating HUD can keep its material active without stealing focus from the user's app.
         SystemBackdrop = null;
         ThemeService.Register(Root);
+        InitializeAcrylicBackdrop();
 
         var presenter = OverlappedPresenter.CreateForContextMenu();
         presenter.IsAlwaysOnTop = true;
@@ -103,18 +131,26 @@ public sealed partial class FloatingUsageWindow : Window
         ContentHost.ActivityClicked += item => ActivityClicked?.Invoke(item);
         ContentHost.DesiredSizeChanged += OnDesiredSizeChanged;
         WidgetSettingsService.Changed += OnWidgetSettingsChanged;
-        Root.ActualThemeChanged += (_, _) => ApplyChromeOpacity();
-        Root.Loaded += (_, _) => ApplyChromeOpacity();
+        Root.ActualThemeChanged += (_, _) => ApplyAcrylicMaterial();
+        Root.Loaded += (_, _) =>
+        {
+            ApplyAcrylicMaterial();
+            ContentHost.EnsureVisibleContent();
+        };
 
-        Root.PointerPressed += Root_PointerPressed;
-        Root.PointerMoved += Root_PointerMoved;
-        Root.PointerReleased += Root_PointerReleased;
-        Root.PointerCanceled += Root_PointerCanceled;
-        Root.PointerCaptureLost += Root_PointerCanceled;
+        // handledEventsToo: activity title/step live inside a Button that marks PointerPressed handled.
+        // Without this, press-on-activity never reaches Root and the floating window cannot be dragged
+        // (same pattern as TaskBarWidget's activity island).
+        Root.AddHandler(UIElement.PointerPressedEvent, _rootPointerPressed, handledEventsToo: true);
+        Root.AddHandler(UIElement.PointerMovedEvent, _rootPointerMoved, handledEventsToo: true);
+        Root.AddHandler(UIElement.PointerReleasedEvent, _rootPointerReleased, handledEventsToo: true);
+        Root.AddHandler(UIElement.PointerCanceledEvent, _rootPointerCanceled, handledEventsToo: true);
+        Root.AddHandler(UIElement.PointerCaptureLostEvent, _rootPointerCanceled, handledEventsToo: true);
+        Root.AddHandler(UIElement.PointerWheelChangedEvent, _rootPointerWheelChanged, handledEventsToo: true);
+        Root.RightTapped += Root_RightTapped;
 
         Closed += OnClosed;
-        EnsureLayeredWindow();
-        ApplyChromeOpacity();
+        ApplyAcrylicMaterial();
         LoadPositionOrDefault();
         ApplyBounds(forceShow: false);
     }
@@ -125,80 +161,164 @@ public sealed partial class FloatingUsageWindow : Window
         ThemeService.Unregister(Root);
         WidgetSettingsService.Changed -= OnWidgetSettingsChanged;
         ContentHost.Clicked -= OnContentClicked;
-        Root.PointerPressed -= Root_PointerPressed;
-        Root.PointerMoved -= Root_PointerMoved;
-        Root.PointerReleased -= Root_PointerReleased;
-        Root.PointerCanceled -= Root_PointerCanceled;
-        Root.PointerCaptureLost -= Root_PointerCanceled;
+        Root.RemoveHandler(UIElement.PointerPressedEvent, _rootPointerPressed);
+        Root.RemoveHandler(UIElement.PointerMovedEvent, _rootPointerMoved);
+        Root.RemoveHandler(UIElement.PointerReleasedEvent, _rootPointerReleased);
+        Root.RemoveHandler(UIElement.PointerCanceledEvent, _rootPointerCanceled);
+        Root.RemoveHandler(UIElement.PointerCaptureLostEvent, _rootPointerCanceled);
+        Root.RemoveHandler(UIElement.PointerWheelChangedEvent, _rootPointerWheelChanged);
+        Root.RightTapped -= Root_RightTapped;
+
+        _accessibilitySettings = null;
+
+        if (_acrylicController is not null)
+        {
+            _acrylicController.RemoveAllSystemBackdropTargets();
+            _acrylicController.Dispose();
+            _acrylicController = null;
+        }
+        _backdropConfiguration = null;
         _shown = false;
     }
 
     private void OnWidgetSettingsChanged(object? sender, EventArgs e)
-        => DispatcherQueue.TryEnqueue(ApplyChromeOpacity);
+        => DispatcherQueue.TryEnqueue(ApplyAcrylicMaterial);
 
-    private void EnsureLayeredWindow()
+    private void InitializeAcrylicBackdrop()
     {
-        var hwnd = Handle;
-        if (hwnd == IntPtr.Zero)
-            return;
+        try
+        {
+            if (!DesktopAcrylicController.IsSupported())
+                return;
 
-        int ex = GetExtendedStyle(hwnd);
-        if ((ex & (int)WindowStylesExtended.WS_EX_LAYERED) == 0)
-            SetExtendedStyle(hwnd, ex | (int)WindowStylesExtended.WS_EX_LAYERED);
-    }
+            // Composition backdrops rely on the system DispatcherQueue in addition to WinUI's queue.
+            DispatcherQueue.EnsureSystemDispatcherQueue();
 
-    private static int GetExtendedStyle(IntPtr hwnd)
-        => IntPtr.Size == 8
-            ? unchecked((int)User32.GetWindowLongPtr(hwnd, User32.GWL_EXSTYLE).ToInt64())
-            : User32.GetWindowLong(hwnd, User32.GWL_EXSTYLE);
+            var configuration = new SystemBackdropConfiguration
+            {
+                // The HUD is always shown with Show(false). Treating it as input-active keeps native
+                // acrylic alive while another application correctly retains keyboard focus.
+                IsInputActive = true,
+            };
+            var controller = new DesktopAcrylicController
+            {
+                Kind = DesktopAcrylicKind.Thin,
+            };
 
-    private static void SetExtendedStyle(IntPtr hwnd, int style)
-    {
-        if (IntPtr.Size == 8)
-            User32.SetWindowLongPtr(hwnd, User32.GWL_EXSTYLE, (IntPtr)style);
-        else
-            User32.SetWindowLong(hwnd, User32.GWL_EXSTYLE, unchecked((uint)style));
+            if (!controller.AddSystemBackdropTarget(this.As<ICompositionSupportsSystemBackdrop>()))
+            {
+                controller.Dispose();
+                return;
+            }
+
+            // Store the controller before the remaining configuration calls so the catch path can
+            // always detach and dispose it if a later WinRT operation fails.
+            _acrylicController = controller;
+            controller.SetSystemBackdropConfiguration(configuration);
+            _backdropConfiguration = configuration;
+
+            _accessibilitySettings = new AccessibilitySettings();
+        }
+        catch (Exception ex)
+        {
+            _acrylicController?.RemoveAllSystemBackdropTargets();
+            _acrylicController?.Dispose();
+            _acrylicController = null;
+            _backdropConfiguration = null;
+            Log.Warning(ex, "Could not initialize native acrylic for the floating widget; using a solid fallback");
+        }
     }
 
     /// <summary>
-    /// Applies user opacity via true layered-window alpha so the desktop shows through.
-    /// XAML brush alpha alone cannot pierce WinUI's opaque composition surface.
+    /// Maps the persisted 35-100% setting to the useful range of the native Acrylic recipe. Keeping
+    /// the tint below fully opaque preserves the blur/noise character even at the strongest setting.
     /// </summary>
-    private void ApplyChromeOpacity()
+    internal static (float TintOpacity, float LuminosityOpacity) ComputeAcrylicMaterial(double opacity)
     {
-        EnsureLayeredWindow();
+        double clamped = Math.Clamp(
+            opacity,
+            WidgetSettingsService.FloatingOpacityMin,
+            WidgetSettingsService.FloatingOpacityMax);
+        double range = WidgetSettingsService.FloatingOpacityMax - WidgetSettingsService.FloatingOpacityMin;
+        double normalized = range <= 0
+            ? 1
+            : (clamped - WidgetSettingsService.FloatingOpacityMin) / range;
 
-        double opacity = WidgetSettingsService.FloatingOpacity;
-        byte alpha = (byte)Math.Clamp((int)Math.Round(opacity * 255), 1, 255);
+        return (
+            AcrylicTintOpacityMin + ((AcrylicTintOpacityMax - AcrylicTintOpacityMin) * (float)normalized),
+            AcrylicLuminosityOpacityMin
+                + ((AcrylicLuminosityOpacityMax - AcrylicLuminosityOpacityMin) * (float)normalized));
+    }
 
-        var hwnd = Handle;
-        if (hwnd != IntPtr.Zero)
-            User32.SetLayeredWindowAttributes(hwnd, 0, alpha, User32.LWA_ALPHA);
-
-        // Solid chrome fill (window-level alpha handles see-through). Keeps shape readable
-        // without relying on theme resources that fight layered composition.
+    private void ApplyAcrylicMaterial()
+    {
         bool light = ThemeService.IsLightChrome(Root);
         byte r = light ? (byte)248 : (byte)28;
         byte g = light ? (byte)248 : (byte)28;
         byte b = light ? (byte)248 : (byte)28;
-        ChromeFill.Background = new SolidColorBrush(Color.FromArgb(255, r, g, b));
-        ChromeFill.Opacity = 1;
+        var tint = Color.FromArgb(255, r, g, b);
+
+        // The XAML fill is only used if Acrylic cannot be initialized on this machine. When the
+        // controller enters policy fallback (for example, Transparency effects off), it draws its own
+        // solid FallbackColor behind the transparent content.
+        ChromeFill.Background = new SolidColorBrush(tint);
+        ChromeFill.Opacity = _acrylicController is null ? 1 : 0;
+
+        if (_acrylicController is null || _backdropConfiguration is null)
+            return;
+
+        var material = ComputeAcrylicMaterial(WidgetSettingsService.FloatingOpacity);
+        _acrylicController.TintColor = tint;
+        _acrylicController.TintOpacity = material.TintOpacity;
+        _acrylicController.LuminosityOpacity = material.LuminosityOpacity;
+        _acrylicController.FallbackColor = tint;
+
+        _backdropConfiguration.Theme = light
+            ? SystemBackdropTheme.Light
+            : SystemBackdropTheme.Dark;
+        _backdropConfiguration.IsInputActive = true;
+        _backdropConfiguration.IsHighContrast = _accessibilitySettings?.HighContrast == true;
+        _backdropConfiguration.HighContrastBackgroundColor = tint;
+    }
+
+    /// <summary>
+    /// Pure step helper for wheel opacity (and tests). Positive <paramref name="wheelDelta"/>
+    /// increases opacity (wheel up); negative decreases.
+    /// </summary>
+    public static double StepOpacityFromWheel(double current, int wheelDelta)
+    {
+        if (wheelDelta == 0)
+            return Math.Clamp(current, WidgetSettingsService.FloatingOpacityMin, WidgetSettingsService.FloatingOpacityMax);
+
+        // Standard mouse notch is 120; precision touchpads may send smaller deltas.
+        int steps = wheelDelta / 120;
+        if (steps == 0)
+            steps = wheelDelta > 0 ? 1 : -1;
+
+        double next = current + (steps * OpacityWheelStep);
+        return Math.Clamp(
+            Math.Round(next / OpacityWheelStep) * OpacityWheelStep,
+            WidgetSettingsService.FloatingOpacityMin,
+            WidgetSettingsService.FloatingOpacityMax);
     }
 
     private void OnContentClicked()
-    {
-        if (_suppressNextClick)
-        {
-            _suppressNextClick = false;
-            return;
-        }
-        Clicked?.Invoke();
-    }
+        => Clicked?.Invoke();
 
     private void OnDesiredSizeChanged(int logicalWidth, int logicalHeight)
     {
         _logicalWidth = Math.Max(DefaultLogicalWidth, logicalWidth + ChromePaddingLogicalX);
         _logicalHeight = Math.Max(DefaultLogicalHeight, logicalHeight + ChromePaddingLogicalY);
+
+        // The activity control can intentionally retain the last non-empty snapshot for a short grace
+        // period. When that timer finally settles to empty and there are no quota tiles, hide the chrome
+        // with the content instead of leaving an empty floating rectangle behind.
+        if (_shown && !ContentHost.HasVisibleContent)
+        {
+            SetVisible(false);
+            return;
+        }
+
         ApplyBounds(forceShow: _shown);
     }
 
@@ -222,8 +342,7 @@ public sealed partial class FloatingUsageWindow : Window
             if (!_appWindow.IsVisible)
                 _appWindow.Show(false);
             _shown = true;
-            // Layered alpha is sometimes reset after Show; re-apply.
-            ApplyChromeOpacity();
+            ApplyAcrylicMaterial();
             // Hide/show and settings thrash can leave tiles at Opacity 0 while still "assigned".
             ContentHost.EnsureVisibleContent();
         }
@@ -265,6 +384,27 @@ public sealed partial class FloatingUsageWindow : Window
         ApplyBounds(forceShow: _shown);
     }
 
+    private void Root_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
+    {
+        if (_isDragging)
+            return;
+
+        var props = e.GetCurrentPoint(Root).Properties;
+        if (props.IsHorizontalMouseWheel || props.MouseWheelDelta == 0)
+            return;
+
+        e.Handled = true;
+        double next = StepOpacityFromWheel(WidgetSettingsService.FloatingOpacity, props.MouseWheelDelta);
+        WidgetSettingsService.ApplyFloatingOpacity(next);
+    }
+
+    private void Root_RightTapped(object sender, RightTappedRoutedEventArgs e)
+    {
+        e.Handled = true;
+        // Reinject into the taskbar; TaskBarManager reacts to WidgetSettingsService.Changed.
+        WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
+    }
+
     private void Root_PointerPressed(object sender, PointerRoutedEventArgs e)
     {
         if (!e.GetCurrentPoint(Root).Properties.IsLeftButtonPressed)
@@ -272,12 +412,13 @@ public sealed partial class FloatingUsageWindow : Window
 
         _isPointerTracking = true;
         _isDragging = false;
-        _suppressNextClick = false;
         if (!User32.GetCursorPos(out _pressCursor))
             _pressCursor = default;
         if (_appWindow is not null)
             _pressWindowPos = _appWindow.Position;
-        Root.CapturePointer(e.Pointer);
+        // Do not capture here: stealing capture from a child Button prevents its release/click from
+        // completing. The handled-events-too move handler will see the first few pixels and capture only
+        // after the gesture crosses the drag threshold.
     }
 
     private void Root_PointerMoved(object sender, PointerRoutedEventArgs e)
@@ -299,7 +440,10 @@ public sealed partial class FloatingUsageWindow : Window
                 return;
 
             _isDragging = true;
-            _suppressNextClick = true;
+            try { Root.CapturePointer(e.Pointer); } catch { }
+            // Prevent the activity Open button (and quota tiles) from firing after a drag.
+            ContentHost.SuppressNextClicks();
+            e.Handled = true;
         }
 
         int newX = _pressWindowPos.X + dx;
@@ -318,18 +462,36 @@ public sealed partial class FloatingUsageWindow : Window
         _isDragging = false;
         try { Root.ReleasePointerCapture(e.Pointer); } catch { }
 
-        if (wasDragging && _appWindow is not null)
+        if (wasDragging)
         {
-            SavePosition(_appWindow.Position.X, _appWindow.Position.Y);
-            _hasManualPosition = true;
+            e.Handled = true;
+            if (_appWindow is not null)
+            {
+                SavePosition(_appWindow.Position.X, _appWindow.Position.Y);
+                _hasManualPosition = true;
+            }
+
+            // The child consumes any click synthesized by this release. Clear every other child's flag
+            // only after routed input finishes so the next genuine single click is never discarded.
+            DispatcherQueue.TryEnqueue(ContentHost.ClearSuppressedClicks);
         }
     }
 
     private void Root_PointerCanceled(object sender, PointerRoutedEventArgs e)
     {
+        bool wasDragging = _isDragging;
         _isPointerTracking = false;
         _isDragging = false;
         try { Root.ReleasePointerCapture(e.Pointer); } catch { }
+
+        // A Button can report capture-lost before Root receives PointerReleased. Persist the position
+        // here too, otherwise activity-origin drags visibly move but revert on the next launch.
+        if (wasDragging && _appWindow is not null)
+        {
+            SavePosition(_appWindow.Position.X, _appWindow.Position.Y);
+            _hasManualPosition = true;
+        }
+        DispatcherQueue.TryEnqueue(ContentHost.ClearSuppressedClicks);
     }
 
     private void LoadPositionOrDefault()

--- a/src/TaskbarQuota.App/FloatingUsageWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FloatingUsageWindow.xaml.cs
@@ -175,7 +175,11 @@ public sealed partial class FloatingUsageWindow : Window
         Root.RemoveHandler(UIElement.PointerWheelChangedEvent, _rootPointerWheelChanged);
         Root.RightTapped -= Root_RightTapped;
 
-        _accessibilitySettings = null;
+        if (_accessibilitySettings is not null)
+        {
+            _accessibilitySettings.HighContrastChanged -= OnHighContrastChanged;
+            _accessibilitySettings = null;
+        }
 
         if (_acrylicController is not null)
         {
@@ -224,9 +228,15 @@ public sealed partial class FloatingUsageWindow : Window
             _backdropConfiguration = configuration;
 
             _accessibilitySettings = new AccessibilitySettings();
+            _accessibilitySettings.HighContrastChanged += OnHighContrastChanged;
         }
         catch (Exception ex)
         {
+            if (_accessibilitySettings is not null)
+            {
+                _accessibilitySettings.HighContrastChanged -= OnHighContrastChanged;
+                _accessibilitySettings = null;
+            }
             _acrylicController?.RemoveAllSystemBackdropTargets();
             _acrylicController?.Dispose();
             _acrylicController = null;
@@ -489,6 +499,9 @@ public sealed partial class FloatingUsageWindow : Window
             DispatcherQueue.TryEnqueue(ContentHost.ClearSuppressedClicks);
         }
     }
+
+    private void OnHighContrastChanged(AccessibilitySettings sender, object args)
+        => DispatcherQueue.TryEnqueue(ApplyAcrylicMaterial);
 
     private void Root_PointerCaptureLost(object sender, PointerRoutedEventArgs e)
     {

--- a/src/TaskbarQuota.App/FloatingUsageWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FloatingUsageWindow.xaml.cs
@@ -402,16 +402,32 @@ public sealed partial class FloatingUsageWindow : Window
 
     private void Root_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
     {
-        if (_isDragging)
-            return;
-
         var props = e.GetCurrentPoint(Root).Properties;
-        if (props.IsHorizontalMouseWheel || props.MouseWheelDelta == 0)
+        bool overAgentActivity = IsAgentActivitySource(e.OriginalSource);
+        if (!ShouldAdjustOpacityFromWheel(
+                _isDragging, props.IsHorizontalMouseWheel, props.MouseWheelDelta, overAgentActivity))
             return;
 
         e.Handled = true;
         double next = StepOpacityFromWheel(WidgetSettingsService.FloatingOpacity, props.MouseWheelDelta);
         WidgetSettingsService.ApplyFloatingOpacity(next);
+    }
+
+    internal static bool ShouldAdjustOpacityFromWheel(
+        bool isDragging, bool isHorizontalWheel, int wheelDelta, bool overAgentActivity)
+        => !isDragging && !isHorizontalWheel && wheelDelta != 0 && !overAgentActivity;
+
+    private static bool IsAgentActivitySource(object? source)
+    {
+        var current = source as DependencyObject;
+        while (current is not null)
+        {
+            if (current is AgentActivitySummary)
+                return true;
+            current = VisualTreeHelper.GetParent(current);
+        }
+
+        return false;
     }
 
     private void Root_RightTapped(object sender, RightTappedRoutedEventArgs e)

--- a/src/TaskbarQuota.App/FloatingUsageWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FloatingUsageWindow.xaml.cs
@@ -392,13 +392,11 @@ public sealed partial class FloatingUsageWindow : Window
         int w = WindowDpi.ToPhysical(_logicalWidth, scale);
         int h = WindowDpi.ToPhysical(_logicalHeight, scale);
 
-        var pos = _appWindow.Position;
         if (!_hasManualPosition && !_shown)
             PlaceAtDefault();
-        else
-            ClampToWorkArea(ref pos, w, h);
 
-        pos = _appWindow.Position;
+        // Clamp once from the current position, then move+resize in a single call.
+        var pos = _appWindow.Position;
         ClampToWorkArea(ref pos, w, h);
         _appWindow.MoveAndResize(new RectInt32(pos.X, pos.Y, w, h));
 
@@ -406,21 +404,20 @@ public sealed partial class FloatingUsageWindow : Window
             _appWindow.Show(false);
     }
 
+    /// <summary>Pure clamp: updates <paramref name="pos"/> only; does not move the window.</summary>
     private void ClampToWorkArea(ref PointInt32 pos, int width, int height)
     {
         int x = pos.X;
         int y = pos.Y;
         ClampToWorkArea(ref x, ref y, width, height);
         pos = new PointInt32(x, y);
-        _appWindow?.Move(pos);
     }
 
     private void ClampToWorkArea(ref int x, ref int y, int width, int height)
     {
-        var hwnd = Handle;
-        var monitor = hwnd != IntPtr.Zero
-            ? User32.MonitorFromWindow(hwnd, MonitorFromFlags.MONITOR_DEFAULTTONEAREST)
-            : User32.MonitorFromPoint(new POINT { x = x, y = y }, MonitorFromFlags.MONITOR_DEFAULTTONEAREST);
+        // Use the candidate rectangle, not the current window, so a drag can cross monitors.
+        var center = new POINT { x = x + (width / 2), y = y + (height / 2) };
+        var monitor = User32.MonitorFromPoint(center, MonitorFromFlags.MONITOR_DEFAULTTONEAREST);
         var info = MONITORINFO.Create();
         if (monitor == IntPtr.Zero || !User32.GetMonitorInfo(monitor, ref info))
             return;

--- a/src/TaskbarQuota.App/FloatingUsageWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FloatingUsageWindow.xaml.cs
@@ -7,6 +7,8 @@ using Microsoft.UI.Composition;
 using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Windows.Graphics;
@@ -35,6 +37,7 @@ public sealed partial class FloatingUsageWindow : Window
     private const int ChromePaddingLogicalY = 12; // Border padding 6*2
     private const int DefaultLogicalWidth = 200;
     private const int DefaultLogicalHeight = 60;
+    private const int HorizontalScrollbarLogicalHeight = 12;
     private const int DragThresholdLogicalPx = 4;
     private const float AcrylicTintOpacityMin = 0.25f;
     private const float AcrylicTintOpacityMax = 0.80f;
@@ -412,6 +415,8 @@ public sealed partial class FloatingUsageWindow : Window
     {
         if (!e.GetCurrentPoint(Root).Properties.IsLeftButtonPressed)
             return;
+        if (IsScrollBarSource(e.OriginalSource))
+            return;
 
         _isPointerTracking = true;
         _isDragging = false;
@@ -573,10 +578,19 @@ public sealed partial class FloatingUsageWindow : Window
         if (!_hasManualPosition && !_shown)
             PlaceAtDefault();
 
-        // Clamp once from the current position, then move+resize in a single call.
         var pos = _appWindow.Position;
-        ClampToWorkArea(ref pos, w, h);
-        _appWindow.MoveAndResize(new RectInt32(pos.X, pos.Y, w, h));
+        bool hasWorkArea = TryGetWorkArea(pos.X, pos.Y, w, h, out var workArea);
+        bool horizontalOverflow = hasWorkArea && w > workArea.Width;
+        ContentScroller.HorizontalScrollBarVisibility = horizontalOverflow
+            ? ScrollBarVisibility.Auto
+            : ScrollBarVisibility.Hidden;
+        if (horizontalOverflow)
+            h += WindowDpi.ToPhysical(HorizontalScrollbarLogicalHeight, scale);
+
+        var bounds = hasWorkArea
+            ? ConstrainBoundsToWorkArea(new RectInt32(pos.X, pos.Y, w, h), workArea)
+            : new RectInt32(pos.X, pos.Y, w, h);
+        _appWindow.MoveAndResize(bounds);
 
         if (forceShow && !_appWindow.IsVisible)
             _appWindow.Show(false);
@@ -593,21 +607,64 @@ public sealed partial class FloatingUsageWindow : Window
 
     private void ClampToWorkArea(ref int x, ref int y, int width, int height)
     {
+        if (!TryGetWorkArea(x, y, width, height, out var workArea))
+            return;
+
+        var constrained = ConstrainBoundsToWorkArea(
+            new RectInt32(x, y, width, height),
+            workArea);
+        x = constrained.X;
+        y = constrained.Y;
+    }
+
+    private static bool TryGetWorkArea(int x, int y, int width, int height, out RectInt32 workArea)
+    {
         // Use the candidate rectangle, not the current window, so a drag can cross monitors.
         var center = new POINT { x = x + (width / 2), y = y + (height / 2) };
         var monitor = User32.MonitorFromPoint(center, MonitorFromFlags.MONITOR_DEFAULTTONEAREST);
         var info = MONITORINFO.Create();
         if (monitor == IntPtr.Zero || !User32.GetMonitorInfo(monitor, ref info))
-            return;
+        {
+            workArea = default;
+            return false;
+        }
 
-        var work = info.rcWork;
-        if (width > work.right - work.left)
-            width = work.right - work.left;
-        if (height > work.bottom - work.top)
-            height = work.bottom - work.top;
+        workArea = new RectInt32(
+            info.rcWork.left,
+            info.rcWork.top,
+            info.rcWork.right - info.rcWork.left,
+            info.rcWork.bottom - info.rcWork.top);
+        return workArea.Width > 0 && workArea.Height > 0;
+    }
 
-        x = Math.Clamp(x, work.left, work.right - width);
-        y = Math.Clamp(y, work.top, work.bottom - height);
+    internal static RectInt32 ConstrainBoundsToWorkArea(RectInt32 desired, RectInt32 workArea)
+    {
+        int width = Math.Clamp(desired.Width, 1, Math.Max(1, workArea.Width));
+        int height = Math.Clamp(desired.Height, 1, Math.Max(1, workArea.Height));
+        int x = Math.Clamp(
+            desired.X,
+            workArea.X,
+            Math.Max(workArea.X, workArea.X + workArea.Width - width));
+        int y = Math.Clamp(
+            desired.Y,
+            workArea.Y,
+            Math.Max(workArea.Y, workArea.Y + workArea.Height - height));
+
+        return new RectInt32(x, y, width, height);
+    }
+
+    private static bool IsScrollBarSource(object? source)
+    {
+        var current = source as DependencyObject;
+        while (current is not null)
+        {
+            if (current is ScrollBar)
+                return true;
+
+            current = VisualTreeHelper.GetParent(current);
+        }
+
+        return false;
     }
 
     private static void SavePosition(int x, int y)

--- a/src/TaskbarQuota.App/FloatingUsageWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FloatingUsageWindow.xaml.cs
@@ -47,6 +47,7 @@ public sealed partial class FloatingUsageWindow : Window
     private bool _shown;
     private bool _isDragging;
     private bool _isPointerTracking;
+    private bool _isTransferringPointerCapture;
     private POINT _pressCursor;
     private PointInt32 _pressWindowPos;
     private int _logicalWidth = DefaultLogicalWidth;
@@ -61,6 +62,7 @@ public sealed partial class FloatingUsageWindow : Window
     private readonly PointerEventHandler _rootPointerMoved;
     private readonly PointerEventHandler _rootPointerReleased;
     private readonly PointerEventHandler _rootPointerCanceled;
+    private readonly PointerEventHandler _rootPointerCaptureLost;
     private readonly PointerEventHandler _rootPointerWheelChanged;
 
     public event Action? Clicked;
@@ -108,6 +110,7 @@ public sealed partial class FloatingUsageWindow : Window
         _rootPointerMoved = Root_PointerMoved;
         _rootPointerReleased = Root_PointerReleased;
         _rootPointerCanceled = Root_PointerCanceled;
+        _rootPointerCaptureLost = Root_PointerCaptureLost;
         _rootPointerWheelChanged = Root_PointerWheelChanged;
 
         // Use the lower-level native controller rather than DesktopAcrylicBackdrop so this deliberately
@@ -145,7 +148,7 @@ public sealed partial class FloatingUsageWindow : Window
         Root.AddHandler(UIElement.PointerMovedEvent, _rootPointerMoved, handledEventsToo: true);
         Root.AddHandler(UIElement.PointerReleasedEvent, _rootPointerReleased, handledEventsToo: true);
         Root.AddHandler(UIElement.PointerCanceledEvent, _rootPointerCanceled, handledEventsToo: true);
-        Root.AddHandler(UIElement.PointerCaptureLostEvent, _rootPointerCanceled, handledEventsToo: true);
+        Root.AddHandler(UIElement.PointerCaptureLostEvent, _rootPointerCaptureLost, handledEventsToo: true);
         Root.AddHandler(UIElement.PointerWheelChangedEvent, _rootPointerWheelChanged, handledEventsToo: true);
         Root.RightTapped += Root_RightTapped;
 
@@ -165,7 +168,7 @@ public sealed partial class FloatingUsageWindow : Window
         Root.RemoveHandler(UIElement.PointerMovedEvent, _rootPointerMoved);
         Root.RemoveHandler(UIElement.PointerReleasedEvent, _rootPointerReleased);
         Root.RemoveHandler(UIElement.PointerCanceledEvent, _rootPointerCanceled);
-        Root.RemoveHandler(UIElement.PointerCaptureLostEvent, _rootPointerCanceled);
+        Root.RemoveHandler(UIElement.PointerCaptureLostEvent, _rootPointerCaptureLost);
         Root.RemoveHandler(UIElement.PointerWheelChangedEvent, _rootPointerWheelChanged);
         Root.RightTapped -= Root_RightTapped;
 
@@ -440,7 +443,12 @@ public sealed partial class FloatingUsageWindow : Window
                 return;
 
             _isDragging = true;
+            // A child Button normally owns capture at this point. Transferring it to Root raises
+            // PointerCaptureLost on that child synchronously; ignore only that expected routed event,
+            // while retaining normal cancellation when Root later loses capture for real.
+            _isTransferringPointerCapture = true;
             try { Root.CapturePointer(e.Pointer); } catch { }
+            finally { _isTransferringPointerCapture = false; }
             // Prevent the activity Open button (and quota tiles) from firing after a drag.
             ContentHost.SuppressNextClicks();
             e.Handled = true;
@@ -475,6 +483,14 @@ public sealed partial class FloatingUsageWindow : Window
             // only after routed input finishes so the next genuine single click is never discarded.
             DispatcherQueue.TryEnqueue(ContentHost.ClearSuppressedClicks);
         }
+    }
+
+    private void Root_PointerCaptureLost(object sender, PointerRoutedEventArgs e)
+    {
+        if (_isTransferringPointerCapture && !ReferenceEquals(e.OriginalSource, Root))
+            return;
+
+        Root_PointerCanceled(sender, e);
     }
 
     private void Root_PointerCanceled(object sender, PointerRoutedEventArgs e)

--- a/src/TaskbarQuota.App/FlyoutLayout.cs
+++ b/src/TaskbarQuota.App/FlyoutLayout.cs
@@ -45,8 +45,11 @@ namespace TaskbarQuota
         /// <summary>Largest dashboard content height before scrolling takes over.</summary>
         public const int MaxLogicalContentHeight = 760;
 
-        /// <summary>Frame padding + scroll padding + bottom chrome (update bar is optional / collapsed).</summary>
-        public const int ChromeLogicalHeight = 122;
+        /// <summary>
+        /// Frame padding + scroll padding + bottom chrome (update bar is optional / collapsed).
+        /// Includes the quick surface/opacity bar above the provider strip (~52px).
+        /// </summary>
+        public const int ChromeLogicalHeight = 174;
 
         public const int HeightMeasureBuffer = 40;
         public const string ForceMinWidthEnvironmentVariable = "TASKBARQUOTA_FORCE_MIN_FLYOUT_WIDTH";

--- a/src/TaskbarQuota.App/FlyoutLayout.cs
+++ b/src/TaskbarQuota.App/FlyoutLayout.cs
@@ -85,5 +85,62 @@ namespace TaskbarQuota
             return string.Equals(value, "1", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
         }
+
+        /// <summary>
+        /// Positions a flyout relative to an anchor (taskbar widget or floating window), preferring
+        /// above when there is room and flipping below when the top of the work area would crush height.
+        /// All coordinates are physical pixels.
+        /// </summary>
+        public static FlyoutPlacementResult ComputePlacement(
+            int anchorLeft,
+            int anchorTop,
+            int anchorRight,
+            int anchorBottom,
+            int workLeft,
+            int workTop,
+            int workRight,
+            int workBottom,
+            int width,
+            int height,
+            int gap)
+        {
+            int workWidth = Math.Max(0, workRight - workLeft);
+            int workHeight = Math.Max(0, workBottom - workTop);
+            width = Math.Clamp(width, 1, Math.Max(1, workWidth));
+            height = Math.Clamp(height, 1, Math.Max(1, workHeight));
+            gap = Math.Max(0, gap);
+
+            int spaceAbove = Math.Max(0, anchorTop - workTop - gap);
+            int spaceBelow = Math.Max(0, workBottom - anchorBottom - gap);
+
+            bool placeAbove;
+            if (spaceAbove >= height)
+                placeAbove = true;
+            else if (spaceBelow >= height)
+                placeAbove = false;
+            else
+                placeAbove = spaceAbove >= spaceBelow;
+
+            int available = placeAbove ? spaceAbove : spaceBelow;
+            // Only shrink when neither side can host the full height; keep as much as fits.
+            if (available < height)
+                height = Math.Max(1, available);
+
+            int x = Math.Clamp(anchorRight - width, workLeft, Math.Max(workLeft, workRight - width));
+            int y = placeAbove
+                ? anchorTop - height - gap
+                : anchorBottom + gap;
+            y = Math.Clamp(y, workTop, Math.Max(workTop, workBottom - height));
+
+            return new FlyoutPlacementResult(x, y, width, height, placeAbove);
+        }
     }
+
+    /// <summary>Result of <see cref="FlyoutLayout.ComputePlacement"/> in physical pixels.</summary>
+    internal readonly record struct FlyoutPlacementResult(
+        int X,
+        int Y,
+        int Width,
+        int Height,
+        bool PlacedAbove);
 }

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml
@@ -80,62 +80,95 @@
                     Grid.Row="2"
                     Margin="12,0,12,12"
                     Spacing="8"
-                    Orientation="Horizontal"
-                    HorizontalAlignment="Left"
                     VerticalAlignment="Bottom">
+            <!-- Quick controls: surface mode + floating opacity (always available).
+                 Opacity slider is created in code — RangeBase Minimum/Maximum cannot be set safely in XAML
+                 (defaults Maximum=1; assigning Minimum=35 throws XamlParseException). -->
             <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1"
                     CornerRadius="8"
-                    Padding="4,0">
-                <StackPanel x:Name="ProviderStrip"
-                            MinHeight="48"
-                            Orientation="Horizontal"/>
+                    Padding="10,8">
+                <StackPanel Orientation="Horizontal" Spacing="10">
+                    <ToggleButton x:Name="FloatingSurfaceButton"
+                                  MinWidth="108"
+                                  VerticalAlignment="Center"
+                                  Click="FloatingSurfaceButton_Click"
+                                  AutomationProperties.Name="Show usage as floating window"
+                                  AutomationProperties.AutomationId="FlyoutFloatingSurfaceButton"
+                                  ToolTipService.ToolTip="Show usage as a floating always-on-top window instead of the taskbar">
+                        <TextBlock x:Name="FloatingSurfaceButtonLabel" Text="Floating"/>
+                    </ToggleButton>
+                    <Grid x:Name="FloatingOpacitySliderHost"
+                          Width="160"
+                          VerticalAlignment="Center"
+                          AutomationProperties.Name="Floating window opacity"/>
+                    <TextBlock x:Name="FloatingOpacityLabel"
+                               MinWidth="40"
+                               VerticalAlignment="Center"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Opacity="0.8"
+                               Text="90%"/>
+                </StackPanel>
             </Border>
 
-            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                    BorderThickness="1"
-                    CornerRadius="8">
-                <Button x:Name="ActivityButton"
-                        Width="48"
-                        Height="48"
-                        MinWidth="0"
-                        MinHeight="0"
-                        Padding="0"
-                        BorderThickness="0"
-                        Background="Transparent"
-                        AutomationProperties.Name="Agent activity"
-                        AutomationProperties.AutomationId="FlyoutActivityButton"
-                        Click="ActivityButton_Click"
-                        ToolTipService.ToolTip="Agent activity">
-                    <FontIcon Glyph="&#xE7F4;"
-                              FontSize="16"
-                              Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                </Button>
-            </Border>
+            <StackPanel Orientation="Horizontal"
+                        Spacing="8"
+                        HorizontalAlignment="Left">
+                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        Padding="4,0">
+                    <StackPanel x:Name="ProviderStrip"
+                                MinHeight="48"
+                                Orientation="Horizontal"/>
+                </Border>
 
-            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                    BorderThickness="1"
-                    CornerRadius="8">
-                <Button x:Name="SettingsButton"
-                        Width="48"
-                        Height="48"
-                        MinWidth="0"
-                        MinHeight="0"
-                        Padding="0"
-                        BorderThickness="0"
-                        Background="Transparent"
-                        AutomationProperties.Name="Settings"
-                        AutomationProperties.AutomationId="FlyoutSettingsButton"
-                        Click="SettingsButton_Click"
-                        ToolTipService.ToolTip="Settings">
-                    <FontIcon Glyph="&#xE713;"
-                              FontSize="16"
-                              Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                </Button>
-            </Border>
+                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="8">
+                    <Button x:Name="ActivityButton"
+                            Width="48"
+                            Height="48"
+                            MinWidth="0"
+                            MinHeight="0"
+                            Padding="0"
+                            BorderThickness="0"
+                            Background="Transparent"
+                            AutomationProperties.Name="Agent activity"
+                            AutomationProperties.AutomationId="FlyoutActivityButton"
+                            Click="ActivityButton_Click"
+                            ToolTipService.ToolTip="Agent activity">
+                        <FontIcon Glyph="&#xE7F4;"
+                                  FontSize="16"
+                                  Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                    </Button>
+                </Border>
+
+                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="8">
+                    <Button x:Name="SettingsButton"
+                            Width="48"
+                            Height="48"
+                            MinWidth="0"
+                            MinHeight="0"
+                            Padding="0"
+                            BorderThickness="0"
+                            Background="Transparent"
+                            AutomationProperties.Name="Settings"
+                            AutomationProperties.AutomationId="FlyoutSettingsButton"
+                            Click="SettingsButton_Click"
+                            ToolTipService.ToolTip="Settings">
+                        <FontIcon Glyph="&#xE713;"
+                                  FontSize="16"
+                                  Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                    </Button>
+                </Border>
+            </StackPanel>
         </StackPanel>
     </Grid>
 </Window>

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml
@@ -81,7 +81,7 @@
                     Margin="12,0,12,12"
                     Spacing="8"
                     VerticalAlignment="Bottom">
-            <!-- Quick controls: surface mode + floating opacity (always available).
+            <!-- Quick controls: surface mode + floating Acrylic strength (always available).
                  Opacity slider is created in code — RangeBase Minimum/Maximum cannot be set safely in XAML
                  (defaults Maximum=1; assigning Minimum=35 throws XamlParseException). -->
             <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
@@ -102,7 +102,7 @@
                     <Grid x:Name="FloatingOpacitySliderHost"
                           Width="160"
                           VerticalAlignment="Center"
-                          AutomationProperties.Name="Floating window opacity"/>
+                          AutomationProperties.Name="Floating acrylic strength"/>
                     <TextBlock x:Name="FloatingOpacityLabel"
                                MinWidth="40"
                                VerticalAlignment="Center"

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml
@@ -48,9 +48,9 @@
                               MinWidth="76"
                               VerticalAlignment="Center"
                               Click="ActivityWidgetButton_Click"
-                              AutomationProperties.Name="Show agent activity in taskbar widget"
+                              AutomationProperties.Name="Show agent activity in usage widget"
                               AutomationProperties.AutomationId="FlyoutActivityWidgetButton"
-                              ToolTipService.ToolTip="Show agent activity in taskbar widget">
+                              ToolTipService.ToolTip="Show agent activity in usage widget">
                     <TextBlock Text="Activity Widget"/>
                 </ToggleButton>
             </Grid>

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -272,9 +272,9 @@ namespace TaskbarQuota
             ActivityWidgetButton.IsEnabled = monitoringEnabled;
             ActivityMonitoringButton.IsChecked = monitoringEnabled;
             ToolTipService.SetToolTip(ActivityWidgetButton,
-                widgetEnabled ? "Hide agent activity from taskbar widget" : "Show agent activity in taskbar widget");
+                widgetEnabled ? "Hide agent activity from usage widget" : "Show agent activity in usage widget");
             AutomationProperties.SetName(ActivityWidgetButton,
-                widgetEnabled ? "Hide agent activity from taskbar widget" : "Show agent activity in taskbar widget");
+                widgetEnabled ? "Hide agent activity from usage widget" : "Show agent activity in usage widget");
             ToolTipService.SetToolTip(ActivityMonitoringButton,
                 monitoringEnabled ? "Stop monitoring local agent activity" : "Start monitoring local agent activity");
             AutomationProperties.SetName(ActivityMonitoringButton,
@@ -781,7 +781,7 @@ namespace TaskbarQuota
             if (_providerStripItems.TryGetValue(id, out var item))
                 item.Pin.Visibility = pinned ? Visibility.Visible : Visibility.Collapsed;
 
-            ToolTipService.SetToolTip(button, pinned ? $"{displayName} — pinned to the taskbar" : displayName);
+            ToolTipService.SetToolTip(button, pinned ? $"{displayName} — pinned in the usage widget" : displayName);
         }
 
         /// <summary>

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -303,9 +303,9 @@ namespace TaskbarQuota
                 Math.Round(WidgetSettingsService.FloatingOpacity * 100),
                 35,
                 100);
-            AutomationProperties.SetName(slider, "Floating window opacity");
+            AutomationProperties.SetName(slider, "Floating acrylic strength");
             AutomationProperties.SetAutomationId(slider, "FlyoutFloatingOpacitySlider");
-            ToolTipService.SetToolTip(slider, "Floating window opacity (lower shows more of the desktop)");
+            ToolTipService.SetToolTip(slider, "Floating Acrylic strength (or scroll the floating window). Lower reveals more of the blurred desktop.");
             slider.ValueChanged += FloatingOpacitySlider_ValueChanged;
 
             FloatingOpacitySliderHost.Children.Clear();
@@ -337,8 +337,8 @@ namespace TaskbarQuota
                     slider.IsEnabled = floating;
                     ToolTipService.SetToolTip(slider,
                         floating
-                            ? "Floating window opacity"
-                            : "Opacity applies when floating window mode is on");
+                            ? "Floating acrylic strength"
+                            : "Acrylic strength applies when floating window mode is on");
                 }
                 FloatingOpacityLabel.Text = $"{percent}%";
                 FloatingOpacityLabel.Opacity = floating ? 0.9 : 0.45;
@@ -586,29 +586,29 @@ namespace TaskbarQuota
                     return;
 
                 int gap = WindowDpi.ToPhysical(8, scale);
-                int maxHeight = Math.Max(WindowDpi.ToPhysical(320, scale), wr.top - gap);
-                h = Math.Min(h, maxHeight);
 
-                // Right-align the flyout to the widget, floating just above the taskbar.
-                int x = wr.right - w;
-                int y = wr.top - h - gap;
-
-                // Confine the flyout to the monitor that hosts the widget so it never straddles a
-                // monitor boundary on multi-display setups (issue #10).
-                if (TryGetWorkArea(_widgetHandle, out RECT work))
+                // Confine to the monitor that hosts the widget so it never straddles a display
+                // (issue #10). Prefer above the anchor; flip below when the top would crush height
+                // (floating window near the top of the screen).
+                RECT work;
+                if (!TryGetWorkArea(_widgetHandle, out work))
                 {
-                    w = Math.Min(w, work.right - work.left);
-                    h = Math.Min(h, work.bottom - work.top);
-                    x = Math.Clamp(wr.right - w, work.left, work.right - w);
-                    y = Math.Clamp(y, work.top, work.bottom - h);
-                }
-                else
-                {
-                    if (y < 0) y = 0;
-                    if (x < 0) x = 0;
+                    work = new RECT
+                    {
+                        left = 0,
+                        top = 0,
+                        right = Math.Max(w, wr.right),
+                        bottom = Math.Max(h + wr.bottom, wr.bottom + h),
+                    };
                 }
 
-                var bounds = new RectInt32(x, y, w, h);
+                var placement = FlyoutLayout.ComputePlacement(
+                    wr.left, wr.top, wr.right, wr.bottom,
+                    work.left, work.top, work.right, work.bottom,
+                    w, h, gap);
+
+                var bounds = new RectInt32(
+                    placement.X, placement.Y, placement.Width, placement.Height);
                 if (_lastAppliedBounds is { } last
                     && last.X == bounds.X
                     && last.Y == bounds.Y

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -38,12 +38,14 @@ namespace TaskbarQuota
         private bool _showingActivity;
         private bool _sizeHooksRegistered;
         private bool _applyingBounds;
+        private bool _suppressSurfaceControlEvents;
         private DispatcherQueueTimer? _boundsUpdateTimer;
         private RectInt32? _lastAppliedBounds;
         private double _lastObservedScale = -1;
         private readonly DashboardViewModel _dashboardViewModel;
         private readonly Dictionary<ProviderId, FlyoutProviderStripItem> _providerStripItems = new();
         private int _stripIconCount;
+        private Slider? _floatingOpacitySlider;
         private static readonly TimeSpan BoundsCoalesceDelay = TimeSpan.FromMilliseconds(80);
 
         public bool IsShown => _shown;
@@ -51,7 +53,9 @@ namespace TaskbarQuota
         public FlyoutWindow()
         {
             InitializeComponent();
+            BuildFloatingOpacitySlider();
             UpdateActivityControls();
+            UpdateSurfaceControls();
             _dashboardViewModel = DashboardPage.SharedViewModel ?? new DashboardViewModel(DispatcherQueue);
             DashboardPage.SharedViewModel = _dashboardViewModel;
             _dashboardViewModel.Cards.CollectionChanged += DashboardCards_CollectionChanged;
@@ -96,6 +100,7 @@ namespace TaskbarQuota
         {
             Closed -= OnClosed;
             Activated -= OnActivated;
+            ThemeService.Unregister(Root);
             WidgetSettingsService.Changed -= OnWidgetSettingsChanged;
             AgentActivityService.Instance.Changed -= OnActivityChanged;
             _dashboardViewModel.Cards.CollectionChanged -= DashboardCards_CollectionChanged;
@@ -111,6 +116,7 @@ namespace TaskbarQuota
             {
                 SyncProviderStripPins();
                 UpdateActivityControls();
+                UpdateSurfaceControls();
             });
 
         private void OnActivated(object sender, WindowActivatedEventArgs args)
@@ -197,6 +203,7 @@ namespace TaskbarQuota
                 _dashboardViewModel.SelectProvider(active);
 
             _shown = true;
+            UpdateSurfaceControls();
             ApplyFlyoutBounds();
             GetAppWindow().Show();
             ActivateFlyout();
@@ -272,6 +279,95 @@ namespace TaskbarQuota
                 monitoringEnabled ? "Stop monitoring local agent activity" : "Start monitoring local agent activity");
             AutomationProperties.SetName(ActivityMonitoringButton,
                 monitoringEnabled ? "Stop monitoring local agent activity" : "Start monitoring local agent activity");
+        }
+
+        /// <summary>
+        /// Builds the opacity slider in code. WinUI RangeBase defaults Maximum=1; assigning Minimum=35
+        /// from XAML throws XamlParseException regardless of attribute order.
+        /// </summary>
+        private void BuildFloatingOpacitySlider()
+        {
+            if (_floatingOpacitySlider is not null)
+                return;
+
+            var slider = new Slider
+            {
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment = VerticalAlignment.Center,
+                StepFrequency = 1,
+            };
+            // Order matters: raise Maximum first, then Minimum, then Value.
+            slider.Maximum = 100;
+            slider.Minimum = 35;
+            slider.Value = Math.Clamp(
+                Math.Round(WidgetSettingsService.FloatingOpacity * 100),
+                35,
+                100);
+            AutomationProperties.SetName(slider, "Floating window opacity");
+            AutomationProperties.SetAutomationId(slider, "FlyoutFloatingOpacitySlider");
+            ToolTipService.SetToolTip(slider, "Floating window opacity (lower shows more of the desktop)");
+            slider.ValueChanged += FloatingOpacitySlider_ValueChanged;
+
+            FloatingOpacitySliderHost.Children.Clear();
+            FloatingOpacitySliderHost.Children.Add(slider);
+            _floatingOpacitySlider = slider;
+        }
+
+        private void UpdateSurfaceControls()
+        {
+            _suppressSurfaceControlEvents = true;
+            try
+            {
+                bool floating = WidgetSettingsService.CurrentSurface == WidgetSurfaceMode.Floating;
+                FloatingSurfaceButton.IsChecked = floating;
+                FloatingSurfaceButtonLabel.Text = floating ? "Floating" : "Taskbar";
+                ToolTipService.SetToolTip(FloatingSurfaceButton,
+                    floating
+                        ? "Switch back to the taskbar widget"
+                        : "Show usage as a floating always-on-top window");
+                AutomationProperties.SetName(FloatingSurfaceButton,
+                    floating
+                        ? "Show usage in the taskbar"
+                        : "Show usage as floating window");
+
+                int percent = (int)Math.Round(WidgetSettingsService.FloatingOpacity * 100);
+                if (_floatingOpacitySlider is { } slider)
+                {
+                    slider.Value = percent;
+                    slider.IsEnabled = floating;
+                    ToolTipService.SetToolTip(slider,
+                        floating
+                            ? "Floating window opacity"
+                            : "Opacity applies when floating window mode is on");
+                }
+                FloatingOpacityLabel.Text = $"{percent}%";
+                FloatingOpacityLabel.Opacity = floating ? 0.9 : 0.45;
+            }
+            finally
+            {
+                _suppressSurfaceControlEvents = false;
+            }
+        }
+
+        private void FloatingSurfaceButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_suppressSurfaceControlEvents)
+                return;
+
+            bool wantFloating = FloatingSurfaceButton.IsChecked == true;
+            WidgetSettingsService.ApplySurface(
+                wantFloating ? WidgetSurfaceMode.Floating : WidgetSurfaceMode.Taskbar);
+            UpdateSurfaceControls();
+        }
+
+        private void FloatingOpacitySlider_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+        {
+            if (_suppressSurfaceControlEvents)
+                return;
+
+            int percent = (int)Math.Round(e.NewValue);
+            FloatingOpacityLabel.Text = $"{percent}%";
+            WidgetSettingsService.ApplyFloatingOpacity(percent / 100d);
         }
 
         private void OnActivityChanged(AgentActivitySnapshot snapshot)

--- a/src/TaskbarQuota.App/Interop/Native.cs
+++ b/src/TaskbarQuota.App/Interop/Native.cs
@@ -147,6 +147,21 @@ namespace TaskbarQuota.Interop
         public static extern IntPtr SetWindowLongPtr(IntPtr hwnd, int index, IntPtr newStyle);
 
         [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern int GetWindowLong(IntPtr hwnd, int index);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern IntPtr GetWindowLongPtr(IntPtr hwnd, int index);
+
+        /// <summary>Sets opacity and/or color key for a WS_EX_LAYERED window.</summary>
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool SetLayeredWindowAttributes(IntPtr hwnd, uint crKey, byte bAlpha, uint dwFlags);
+
+        public const int GWL_EXSTYLE = -20;
+        public const uint LWA_COLORKEY = 0x1;
+        public const uint LWA_ALPHA = 0x2;
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         public static extern IntPtr SendMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
 
         public const uint WM_SETICON = 0x0080;
@@ -240,6 +255,10 @@ namespace TaskbarQuota.Interop
     {
         Default = 0,
         WS_EX_LAYERED = 0x80000,
+        WS_EX_TOOLWINDOW = 0x00000080,
+        WS_EX_TOPMOST = 0x00000008,
+        WS_EX_NOACTIVATE = 0x08000000,
+        WS_EX_TRANSPARENT = 0x00000020,
     }
 
     [Flags]

--- a/src/TaskbarQuota.App/MainWindow.xaml.cs
+++ b/src/TaskbarQuota.App/MainWindow.xaml.cs
@@ -37,6 +37,7 @@ namespace TaskbarQuota
             // go of the static settings event or every reopen leaks one.
             Closed += (_, _) =>
             {
+                ThemeService.Unregister(Root);
                 _navigationBinder?.Dispose();
                 _navigationBinder = null;
             };

--- a/src/TaskbarQuota.App/Services/AppStorage.cs
+++ b/src/TaskbarQuota.App/Services/AppStorage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 
 namespace TaskbarQuota;
 
@@ -9,8 +10,24 @@ public static class AppStorage
     public const string AppFolderName = "TaskbarQuota";
     private const string LegacyAppFolderName = "WinCheck";
 
-    public static string AppDataDirectory =>
-        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), AppFolderName);
+    private static string? _appDataDirectoryOverride;
+
+    public static string AppDataDirectory => _appDataDirectoryOverride
+        ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), AppFolderName);
+
+    internal static IDisposable OverrideAppDataDirectoryForTesting(string directory)
+    {
+        var previous = _appDataDirectoryOverride;
+        _appDataDirectoryOverride = directory;
+        return new AppDataDirectoryOverride(() => _appDataDirectoryOverride = previous);
+    }
+
+    private sealed class AppDataDirectoryOverride(Action restore) : IDisposable
+    {
+        private Action? _restore = restore;
+
+        public void Dispose() => Interlocked.Exchange(ref _restore, null)?.Invoke();
+    }
 
     /// <summary>Copies files from %LOCALAPPDATA%\WinCheck when the new folder is empty.</summary>
     public static void MigrateLegacyDataIfNeeded()

--- a/src/TaskbarQuota.App/Services/PinBudgetService.cs
+++ b/src/TaskbarQuota.App/Services/PinBudgetService.cs
@@ -22,6 +22,21 @@ public static class PinBudgetService
     /// <summary>Raised after the budget auto-unpins providers, so the UI can refresh and explain.</summary>
     public static event Action<IReadOnlyList<ProviderId>>? ProvidersUnpinned;
 
+    /// <summary>
+    /// Free width assumed when the usage UI is a floating window rather than a taskbar island. Wide enough
+    /// that pins are limited by <see cref="UsageCoordinator.MaxDisplayedWidgetTiles"/>, not by the tray gap.
+    /// </summary>
+    public const int FloatingAvailableLogicalWidth = 1200;
+
+    /// <summary>
+    /// Free width the pin budget uses for the current surface: measured taskbar span, or a large fixed
+    /// budget when usage is shown in the floating window.
+    /// </summary>
+    public static int AvailableLogicalWidth
+        => WidgetSettingsService.CurrentSurface == WidgetSurfaceMode.Floating
+            ? FloatingAvailableLogicalWidth
+            : Taskbar.TaskbarSpace.AvailableLogicalWidth;
+
     // Tile chrome, mirroring TaskBarWidget: 4px of margin per tile and a 7px divider between neighbours.
     private const int TileMarginLogicalPx = 4;
     private const int TileSeparatorLogicalPx = 7;
@@ -115,19 +130,25 @@ public static class PinBudgetService
         }
 
         var candidate = pinned.Append(provider).ToList();
-        if (!FitsTaskbar(candidate, Taskbar.TaskbarSpace.AvailableLogicalWidth))
+        int available = AvailableLogicalWidth;
+        if (!FitsTaskbar(candidate, available))
         {
             // A refusal the user did not expect is impossible to diagnose from the message alone, since it
             // turns on measurements they cannot see. Record what the decision was actually made from.
             Diagnostics.Log.Debug(
                 $"[pin] refused {provider}: tiles=[{string.Join(", ", candidate.Select(p => $"{p}:{TileWidth(p)}{(Taskbar.TaskbarSpace.TryGetTileWidth(p, out _) ? "" : "~")}"))}] "
                 + $"row={RowWidth(candidate.Select(TileWidth).ToList())} "
-                + $"available={Taskbar.TaskbarSpace.AvailableLogicalWidth}");
+                + $"available={available}");
 
-            reason = $"There isn't room on the taskbar for {name} ({Describe(provider)}) next to "
-                + $"{string.Join(" and ", pinned.Select(p => $"{ProviderName(p)} ({Describe(p)})"))}. "
-                + $"Turn off some rows for {name} or for a pinned provider, unpin one, or set the Windows "
-                + "taskbar to left alignment — that frees up a lot more room.";
+            bool floating = WidgetSettingsService.CurrentSurface == WidgetSurfaceMode.Floating;
+            reason = floating
+                ? $"There isn't room in the floating widget for {name} ({Describe(provider)}) next to "
+                  + $"{string.Join(" and ", pinned.Select(p => $"{ProviderName(p)} ({Describe(p)})"))}. "
+                  + $"Turn off some rows for {name} or for a pinned provider, or unpin one."
+                : $"There isn't room on the taskbar for {name} ({Describe(provider)}) next to "
+                  + $"{string.Join(" and ", pinned.Select(p => $"{ProviderName(p)} ({Describe(p)})"))}. "
+                  + $"Turn off some rows for {name} or for a pinned provider, unpin one, or set the Windows "
+                  + "taskbar to left alignment — that frees up a lot more room.";
             return false;
         }
 
@@ -178,10 +199,11 @@ public static class PinBudgetService
 
         var keeping = new List<ProviderId>(order);
         var dropped = new List<ProviderId>();
+        int available = AvailableLogicalWidth;
         foreach (var provider in order)
         {
             if (keeping.Count <= UsageCoordinator.MaxDisplayedWidgetTiles
-                && FitsTaskbar(keeping, Taskbar.TaskbarSpace.AvailableLogicalWidth))
+                && FitsTaskbar(keeping, available))
             {
                 break;
             }
@@ -215,7 +237,8 @@ public static class PinBudgetService
     private static int BudgetKey()
     {
         var hash = new HashCode();
-        hash.Add(Taskbar.TaskbarSpace.AvailableLogicalWidth);
+        hash.Add(AvailableLogicalWidth);
+        hash.Add((int)WidgetSettingsService.CurrentSurface);
         hash.Add(UsageCoordinator.MaxDisplayedWidgetTiles);
         foreach (var provider in AllProviders)
         {

--- a/src/TaskbarQuota.App/Services/PinBudgetService.cs
+++ b/src/TaskbarQuota.App/Services/PinBudgetService.cs
@@ -23,8 +23,10 @@ public static class PinBudgetService
     public static event Action<IReadOnlyList<ProviderId>>? ProvidersUnpinned;
 
     /// <summary>
-    /// Free width assumed when the usage UI is a floating window rather than a taskbar island. Wide enough
-    /// that pins are limited by <see cref="UsageCoordinator.MaxDisplayedWidgetTiles"/>, not by the tray gap.
+    /// Free width for the floating surface pin budget, in logical px of <em>tile content</em>
+    /// (not including the floating window's chrome padding). Wide enough that pins are limited by
+    /// <see cref="UsageCoordinator.MaxDisplayedWidgetTiles"/>, not by a tray gap.
+    /// Matches what <c>QuotaWidgetContent</c> sums when sizing tiles; host padding is applied outside this.
     /// </summary>
     public const int FloatingAvailableLogicalWidth = 1200;
 
@@ -121,10 +123,12 @@ public static class PinBudgetService
 
         var pinned = PinnedProviders();
         string name = ProviderName(provider);
+        bool floating = WidgetSettingsService.CurrentSurface == WidgetSurfaceMode.Floating;
+        string surfaceNoun = floating ? "floating widget" : "taskbar";
 
         if (pinned.Count >= UsageCoordinator.MaxDisplayedWidgetTiles)
         {
-            reason = $"The taskbar can show at most {UsageCoordinator.MaxDisplayedWidgetTiles} quota providers at once, and you already "
+            reason = $"The {surfaceNoun} can show at most {UsageCoordinator.MaxDisplayedWidgetTiles} quota providers at once, and you already "
                 + $"have {string.Join(", ", pinned.Select(ProviderName))} pinned. Unpin one of those to make room for {name}.";
             return false;
         }
@@ -140,7 +144,6 @@ public static class PinBudgetService
                 + $"row={RowWidth(candidate.Select(TileWidth).ToList())} "
                 + $"available={available}");
 
-            bool floating = WidgetSettingsService.CurrentSurface == WidgetSurfaceMode.Floating;
             reason = floating
                 ? $"There isn't room in the floating widget for {name} ({Describe(provider)}) next to "
                   + $"{string.Join(" and ", pinned.Select(p => $"{ProviderName(p)} ({Describe(p)})"))}. "

--- a/src/TaskbarQuota.App/Services/PinBudgetService.cs
+++ b/src/TaskbarQuota.App/Services/PinBudgetService.cs
@@ -23,20 +23,12 @@ public static class PinBudgetService
     public static event Action<IReadOnlyList<ProviderId>>? ProvidersUnpinned;
 
     /// <summary>
-    /// Free width for the floating surface pin budget, in logical px of <em>tile content</em>
-    /// (not including the floating window's chrome padding). Wide enough that pins are limited by
-    /// <see cref="UsageCoordinator.MaxDisplayedWidgetTiles"/>, not by a tray gap.
-    /// Matches what <c>QuotaWidgetContent</c> sums when sizing tiles; host padding is applied outside this.
-    /// </summary>
-    public const int FloatingAvailableLogicalWidth = 1200;
-
-    /// <summary>
-    /// Free width the pin budget uses for the current surface: measured taskbar span, or a large fixed
-    /// budget when usage is shown in the floating window.
+    /// Free width the pin budget uses for the current surface. Floating mode is constrained only by the
+    /// tile cap; its host scrolls horizontally when content is wider than the monitor work area.
     /// </summary>
     public static int AvailableLogicalWidth
         => WidgetSettingsService.CurrentSurface == WidgetSurfaceMode.Floating
-            ? FloatingAvailableLogicalWidth
+            ? int.MaxValue
             : Taskbar.TaskbarSpace.AvailableLogicalWidth;
 
     // Tile chrome, mirroring TaskBarWidget: 4px of margin per tile and a 7px divider between neighbours.

--- a/src/TaskbarQuota.App/Services/ThemeService.cs
+++ b/src/TaskbarQuota.App/Services/ThemeService.cs
@@ -1,24 +1,86 @@
+using System;
+using System.Collections.Generic;
 using Microsoft.UI.Xaml;
 
 namespace TaskbarQuota
 {
-    /// <summary>Applies an app theme override to the shell's root element.</summary>
+    /// <summary>
+    /// Applies an app theme override to every registered window root (main window, flyout, floating HUD).
+    /// Multiple roots are required: a single root meant creating the floating window stole theme from the
+    /// main window, and disposing the floating window left theme updates targeting a dead element.
+    /// </summary>
     public static class ThemeService
     {
-        private static FrameworkElement? _root;
+        private static readonly object Gate = new();
+        private static readonly List<WeakReference<FrameworkElement>> Roots = new();
 
         public static ElementTheme Current { get; private set; } = ElementTheme.Default;
 
         public static void Register(FrameworkElement root)
         {
-            _root = root;
-            _root.RequestedTheme = Current;
+            lock (Gate)
+            {
+                PruneUnlocked();
+                for (int i = 0; i < Roots.Count; i++)
+                {
+                    if (Roots[i].TryGetTarget(out var existing) && ReferenceEquals(existing, root))
+                    {
+                        root.RequestedTheme = Current;
+                        return;
+                    }
+                }
+
+                Roots.Add(new WeakReference<FrameworkElement>(root));
+                root.RequestedTheme = Current;
+            }
+        }
+
+        public static void Unregister(FrameworkElement root)
+        {
+            lock (Gate)
+            {
+                Roots.RemoveAll(wr =>
+                    !wr.TryGetTarget(out var target) || ReferenceEquals(target, root));
+            }
         }
 
         public static void Apply(ElementTheme theme)
         {
             Current = theme;
-            if (_root != null) _root.RequestedTheme = theme;
+            lock (Gate)
+            {
+                PruneUnlocked();
+                foreach (var wr in Roots)
+                {
+                    if (wr.TryGetTarget(out var root))
+                        root.RequestedTheme = theme;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Whether chrome should use light (dark text) or dark (light text) colors for the given element,
+        /// honoring its ActualTheme, then the app override, then the system theme.
+        /// </summary>
+        public static bool IsLightChrome(FrameworkElement element)
+        {
+            var actual = element.ActualTheme;
+            if (actual == ElementTheme.Light)
+                return true;
+            if (actual == ElementTheme.Dark)
+                return false;
+
+            if (Current == ElementTheme.Light)
+                return true;
+            if (Current == ElementTheme.Dark)
+                return false;
+
+            return Interop.SystemInfos.IsSystemLightThemeUsed() == true;
+        }
+
+        private static void PruneUnlocked()
+        {
+            Roots.RemoveAll(wr => !wr.TryGetTarget(out _));
         }
     }
 }

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -49,10 +49,10 @@ public static class WidgetSettingsService
     private static readonly string WidgetDisplayModePath =
         Path.Combine(AppStorage.AppDataDirectory, "widget-display-mode.txt");
 
-    private static readonly string WidgetSurfaceModePath =
+    private static string WidgetSurfaceModePath =>
         Path.Combine(AppStorage.AppDataDirectory, "widget-surface-mode.txt");
 
-    private static readonly string FloatingOpacityPath =
+    private static string FloatingOpacityPath =>
         Path.Combine(AppStorage.AppDataDirectory, "floating-opacity.txt");
 
     private static readonly string PercentageDisplayModePath =
@@ -113,6 +113,19 @@ public static class WidgetSettingsService
     public static event EventHandler? Changed;
     public static event EventHandler? DashboardCompositionChanged;
     public static event EventHandler? PercentageModeChanged;
+
+    internal static void ReloadSurfaceSettingsForTesting()
+    {
+        CurrentSurface = LoadWidgetSurfaceMode();
+        FloatingOpacity = LoadFloatingOpacity();
+    }
+
+    internal static void RestoreSurfaceSettingsForTesting(
+        WidgetSurfaceMode surface, double floatingOpacity)
+    {
+        CurrentSurface = surface;
+        FloatingOpacity = floatingOpacity;
+    }
 
     public static void Apply(WidgetDisplayMode mode)
     {

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -131,9 +131,8 @@ public static class WidgetSettingsService
 
         CurrentSurface = mode;
         Save(WidgetSurfaceModePath, (int)mode);
-        // Moving back to the taskbar may leave a pin set that no longer fits the free span.
-        if (mode == WidgetSurfaceMode.Taskbar)
-            Services.PinBudgetService.EnforceBudget(notify: false);
+        // TaskBarManager enforces the taskbar budget after a current widget measurement exists.
+        // Doing it here would use the span cached before floating mode and could remove valid pins.
         Changed?.Invoke(null, EventArgs.Empty);
     }
 

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -21,6 +21,16 @@ public enum PercentageDisplayMode
     Remaining = 1,
 }
 
+/// <summary>
+/// Where the compact usage UI is hosted: injected into each taskbar, or a single always-on-top
+/// floating window. Modes are mutually exclusive.
+/// </summary>
+public enum WidgetSurfaceMode
+{
+    Taskbar = 0,
+    Floating = 1,
+}
+
 public readonly record struct WidgetRowOption(string Id, string Label);
 
 public static class WidgetSettingsService
@@ -38,6 +48,12 @@ public static class WidgetSettingsService
 
     private static readonly string WidgetDisplayModePath =
         Path.Combine(AppStorage.AppDataDirectory, "widget-display-mode.txt");
+
+    private static readonly string WidgetSurfaceModePath =
+        Path.Combine(AppStorage.AppDataDirectory, "widget-surface-mode.txt");
+
+    private static readonly string FloatingOpacityPath =
+        Path.Combine(AppStorage.AppDataDirectory, "floating-opacity.txt");
 
     private static readonly string PercentageDisplayModePath =
         Path.Combine(AppStorage.AppDataDirectory, "percentage-display-mode.txt");
@@ -70,7 +86,17 @@ public static class WidgetSettingsService
     private static readonly Dictionary<string, bool> DashboardProviderVisibility = LoadDashboardProviderVisibility();
     private static readonly Dictionary<string, bool> ProviderPins = LoadProviderPins();
 
+    /// <summary>Minimum opacity for the floating usage window (35%).</summary>
+    public const double FloatingOpacityMin = 0.35;
+    /// <summary>Maximum opacity for the floating usage window (fully solid).</summary>
+    public const double FloatingOpacityMax = 1.0;
+    /// <summary>Default floating chrome opacity.</summary>
+    public const double FloatingOpacityDefault = 0.90;
+
     public static WidgetDisplayMode Current { get; private set; } = LoadWidgetDisplayMode();
+    public static WidgetSurfaceMode CurrentSurface { get; private set; } = LoadWidgetSurfaceMode();
+    /// <summary>Floating window chrome opacity in the range [<see cref="FloatingOpacityMin"/>, <see cref="FloatingOpacityMax"/>].</summary>
+    public static double FloatingOpacity { get; private set; } = LoadFloatingOpacity();
     public static PercentageDisplayMode CurrentPercentageMode { get; private set; } = LoadPercentageDisplayMode();
     public static bool AutoHideUnavailable { get; private set; } = LoadAutoHideUnavailable();
     /// <summary>
@@ -95,6 +121,36 @@ public static class WidgetSettingsService
 
         Current = mode;
         Save(WidgetDisplayModePath, (int)mode);
+        Changed?.Invoke(null, EventArgs.Empty);
+    }
+
+    public static void ApplySurface(WidgetSurfaceMode mode)
+    {
+        if (CurrentSurface == mode)
+            return;
+
+        CurrentSurface = mode;
+        Save(WidgetSurfaceModePath, (int)mode);
+        // Moving back to the taskbar may leave a pin set that no longer fits the free span.
+        if (mode == WidgetSurfaceMode.Taskbar)
+            Services.PinBudgetService.EnforceBudget(notify: false);
+        Changed?.Invoke(null, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Sets floating window chrome opacity. Values outside
+    /// [<see cref="FloatingOpacityMin"/>, <see cref="FloatingOpacityMax"/>] are clamped.
+    /// </summary>
+    public static void ApplyFloatingOpacity(double opacity)
+    {
+        double clamped = Math.Clamp(opacity, FloatingOpacityMin, FloatingOpacityMax);
+        // Ignore sub-percent noise from slider drag so we don't rewrite disk every pixel.
+        if (Math.Abs(FloatingOpacity - clamped) < 0.005)
+            return;
+
+        FloatingOpacity = clamped;
+        // Persist as integer percent for stable round-trips.
+        Save(FloatingOpacityPath, (int)Math.Round(clamped * 100));
         Changed?.Invoke(null, EventArgs.Empty);
     }
 
@@ -488,6 +544,54 @@ public static class WidgetSettingsService
         catch
         {
             return WidgetDisplayMode.BarsOnly;
+        }
+    }
+
+    private static WidgetSurfaceMode LoadWidgetSurfaceMode()
+    {
+        try
+        {
+            if (!File.Exists(WidgetSurfaceModePath))
+                return WidgetSurfaceMode.Taskbar;
+
+            string raw = File.ReadAllText(WidgetSurfaceModePath);
+            return int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value)
+                && Enum.IsDefined(typeof(WidgetSurfaceMode), value)
+                ? (WidgetSurfaceMode)value
+                : WidgetSurfaceMode.Taskbar;
+        }
+        catch
+        {
+            return WidgetSurfaceMode.Taskbar;
+        }
+    }
+
+    private static double LoadFloatingOpacity()
+    {
+        try
+        {
+            if (!File.Exists(FloatingOpacityPath))
+                return FloatingOpacityDefault;
+
+            string raw = File.ReadAllText(FloatingOpacityPath).Trim();
+            // Stored as integer percent (35–100). Also accept a fractional 0–1 for hand-edited files.
+            if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int percent)
+                && percent is >= 1 and <= 100)
+            {
+                return Math.Clamp(percent / 100d, FloatingOpacityMin, FloatingOpacityMax);
+            }
+
+            if (double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out double fraction)
+                && fraction is > 0 and <= 1)
+            {
+                return Math.Clamp(fraction, FloatingOpacityMin, FloatingOpacityMax);
+            }
+
+            return FloatingOpacityDefault;
+        }
+        catch
+        {
+            return FloatingOpacityDefault;
         }
     }
 

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -86,16 +86,16 @@ public static class WidgetSettingsService
     private static readonly Dictionary<string, bool> DashboardProviderVisibility = LoadDashboardProviderVisibility();
     private static readonly Dictionary<string, bool> ProviderPins = LoadProviderPins();
 
-    /// <summary>Minimum opacity for the floating usage window (35%).</summary>
+    /// <summary>Minimum material strength for the floating usage window (35%).</summary>
     public const double FloatingOpacityMin = 0.35;
-    /// <summary>Maximum opacity for the floating usage window (fully solid).</summary>
+    /// <summary>Maximum material strength for the floating usage window.</summary>
     public const double FloatingOpacityMax = 1.0;
-    /// <summary>Default floating chrome opacity.</summary>
+    /// <summary>Default floating Acrylic strength.</summary>
     public const double FloatingOpacityDefault = 0.90;
 
     public static WidgetDisplayMode Current { get; private set; } = LoadWidgetDisplayMode();
     public static WidgetSurfaceMode CurrentSurface { get; private set; } = LoadWidgetSurfaceMode();
-    /// <summary>Floating window chrome opacity in the range [<see cref="FloatingOpacityMin"/>, <see cref="FloatingOpacityMax"/>].</summary>
+    /// <summary>Floating window Acrylic strength in the range [<see cref="FloatingOpacityMin"/>, <see cref="FloatingOpacityMax"/>].</summary>
     public static double FloatingOpacity { get; private set; } = LoadFloatingOpacity();
     public static PercentageDisplayMode CurrentPercentageMode { get; private set; } = LoadPercentageDisplayMode();
     public static bool AutoHideUnavailable { get; private set; } = LoadAutoHideUnavailable();
@@ -138,7 +138,7 @@ public static class WidgetSettingsService
     }
 
     /// <summary>
-    /// Sets floating window chrome opacity. Values outside
+    /// Sets floating window Acrylic strength. Values outside
     /// [<see cref="FloatingOpacityMin"/>, <see cref="FloatingOpacityMax"/>] are clamped.
     /// </summary>
     public static void ApplyFloatingOpacity(double opacity)

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -14,7 +14,10 @@ using TaskbarQuota.AgentActivity;
 
 namespace TaskbarQuota.Taskbar
 {
-    /// <summary>Owns the tray icon and injected taskbar widgets, and pushes coordinator state into every widget.</summary>
+    /// <summary>
+    /// Owns the tray icon and the active usage surface (taskbar widgets or floating window), and pushes
+    /// coordinator state into that surface.
+    /// </summary>
     internal static class TaskBarManager
     {
         private static TrayIconWithContextMenu? _trayIcon;
@@ -23,6 +26,7 @@ namespace TaskbarQuota.Taskbar
         // Reused snapshot of Widgets.Values, so iterating it while a callback may mutate the dictionary
         // doesn't allocate. Only valid until the next SnapshotWidgets call, and only used on the UI thread.
         private static readonly List<TaskBarWidget> _widgetBuffer = new();
+        private static FloatingUsageWindow? _floatingWindow;
         private static FlyoutWindow? _flyout;
         private static DispatcherQueue? _dispatcher;
         private static Action? _showMainWindow;
@@ -34,9 +38,12 @@ namespace TaskbarQuota.Taskbar
         private static bool _initialized;
         private static bool _isReconcilingWidgets;
         private static ProviderId? _lastLoggedWidgetApplyProvider;
+        private static WidgetSurfaceMode _activeSurface = WidgetSurfaceMode.Taskbar;
         // Foreground hook: fires the instant Windows switches windows so the focus-follows-provider
         // widget reacts on the switch itself instead of waiting for the next 500 ms detect tick.
         private static ActiveApp.ForegroundWatcher? _foregroundWatcher;
+
+        private static bool IsFloatingSurface => _activeSurface == WidgetSurfaceMode.Floating;
 
         public static void Initialize(DispatcherQueue dispatcher, Action showMainWindow)
         {
@@ -44,7 +51,7 @@ namespace TaskbarQuota.Taskbar
             _showMainWindow = showMainWindow;
 
             CreateTrayIcon();
-            EnsureWidgets();
+            ApplySurfaceFromSettings();
 
             if (!_initialized)
             {
@@ -57,7 +64,9 @@ namespace TaskbarQuota.Taskbar
                 // instead of as the user having left the provider app. Otherwise the opt-in hide-on-unfocus
                 // path can hide the widget during the drag and restore its old position.
                 UsageCoordinator.Instance.IsOwnUiEngaged = () =>
-                    _flyout?.IsShown == true || TaskBarWidget.IsAnyUserRepositioning;
+                    _flyout?.IsShown == true
+                    || TaskBarWidget.IsAnyUserRepositioning
+                    || _floatingWindow?.IsDragging == true;
                 WidgetSettingsService.Changed += OnWidgetSettingsChanged;
                 App.Quitting += OnQuitting;
                 // Installed from the UI thread on purpose: WINEVENT_OUTOFCONTEXT callbacks arrive through
@@ -71,6 +80,128 @@ namespace TaskbarQuota.Taskbar
             StartWidgetHealthTimer();
             ConfigureActivityTimer();
             OnActiveToolPresenceChanged(UsageCoordinator.Instance.IsActiveToolPresent);
+        }
+
+        private static void ApplySurfaceFromSettings()
+        {
+            var desired = WidgetSettingsService.CurrentSurface;
+            if (desired == WidgetSurfaceMode.Floating)
+            {
+                DisposeAllTaskbarWidgets();
+                EnsureFloatingWindow();
+                _activeSurface = WidgetSurfaceMode.Floating;
+                SyncFloatingState();
+            }
+            else
+            {
+                DisposeFloatingWindow();
+                _activeSurface = WidgetSurfaceMode.Taskbar;
+                EnsureWidgets();
+                SyncWidgetState();
+            }
+        }
+
+        private static void EnsureFloatingWindow()
+        {
+            if (_floatingWindow is { IsAlive: true })
+                return;
+
+            try { _floatingWindow?.Close(); } catch { }
+            _floatingWindow = null;
+
+            try
+            {
+                var window = new FloatingUsageWindow();
+                window.HydrateProvider = provider => HydrateResult(UsageCoordinator.Instance, provider);
+                window.Clicked += () => _dispatcher?.TryEnqueue(() => ToggleFlyout(window.Handle));
+                window.ActivityClicked += item => _dispatcher?.TryEnqueue(
+                    () => ToggleActivityFlyout(window.Handle, item?.Id));
+                _floatingWindow = window;
+                PrewarmFlyout();
+                Log.Information("Floating usage window created");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to create floating usage window");
+                try { _floatingWindow?.Close(); } catch { }
+                _floatingWindow = null;
+            }
+        }
+
+        private static void DisposeFloatingWindow()
+        {
+            if (_floatingWindow is null)
+                return;
+
+            try { _floatingWindow.Close(); } catch (Exception ex) { Log.Warning(ex, "Failed to close floating usage window"); }
+            _floatingWindow = null;
+        }
+
+        private static void DisposeAllTaskbarWidgets()
+        {
+            foreach (var widget in Widgets.Values.ToArray())
+            {
+                try { widget.Dispose(); } catch (Exception ex) { Log.Warning(ex, "Failed to dispose taskbar widget"); }
+            }
+            Widgets.Clear();
+        }
+
+        private static void SyncFloatingState()
+        {
+            if (_floatingWindow is not { IsAlive: true })
+                return;
+
+            var coordinator = UsageCoordinator.Instance;
+            var providers = coordinator.WidgetDisplayProviders;
+            var activity = AgentActivityService.Instance.Snapshot;
+
+            _floatingWindow.SetActivitySnapshot(activity);
+
+            if (providers.Count == 0
+                && !(WidgetSettingsService.ShowAgentActivityInWidget && activity.Primary is not null))
+            {
+                _floatingWindow.SetDisplayProviders(Array.Empty<ProviderId>(), coordinator.ActiveProvider);
+                _floatingWindow.SetVisible(false);
+                return;
+            }
+
+            _floatingWindow.SetDisplayProviders(providers, coordinator.ActiveProvider);
+            _floatingWindow.SetVisible(true);
+
+            bool needsFetch = false;
+            foreach (var provider in providers)
+            {
+                var toApply = HydrateResult(coordinator, provider);
+                if (toApply is { } result)
+                {
+                    _floatingWindow.ApplyResult(result, force: true);
+                    LogWidgetApply(result.Id, "floating-sync");
+                }
+
+                if (toApply is null or { Ok: false })
+                    needsFetch = true;
+            }
+
+            if (needsFetch)
+                _ = coordinator.TickAsync(force: true);
+        }
+
+        /// <summary>
+        /// True when the floating surface should be showing content but the window is hidden or gone.
+        /// Used by the health timer so a transient hide does not become permanent.
+        /// </summary>
+        private static bool NeedsFloatingResync()
+        {
+            if (_floatingWindow is not { IsAlive: true })
+                return true;
+
+            var coordinator = UsageCoordinator.Instance;
+            var providers = coordinator.WidgetDisplayProviders;
+            var activity = AgentActivityService.Instance.Snapshot;
+            bool shouldShow = providers.Count > 0
+                || (WidgetSettingsService.ShowAgentActivityInWidget && activity.Primary is not null);
+
+            return shouldShow && !_floatingWindow.IsShown;
         }
 
         private static void StartActivityTimer()
@@ -113,15 +244,9 @@ namespace TaskbarQuota.Taskbar
         {
             var open = new PopupMenuItem("Open TaskbarQuota", (_, _) => _dispatcher?.TryEnqueue(() => _showMainWindow?.Invoke()));
             var activity = new PopupMenuItem("Open agent activity", (_, _) => _dispatcher?.TryEnqueue(
-                () => ToggleActivityFlyout(sourceWidget: null, selectedActivityId: null)));
-            var move = new PopupMenuItem("Move primary taskbar widget", (_, _) => _dispatcher?.TryEnqueue(
-                () => PrimaryWidget()?.StartDragging()));
-            var reset = new PopupMenuItem("Reset widget positions", (_, _) => _dispatcher?.TryEnqueue(
-                () =>
-                {
-                    foreach (var widget in Widgets.Values.ToArray())
-                        widget.UpdatePosition(resetManualPosition: true);
-                }));
+                () => ToggleActivityFlyout(anchorHandle: null, selectedActivityId: null)));
+            var move = new PopupMenuItem("Move usage widget", (_, _) => _dispatcher?.TryEnqueue(StartMoveActiveSurface));
+            var reset = new PopupMenuItem("Reset widget positions", (_, _) => _dispatcher?.TryEnqueue(ResetActiveSurfacePositions));
             var quit = new PopupMenuItem("Quit", (_, _) => _dispatcher?.TryEnqueue(App.Quit));
 
             System.Drawing.Icon? icon = null;
@@ -153,6 +278,29 @@ namespace TaskbarQuota.Taskbar
             };
         }
 
+        private static void StartMoveActiveSurface()
+        {
+            if (IsFloatingSurface)
+            {
+                _floatingWindow?.StartDragging();
+                return;
+            }
+
+            PrimaryWidget()?.StartDragging();
+        }
+
+        private static void ResetActiveSurfacePositions()
+        {
+            if (IsFloatingSurface)
+            {
+                _floatingWindow?.ResetPosition();
+                return;
+            }
+
+            foreach (var widget in Widgets.Values.ToArray())
+                widget.UpdatePosition(resetManualPosition: true);
+        }
+
         private static void StartWidgetHealthTimer()
         {
             if (_widgetHealthTimer != null)
@@ -161,6 +309,26 @@ namespace TaskbarQuota.Taskbar
             _widgetHealthTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
             _widgetHealthTimer.Tick += (_, _) =>
             {
+                if (IsFloatingSurface)
+                {
+                    bool recreated = false;
+                    if (_floatingWindow is null || !_floatingWindow.IsAlive)
+                    {
+                        EnsureFloatingWindow();
+                        recreated = true;
+                    }
+
+                    // Recreate is empty until hydrated. Also re-sync periodically so a hide from a
+                    // transient empty provider set (or opacity stuck at 0 after settings thrash) cannot
+                    // leave the HUD gone until the next process restart.
+                    if (recreated || NeedsFloatingResync())
+                        SyncFloatingState();
+
+                    RefreshPinnedTiles();
+                    Services.PinBudgetService.EnforceBudget();
+                    return;
+                }
+
                 EnsureWidgets();
                 RefreshPinnedTiles();
                 // The free span is only known once a widget has measured it, so a set pinned before that
@@ -184,6 +352,9 @@ namespace TaskbarQuota.Taskbar
 
         private static void EnsureWidgets()
         {
+            if (IsFloatingSurface)
+                return;
+
             if (_isReconcilingWidgets)
                 return;
 
@@ -271,6 +442,12 @@ namespace TaskbarQuota.Taskbar
 
         private static void SyncWidgetState()
         {
+            if (IsFloatingSurface)
+            {
+                SyncFloatingState();
+                return;
+            }
+
             foreach (var widget in Widgets.Values.ToArray())
                 SyncWidgetState(widget);
         }
@@ -360,12 +537,18 @@ namespace TaskbarQuota.Taskbar
         private static void ToggleFlyout(TaskBarWidget widget)
         {
             if (!widget.IsAlive) return;
+            ToggleFlyout(widget.Handle);
+        }
+
+        private static void ToggleFlyout(IntPtr anchorHandle)
+        {
+            if (anchorHandle == IntPtr.Zero) return;
             FlyoutWindow? flyout = null;
             try
             {
                 flyout = _flyout ?? new FlyoutWindow();
                 _flyout = flyout;
-                flyout.ToggleAbove(widget.Handle);
+                flyout.ToggleAbove(anchorHandle);
             }
             catch (Exception ex)
             {
@@ -377,20 +560,37 @@ namespace TaskbarQuota.Taskbar
 
         private static void ToggleActivityFlyout(TaskBarWidget? sourceWidget, string? selectedActivityId)
         {
-            var widget = sourceWidget ?? PrimaryWidget();
-            if (widget is null)
+            if (sourceWidget is { IsAlive: true })
             {
-                Log.Warning("Cannot toggle agent activity: no taskbar widget is available");
+                ToggleActivityFlyout(sourceWidget.ActivityHandle, selectedActivityId);
                 return;
             }
 
-            if (!widget.IsAlive) return;
+            ToggleActivityFlyout(anchorHandle: null, selectedActivityId);
+        }
+
+        private static void ToggleActivityFlyout(IntPtr? anchorHandle, string? selectedActivityId)
+        {
+            IntPtr handle = anchorHandle is { } h && h != IntPtr.Zero
+                ? h
+                : IsFloatingSurface
+                    ? _floatingWindow?.Handle ?? IntPtr.Zero
+                    : PrimaryWidget() is { IsAlive: true } primary
+                        ? primary.ActivityHandle
+                        : IntPtr.Zero;
+
+            if (handle == IntPtr.Zero)
+            {
+                Log.Warning("Cannot toggle agent activity: no usage surface is available");
+                return;
+            }
+
             FlyoutWindow? flyout = null;
             try
             {
                 flyout = _flyout ?? new FlyoutWindow();
                 _flyout = flyout;
-                flyout.ToggleActivityAbove(widget.ActivityHandle, selectedActivityId);
+                flyout.ToggleActivityAbove(handle, selectedActivityId);
             }
             catch (Exception ex)
             {
@@ -429,6 +629,30 @@ namespace TaskbarQuota.Taskbar
             var providers = coordinator.WidgetDisplayProviders;
             var activity = AgentActivityService.Instance.Snapshot;
             bool isDisplayed = providers.Contains(result.Id);
+
+            if (IsFloatingSurface)
+            {
+                if (_floatingWindow is not { IsAlive: true })
+                    return;
+
+                _floatingWindow.SetActivitySnapshot(activity);
+                if (providers.Count == 0
+                    && !(WidgetSettingsService.ShowAgentActivityInWidget && activity.Primary is not null))
+                {
+                    _floatingWindow.SetDisplayProviders(Array.Empty<ProviderId>(), coordinator.ActiveProvider);
+                    _floatingWindow.SetVisible(false);
+                    return;
+                }
+
+                _floatingWindow.SetDisplayProviders(providers, coordinator.ActiveProvider);
+                _floatingWindow.SetVisible(true);
+                if (!isDisplayed)
+                    return;
+
+                _floatingWindow.ApplyResult(result);
+                LogWidgetApply(result.Id, "floating-state");
+                return;
+            }
 
             // Reused buffer: this runs on every usage publish, so a fresh array per publish was pure waste.
             SnapshotWidgets();
@@ -507,18 +731,20 @@ namespace TaskbarQuota.Taskbar
 
         private static void ApplyActiveToolPresenceChanged(bool isPresent)
         {
-            // Pinned tiles stay on the taskbar even when no AI tool is in the foreground; only the active
+            // Pinned tiles stay on the surface even when no AI tool is in the foreground; only the active
             // tile follows presence. SyncWidgetState recomputes the whole set and hydrates it.
-            foreach (var widget in Widgets.Values.ToArray())
-            {
-                if (widget.IsAlive)
-                    SyncWidgetState(widget);
-            }
+            SyncWidgetState();
         }
 
         private static void OnActivityChanged(AgentActivitySnapshot snapshot)
             => _dispatcher?.TryEnqueue(() =>
             {
+                if (IsFloatingSurface)
+                {
+                    SyncFloatingState();
+                    return;
+                }
+
                 foreach (var widget in Widgets.Values.ToArray())
                 {
                     if (!widget.IsAlive)
@@ -547,7 +773,10 @@ namespace TaskbarQuota.Taskbar
             _dispatcher?.TryEnqueue(() =>
             {
                 ConfigureActivityTimer();
-                SyncWidgetState();
+                if (WidgetSettingsService.CurrentSurface != _activeSurface)
+                    ApplySurfaceFromSettings();
+                else
+                    SyncWidgetState();
             });
         }
 
@@ -577,11 +806,8 @@ namespace TaskbarQuota.Taskbar
             if (_trayIcon != null) { _trayIcon.TryRemove(); _trayIcon.Dispose(); _trayIcon = null; }
             try { _flyout?.Close(); } catch { }
             _flyout = null;
-            foreach (var widget in Widgets.Values.ToArray())
-            {
-                try { widget.Dispose(); } catch { }
-            }
-            Widgets.Clear();
+            DisposeFloatingWindow();
+            DisposeAllTaskbarWidgets();
         }
     }
 }

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -144,6 +144,7 @@ namespace TaskbarQuota.Taskbar
                 try { widget.Dispose(); } catch (Exception ex) { Log.Warning(ex, "Failed to dispose taskbar widget"); }
             }
             Widgets.Clear();
+            TaskbarSpace.ResetAvailableWidth();
         }
 
         /// <summary>

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -160,16 +160,17 @@ namespace TaskbarQuota.Taskbar
             var activity = AgentActivityService.Instance.Snapshot;
 
             _floatingWindow.SetActivitySnapshot(activity);
+            _floatingWindow.SetDisplayProviders(providers, coordinator.ActiveProvider);
 
-            if (providers.Count == 0
-                && !(WidgetSettingsService.ShowAgentActivityInWidget && activity.Primary is not null))
+            // Consult the content actually applied by the floating host. A transient empty scan may be
+            // held for a short grace period; using the raw snapshot here hid the entire window anyway and
+            // defeated that protection.
+            if (!_floatingWindow.HasVisibleContent)
             {
-                _floatingWindow.SetDisplayProviders(Array.Empty<ProviderId>(), coordinator.ActiveProvider);
                 _floatingWindow.SetVisible(false);
                 return false;
             }
 
-            _floatingWindow.SetDisplayProviders(providers, coordinator.ActiveProvider);
             _floatingWindow.SetVisible(true);
             return true;
         }
@@ -211,9 +212,7 @@ namespace TaskbarQuota.Taskbar
 
             var coordinator = UsageCoordinator.Instance;
             var providers = coordinator.WidgetDisplayProviders;
-            var activity = AgentActivityService.Instance.Snapshot;
-            bool shouldShow = providers.Count > 0
-                || (WidgetSettingsService.ShowAgentActivityInWidget && activity.Primary is not null);
+            bool shouldShow = providers.Count > 0 || _floatingWindow.HasVisibleContent;
 
             return shouldShow && !_floatingWindow.IsShown;
         }
@@ -225,7 +224,9 @@ namespace TaskbarQuota.Taskbar
 
             _activityCts = new CancellationTokenSource();
             var cancellationToken = _activityCts.Token;
-            _activityTimer = new DispatcherTimer { Interval = IdleActivityInterval };
+            // Start fast so a transcript created just after launch is not held behind the ten-second idle
+            // interval. The first completed timer refresh selects the normal active/idle cadence.
+            _activityTimer = new DispatcherTimer { Interval = ActiveActivityInterval };
             _activityTimer.Tick += async (_, _) =>
             {
                 await AgentActivityService.Instance.RefreshFromTranscriptsAsync(cancellationToken);
@@ -483,7 +484,7 @@ namespace TaskbarQuota.Taskbar
             if (providers.Count == 0)
             {
                 widget.SetDisplayProviders(Array.Empty<ProviderId>(), coordinator.ActiveProvider);
-                if (WidgetSettingsService.ShowAgentActivityInWidget && activity.Primary is not null)
+                if (widget.HasVisibleActivity)
                     widget.SetQuotaVisible(false);
                 else
                     widget.SetVisible(false);
@@ -669,7 +670,7 @@ namespace TaskbarQuota.Taskbar
                 if (providers.Count == 0)
                 {
                     widget.SetDisplayProviders(Array.Empty<ProviderId>(), coordinator.ActiveProvider);
-                    if (WidgetSettingsService.ShowAgentActivityInWidget && activity.Primary is not null)
+                    if (widget.HasVisibleActivity)
                         widget.SetQuotaVisible(false);
                     else
                         widget.SetVisible(false);
@@ -755,7 +756,7 @@ namespace TaskbarQuota.Taskbar
                     if (providers.Count == 0)
                     {
                         widget.SetDisplayProviders(Array.Empty<ProviderId>(), UsageCoordinator.Instance.ActiveProvider);
-                        if (WidgetSettingsService.ShowAgentActivityInWidget && snapshot.Primary is not null)
+                        if (widget.HasVisibleActivity)
                             widget.SetQuotaVisible(false);
                         else
                             widget.SetVisible(false);

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -146,10 +146,14 @@ namespace TaskbarQuota.Taskbar
             Widgets.Clear();
         }
 
-        private static void SyncFloatingState()
+        /// <summary>
+        /// Pushes providers, activity, and visibility into the floating window.
+        /// Returns false when the surface is unavailable or has nothing to show.
+        /// </summary>
+        private static bool SyncFloatingSurface()
         {
             if (_floatingWindow is not { IsAlive: true })
-                return;
+                return false;
 
             var coordinator = UsageCoordinator.Instance;
             var providers = coordinator.WidgetDisplayProviders;
@@ -162,11 +166,21 @@ namespace TaskbarQuota.Taskbar
             {
                 _floatingWindow.SetDisplayProviders(Array.Empty<ProviderId>(), coordinator.ActiveProvider);
                 _floatingWindow.SetVisible(false);
-                return;
+                return false;
             }
 
             _floatingWindow.SetDisplayProviders(providers, coordinator.ActiveProvider);
             _floatingWindow.SetVisible(true);
+            return true;
+        }
+
+        private static void SyncFloatingState()
+        {
+            if (!SyncFloatingSurface())
+                return;
+
+            var coordinator = UsageCoordinator.Instance;
+            var providers = coordinator.WidgetDisplayProviders;
 
             bool needsFetch = false;
             foreach (var provider in providers)
@@ -174,7 +188,7 @@ namespace TaskbarQuota.Taskbar
                 var toApply = HydrateResult(coordinator, provider);
                 if (toApply is { } result)
                 {
-                    _floatingWindow.ApplyResult(result, force: true);
+                    _floatingWindow!.ApplyResult(result, force: true);
                     LogWidgetApply(result.Id, "floating-sync");
                 }
 
@@ -632,24 +646,10 @@ namespace TaskbarQuota.Taskbar
 
             if (IsFloatingSurface)
             {
-                if (_floatingWindow is not { IsAlive: true })
+                if (!SyncFloatingSurface() || !isDisplayed)
                     return;
 
-                _floatingWindow.SetActivitySnapshot(activity);
-                if (providers.Count == 0
-                    && !(WidgetSettingsService.ShowAgentActivityInWidget && activity.Primary is not null))
-                {
-                    _floatingWindow.SetDisplayProviders(Array.Empty<ProviderId>(), coordinator.ActiveProvider);
-                    _floatingWindow.SetVisible(false);
-                    return;
-                }
-
-                _floatingWindow.SetDisplayProviders(providers, coordinator.ActiveProvider);
-                _floatingWindow.SetVisible(true);
-                if (!isDisplayed)
-                    return;
-
-                _floatingWindow.ApplyResult(result);
+                _floatingWindow!.ApplyResult(result);
                 LogWidgetApply(result.Id, "floating-state");
                 return;
             }

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -248,6 +248,13 @@ namespace TaskbarQuota.Taskbar
         public event Action? Clicked;
         /// <summary>Raised when the agent activity summary is clicked, so its activity panel can open.</summary>
         public event Action<AgentActivityItem?>? ActivityClicked;
+
+        /// <summary>
+        /// Whether the activity island is backed by the snapshot currently applied to this widget. The
+        /// applied snapshot can intentionally lag a transient empty scan during the grace period.
+        /// </summary>
+        public bool HasVisibleActivity => WidgetSettingsService.ShowAgentActivityInWidget
+            && activitySnapshot.Primary is not null;
         public event EventHandler? Destroying;
 
         public TaskBarWidget(TaskbarWindowTarget target)

--- a/src/TaskbarQuota.App/Taskbar/TaskbarSpace.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskbarSpace.cs
@@ -17,6 +17,10 @@ internal static class TaskbarSpace
     /// <summary>Widest free span on the taskbar, in logical pixels. Zero until first measured.</summary>
     public static int AvailableLogicalWidth { get; set; } = UnknownWidth;
 
+    /// <summary>Forgets taskbar geometry when no injected widget remains to keep it current.</summary>
+    public static void ResetAvailableWidth()
+        => AvailableLogicalWidth = UnknownWidth;
+
     // Real rendered width per provider. The budget used to model this — an icon plus a column group per
     // two rows — which is close but not close enough: a Credits row or a long label puts a tile tens of
     // pixels over the model, and at that error a set that genuinely fits gets refused. The widget measures

--- a/src/TaskbarQuota.App/ViewModels/ProviderCardViewModel.cs
+++ b/src/TaskbarQuota.App/ViewModels/ProviderCardViewModel.cs
@@ -32,7 +32,7 @@ namespace TaskbarQuota.ViewModels
         public Brush PercentForeground { get; }
         public bool IsWidgetVisible { get; internal set; }
         public bool IsWidgetToggleEnabled { get; internal set; }
-        public string WidgetToggleName => $"Show {Label} in taskbar widget";
+        public string WidgetToggleName => $"Show {Label} in usage widget";
 
         public BarViewModel(ProviderId providerId, string widgetRowId, string label, RateWindow w)
         {
@@ -69,7 +69,7 @@ namespace TaskbarQuota.ViewModels
         public double MutedOpacity { get; }
         public bool IsWidgetVisible { get; internal set; }
         public bool IsWidgetToggleEnabled { get; internal set; }
-        public string WidgetToggleName => $"Show {Label} in taskbar widget";
+        public string WidgetToggleName => $"Show {Label} in usage widget";
 
         public TextMetricViewModel(ProviderId providerId, string widgetRowId, string label, string value, bool muted = false)
         {
@@ -96,7 +96,7 @@ namespace TaskbarQuota.ViewModels
         public string Label { get; }
         public bool IsWidgetVisible { get; internal set; }
         public bool IsWidgetToggleEnabled { get; internal set; }
-        public string WidgetToggleName => $"Show {Label} in taskbar widget";
+        public string WidgetToggleName => $"Show {Label} in usage widget";
 
         public WidgetRowToggleViewModel(ProviderId providerId, WidgetRowOption option)
         {
@@ -232,9 +232,9 @@ namespace TaskbarQuota.ViewModels
             ActiveVisibility = isActive ? Visibility.Visible : Visibility.Collapsed;
             ProviderId = r.Id;
             IsProviderWidgetVisible = WidgetSettingsService.IsProviderVisible(r.Id);
-            ProviderWidgetToggleName = $"Show {DisplayName} in taskbar widget";
+            ProviderWidgetToggleName = $"Show {DisplayName} in usage widget";
             IsProviderPinned = WidgetSettingsService.IsProviderPinned(r.Id);
-            ProviderPinToggleName = $"Pin {DisplayName} to the taskbar widget";
+            ProviderPinToggleName = $"Pin {DisplayName} in the usage widget";
 
             var bars = new List<BarViewModel>();
             var textMetrics = new List<TextMetricViewModel>();

--- a/src/TaskbarQuota.App/Views/DashboardPage.xaml
+++ b/src/TaskbarQuota.App/Views/DashboardPage.xaml
@@ -34,7 +34,7 @@
                                   Padding="6"
                                   MinWidth="32"
                                   MinHeight="32"
-                                  ToolTipService.ToolTip="Show in taskbar widget"
+                                  ToolTipService.ToolTip="Show in usage widget"
                                   Click="WidgetRowVisibility_Click">
                         <FontIcon Glyph="&#xE890;" FontSize="12"/>
                     </ToggleButton>
@@ -79,7 +79,7 @@
                               Padding="6"
                               MinWidth="32"
                               MinHeight="32"
-                              ToolTipService.ToolTip="Show in taskbar widget"
+                              ToolTipService.ToolTip="Show in usage widget"
                               Click="WidgetRowVisibility_Click">
                     <FontIcon Glyph="&#xE890;" FontSize="12"/>
                 </ToggleButton>
@@ -218,7 +218,7 @@
                                           Padding="6"
                                           MinWidth="32"
                                           MinHeight="32"
-                                          ToolTipService.ToolTip="Show in taskbar widget"
+                                          ToolTipService.ToolTip="Show in usage widget"
                                           Click="WidgetRowVisibility_Click">
                                 <FontIcon Glyph="&#xE890;" FontSize="12"/>
                             </ToggleButton>
@@ -280,7 +280,7 @@
                                           Padding="6"
                                           MinWidth="32"
                                           MinHeight="32"
-                                          ToolTipService.ToolTip="Show in taskbar widget"
+                                          ToolTipService.ToolTip="Show in usage widget"
                                           Click="WidgetRowVisibility_Click">
                                 <FontIcon Glyph="&#xE890;" FontSize="12"/>
                             </ToggleButton>
@@ -343,7 +343,7 @@
                                           Padding="6"
                                           MinWidth="32"
                                           MinHeight="32"
-                                          ToolTipService.ToolTip="Show in taskbar widget"
+                                          ToolTipService.ToolTip="Show in usage widget"
                                           Click="WidgetRowVisibility_Click">
                                 <FontIcon Glyph="&#xE890;" FontSize="12"/>
                             </ToggleButton>
@@ -556,7 +556,7 @@
                                           Tag="{x:Bind ViewModel.SelectedCard, Mode=OneWay}"
                                           VerticalAlignment="Center"
                                           MinWidth="76"
-                                          ToolTipService.ToolTip="Keep this provider on the taskbar even when another tool is active"
+                                          ToolTipService.ToolTip="Keep this provider in the usage widget even when another tool is active"
                                           Click="ProviderPinToggle_Click">
                                 <StackPanel Orientation="Horizontal" Spacing="6">
                                     <FontIcon Glyph="&#xE718;" FontSize="14"/>

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml
@@ -64,7 +64,7 @@
             </tk:SettingsCard>
 
             <tk:SettingsCard Header="Hide widget when no AI app is focused"
-                             Description="Fade the active provider's tile out when you switch to a browser or any other app, and bring it back when you return. Pinned providers always stay on the taskbar.">
+                             Description="Fade the active provider's tile out when you switch to a browser or any other app, and bring it back when you return. Pinned providers always stay visible.">
                 <tk:SettingsCard.HeaderIcon>
                     <FontIcon Glyph="&#xE890;"/>
                 </tk:SettingsCard.HeaderIcon>
@@ -118,7 +118,7 @@
                               Toggled="OnAutoHideUnavailableToggled"/>
             </tk:SettingsCard>
 
-            <TextBlock Text="Choose which providers appear in the dashboard and taskbar widget."
+            <TextBlock Text="Choose which providers appear in the dashboard and usage widget."
                        Opacity="0.7"
                        Style="{StaticResource CaptionTextBlockStyle}"
                        TextWrapping="Wrap"
@@ -127,7 +127,7 @@
             <StackPanel x:Name="ProviderSettingsPanel" Spacing="4"/>
 
             <TextBlock Text="Behavior" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,16,0,2"/>
-            <tk:SettingsCard Header="Open at startup" Description="Start TaskbarQuota with Windows and show only the taskbar widget.">
+            <tk:SettingsCard Header="Open at startup" Description="Start TaskbarQuota with Windows and show only the usage widget.">
                 <tk:SettingsCard.HeaderIcon>
                     <FontIcon Glyph="&#xE7F4;"/>
                 </tk:SettingsCard.HeaderIcon>
@@ -196,7 +196,7 @@
                        Opacity="0.7" Style="{StaticResource CaptionTextBlockStyle}" TextWrapping="Wrap" Margin="0,0,0,4"/>
 
             <TextBlock Text="About" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,16,0,2"/>
-            <tk:SettingsCard Description="Native WinUI taskbar widget for AI coding-tool usage.">
+            <tk:SettingsCard Description="Native WinUI widget for AI coding-tool usage.">
                 <tk:SettingsCard.Header>
                     <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
                         <Border Width="40" Height="40"

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml
@@ -30,6 +30,42 @@
                           Margin="0,0,0,4"/>
 
             <TextBlock Text="Appearance" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,8,0,2"/>
+
+            <!-- Surface mode first so taskbar vs floating is easy to find (not buried under Theme). -->
+            <tk:SettingsCard Header="Where to show usage"
+                             Description="Taskbar places the compact widget next to the tray. Floating window uses a semi-transparent always-on-top HUD with the same layout.">
+                <tk:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE8A7;"/>
+                </tk:SettingsCard.HeaderIcon>
+                <ComboBox x:Name="WidgetSurfaceCombo"
+                          SelectionChanged="OnWidgetSurfaceChanged"
+                          MinWidth="200"
+                          AutomationProperties.Name="Where to show usage"
+                          AutomationProperties.AutomationId="WidgetSurfaceCombo">
+                    <ComboBoxItem Content="In the taskbar" Tag="Taskbar"/>
+                    <ComboBoxItem Content="Floating always-on-top window" Tag="Floating"/>
+                </ComboBox>
+            </tk:SettingsCard>
+
+            <tk:SettingsCard x:Name="FloatingOpacityCard"
+                             Header="Floating window opacity"
+                             Description="How solid the always-on-top usage window is (lower values show more of the desktop behind it).">
+                <tk:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE790;"/>
+                </tk:SettingsCard.HeaderIcon>
+                <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                    <!-- Slider range is applied in code — XAML Minimum/Maximum on RangeBase is unsafe. -->
+                    <Grid x:Name="FloatingOpacitySliderHost"
+                          Width="180"
+                          VerticalAlignment="Center"
+                          AutomationProperties.Name="Floating window opacity"/>
+                    <TextBlock x:Name="FloatingOpacityLabel"
+                               VerticalAlignment="Center"
+                               MinWidth="40"
+                               Style="{StaticResource BodyTextBlockStyle}"/>
+                </StackPanel>
+            </tk:SettingsCard>
+
             <tk:SettingsCard Header="Theme" Description="Choose how TaskbarQuota looks.">
                 <tk:SettingsCard.HeaderIcon>
                     <FontIcon Glyph="&#xE771;"/>
@@ -41,7 +77,7 @@
                 </ComboBox>
             </tk:SettingsCard>
 
-            <tk:SettingsCard Header="Taskbar widget" Description="Choose the compact usage layout shown beside the tray.">
+            <tk:SettingsCard Header="Widget layout" Description="Choose the compact usage layout (bars, percentages, or both).">
                 <tk:SettingsCard.HeaderIcon>
                     <FontIcon Glyph="&#xE71D;"/>
                 </tk:SettingsCard.HeaderIcon>

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml
@@ -31,41 +31,6 @@
 
             <TextBlock Text="Appearance" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,8,0,2"/>
 
-            <!-- Surface mode first so taskbar vs floating is easy to find (not buried under Theme). -->
-            <tk:SettingsCard Header="Where to show usage"
-                             Description="Taskbar places the compact widget next to the tray. Floating window uses a semi-transparent always-on-top HUD with the same layout.">
-                <tk:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE8A7;"/>
-                </tk:SettingsCard.HeaderIcon>
-                <ComboBox x:Name="WidgetSurfaceCombo"
-                          SelectionChanged="OnWidgetSurfaceChanged"
-                          MinWidth="200"
-                          AutomationProperties.Name="Where to show usage"
-                          AutomationProperties.AutomationId="WidgetSurfaceCombo">
-                    <ComboBoxItem Content="In the taskbar" Tag="Taskbar"/>
-                    <ComboBoxItem Content="Floating always-on-top window" Tag="Floating"/>
-                </ComboBox>
-            </tk:SettingsCard>
-
-            <tk:SettingsCard x:Name="FloatingOpacityCard"
-                             Header="Floating window opacity"
-                             Description="How solid the always-on-top usage window is (lower values show more of the desktop behind it).">
-                <tk:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE790;"/>
-                </tk:SettingsCard.HeaderIcon>
-                <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
-                    <!-- Slider range is applied in code — XAML Minimum/Maximum on RangeBase is unsafe. -->
-                    <Grid x:Name="FloatingOpacitySliderHost"
-                          Width="180"
-                          VerticalAlignment="Center"
-                          AutomationProperties.Name="Floating window opacity"/>
-                    <TextBlock x:Name="FloatingOpacityLabel"
-                               VerticalAlignment="Center"
-                               MinWidth="40"
-                               Style="{StaticResource BodyTextBlockStyle}"/>
-                </StackPanel>
-            </tk:SettingsCard>
-
             <tk:SettingsCard Header="Theme" Description="Choose how TaskbarQuota looks.">
                 <tk:SettingsCard.HeaderIcon>
                     <FontIcon Glyph="&#xE771;"/>
@@ -106,6 +71,40 @@
                 <ToggleSwitch x:Name="HideWhenUnfocusedToggle"
                               AutomationProperties.Name="Hide widget when no AI app is focused"
                               Toggled="OnHideWhenUnfocusedToggled"/>
+            </tk:SettingsCard>
+
+            <tk:SettingsCard Header="Where to show usage"
+                             Description="Taskbar places the compact widget next to the tray. Floating uses a native Acrylic always-on-top window with the same layout. Scroll wheel adjusts its strength; right-click returns to the taskbar.">
+                <tk:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE8A7;"/>
+                </tk:SettingsCard.HeaderIcon>
+                <ComboBox x:Name="WidgetSurfaceCombo"
+                          SelectionChanged="OnWidgetSurfaceChanged"
+                          MinWidth="200"
+                          AutomationProperties.Name="Where to show usage"
+                          AutomationProperties.AutomationId="WidgetSurfaceCombo">
+                    <ComboBoxItem Content="In the taskbar" Tag="Taskbar"/>
+                    <ComboBoxItem Content="Floating always-on-top window" Tag="Floating"/>
+                </ComboBox>
+            </tk:SettingsCard>
+
+            <tk:SettingsCard x:Name="FloatingOpacityCard"
+                             Header="Floating acrylic strength"
+                             Description="How opaque the native Acrylic tint is (lower values reveal more of the blurred desktop behind it).">
+                <tk:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE790;"/>
+                </tk:SettingsCard.HeaderIcon>
+                <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                    <!-- Slider range is applied in code — XAML Minimum/Maximum on RangeBase is unsafe. -->
+                    <Grid x:Name="FloatingOpacitySliderHost"
+                          Width="180"
+                          VerticalAlignment="Center"
+                          AutomationProperties.Name="Floating acrylic strength"/>
+                    <TextBlock x:Name="FloatingOpacityLabel"
+                               VerticalAlignment="Center"
+                               MinWidth="40"
+                               Style="{StaticResource BodyTextBlockStyle}"/>
+                </StackPanel>
             </tk:SettingsCard>
 
             <TextBlock Text="Providers" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,16,0,2"/>

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
+using TaskbarQuota.Diagnostics;
 using TaskbarQuota.Helpers;
 using TaskbarQuota.Services;
 using TaskbarQuota.Usage;
@@ -16,6 +18,7 @@ namespace TaskbarQuota.Views
         private bool _isInitializing;
         // Suppresses the Toggled handlers while a row's toggles are synced programmatically.
         private bool _suppressProviderToggleEvents;
+        private Slider? _floatingOpacitySlider;
         // Per-provider toggles, so changing one updates only its own row instead of rebuilding the list.
         private readonly Dictionary<ProviderId, ProviderToggleRow> _providerRows = new();
 
@@ -30,12 +33,19 @@ namespace TaskbarQuota.Views
         {
             _isInitializing = true;
             InitializeComponent();
+            BuildFloatingOpacitySlider();
             ThemeCombo.SelectedIndex = ThemeService.Current switch
             {
                 ElementTheme.Light => 1,
                 ElementTheme.Dark => 2,
                 _ => 0,
             };
+            WidgetSurfaceCombo.SelectedIndex = WidgetSettingsService.CurrentSurface == WidgetSurfaceMode.Floating ? 1 : 0;
+            int opacityPercent = (int)System.Math.Round(WidgetSettingsService.FloatingOpacity * 100);
+            if (_floatingOpacitySlider is { } slider)
+                slider.Value = opacityPercent;
+            FloatingOpacityLabel.Text = $"{opacityPercent}%";
+            FloatingOpacityCard.IsEnabled = WidgetSettingsService.CurrentSurface == WidgetSurfaceMode.Floating;
             WidgetModeCombo.SelectedIndex = WidgetSettingsService.Current switch
             {
                 WidgetDisplayMode.PercentagesOnly => 1,
@@ -52,6 +62,8 @@ namespace TaskbarQuota.Views
             VersionLabel.Text = $"Version {AppVersion.GetDisplayLabel()}";
             Loaded += (_, _) =>
             {
+                Log.Information(
+                    $"Settings page loaded (surface={WidgetSettingsService.CurrentSurface}, layout={WidgetSettingsService.Current})");
                 ViewModel.ReloadProviders();
                 RebuildProviderSettings();
             };
@@ -239,6 +251,61 @@ namespace TaskbarQuota.Views
                 };
                 ThemeService.Apply(theme);
             }
+        }
+
+        private void OnWidgetSurfaceChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isInitializing)
+                return;
+
+            if (WidgetSurfaceCombo.SelectedItem is ComboBoxItem item && item.Tag is string tag)
+            {
+                var mode = tag == "Floating"
+                    ? WidgetSurfaceMode.Floating
+                    : WidgetSurfaceMode.Taskbar;
+                WidgetSettingsService.ApplySurface(mode);
+                FloatingOpacityCard.IsEnabled = mode == WidgetSurfaceMode.Floating;
+            }
+        }
+
+        /// <summary>
+        /// Builds the opacity slider in code. WinUI RangeBase defaults Maximum=1; assigning Minimum=35
+        /// from XAML throws XamlParseException regardless of attribute order.
+        /// </summary>
+        private void BuildFloatingOpacitySlider()
+        {
+            if (_floatingOpacitySlider is not null)
+                return;
+
+            var slider = new Slider
+            {
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment = VerticalAlignment.Center,
+                StepFrequency = 1,
+            };
+            slider.Maximum = 100;
+            slider.Minimum = 35;
+            slider.Value = System.Math.Clamp(
+                System.Math.Round(WidgetSettingsService.FloatingOpacity * 100),
+                35,
+                100);
+            AutomationProperties.SetName(slider, "Floating window opacity");
+            AutomationProperties.SetAutomationId(slider, "SettingsFloatingOpacitySlider");
+            slider.ValueChanged += OnFloatingOpacityChanged;
+
+            FloatingOpacitySliderHost.Children.Clear();
+            FloatingOpacitySliderHost.Children.Add(slider);
+            _floatingOpacitySlider = slider;
+        }
+
+        private void OnFloatingOpacityChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+        {
+            if (_isInitializing)
+                return;
+
+            int percent = (int)System.Math.Round(e.NewValue);
+            FloatingOpacityLabel.Text = $"{percent}%";
+            WidgetSettingsService.ApplyFloatingOpacity(percent / 100d);
         }
 
         private void OnWidgetModeChanged(object sender, SelectionChangedEventArgs e)

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
@@ -289,7 +289,7 @@ namespace TaskbarQuota.Views
                 System.Math.Round(WidgetSettingsService.FloatingOpacity * 100),
                 35,
                 100);
-            AutomationProperties.SetName(slider, "Floating window opacity");
+            AutomationProperties.SetName(slider, "Floating acrylic strength");
             AutomationProperties.SetAutomationId(slider, "SettingsFloatingOpacitySlider");
             slider.ValueChanged += OnFloatingOpacityChanged;
 

--- a/tests/TaskbarQuota.Tests/AgentActivityTests.cs
+++ b/tests/TaskbarQuota.Tests/AgentActivityTests.cs
@@ -320,6 +320,40 @@ public sealed class AgentActivityTests
     }
 
     [Fact]
+    public void ClineSession_OlderThanHistoryWindow_RemainsIdleWhileProcessIsLive()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "taskbarquota-cline-old-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var lastActivity = DateTimeOffset.UtcNow.AddHours(-8);
+            var metadataPath = Path.Combine(root, "cline-old.json");
+            File.WriteAllText(metadataPath, $$"""
+                {
+                  "session_id": "cline-old",
+                  "started_at": "{{lastActivity:O}}",
+                  "updated_at": "{{lastActivity:O}}",
+                  "status": "running",
+                  "prompt": "Continue the long-running task"
+                }
+                """);
+            File.SetLastWriteTimeUtc(metadataPath, lastActivity.UtcDateTime);
+
+            var live = AgentActivityScanner.ReadClineForTesting(metadataPath, claimLive: true);
+            var closed = AgentActivityScanner.ReadClineForTesting(metadataPath, claimLive: false);
+
+            Assert.NotNull(live);
+            Assert.Equal(AgentActivityStatus.Idle, live.Status);
+            Assert.NotNull(closed);
+            Assert.Equal(AgentActivityStatus.Completed, closed.Status);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void KimiSession_ExtractsTitleToolActionAndSubagentCount()
     {
         var root = Path.Combine(Path.GetTempPath(), "taskbarquota-kimi-" + Guid.NewGuid().ToString("N"));

--- a/tests/TaskbarQuota.Tests/AgentActivityTests.cs
+++ b/tests/TaskbarQuota.Tests/AgentActivityTests.cs
@@ -70,24 +70,22 @@ public sealed class AgentActivityTests
     }
 
     [Fact]
-    public void CompactItems_ShowsIdleThenCompletedThenExpires()
+    public void CompactItems_KeepsProcessBackedIdleAgentsRegardlessOfTranscriptAge()
     {
         var now = DateTimeOffset.UtcNow;
         var snapshot = new AgentActivitySnapshot(new[]
         {
             new AgentActivityItem("recent-idle", ProviderId.Codex, "Task", "Waiting for the next prompt",
                 AgentActivityStatus.Idle, now.AddSeconds(-30), now.AddSeconds(-30)),
-              new AgentActivityItem("completed-idle", ProviderId.Codex, "Completed task", "Waiting for the next prompt",
-                  AgentActivityStatus.Idle, now.AddSeconds(-100), now.AddSeconds(-100)),
-              new AgentActivityItem("old-idle", ProviderId.Codex, "Old task", "Waiting for the next prompt",
-                  AgentActivityStatus.Idle, now.AddSeconds(-130), now.AddSeconds(-130)),
-          });
+            new AgentActivityItem("completed-idle", ProviderId.Codex, "Completed task", "Waiting for the next prompt",
+                AgentActivityStatus.Idle, now.AddSeconds(-100), now.AddSeconds(-100)),
+            new AgentActivityItem("old-idle", ProviderId.Codex, "Old task", "Waiting for the next prompt",
+                AgentActivityStatus.Idle, now.AddSeconds(-130), now.AddSeconds(-130)),
+        });
 
-          Assert.Contains(snapshot.CompactItems, item => item.Id == "recent-idle");
-          var completed = Assert.Single(snapshot.CompactItems, item => item.Id == "completed-idle");
-          Assert.Equal(AgentActivityStatus.Completed, completed.Status);
-          Assert.Equal("Completed", completed.Step);
-          Assert.DoesNotContain(snapshot.CompactItems, item => item.Id == "old-idle");
+        Assert.Equal(3, snapshot.CompactItems.Count);
+        Assert.All(snapshot.CompactItems, item => Assert.Equal(AgentActivityStatus.Idle, item.Status));
+        Assert.Equal("recent-idle", snapshot.Primary?.Id);
     }
 
     [Theory]

--- a/tests/TaskbarQuota.Tests/FloatingWidgetLayoutTests.cs
+++ b/tests/TaskbarQuota.Tests/FloatingWidgetLayoutTests.cs
@@ -1,0 +1,54 @@
+using TaskbarQuota.Controls;
+
+namespace TaskbarQuota.Tests;
+
+public class FloatingWidgetLayoutTests
+{
+    [Fact]
+    public void ComputeContentLogicalWidth_IncludesFullActivityWidthWhenShown()
+    {
+        int tilesOnly = QuotaWidgetContent.ComputeContentLogicalWidth(
+            tileWidths: [225, 225],
+            showActivity: false);
+
+        int withActivity = QuotaWidgetContent.ComputeContentLogicalWidth(
+            tileWidths: [225, 225],
+            showActivity: true,
+            activityLogicalWidth: AgentActivitySummary.DesiredLogicalWidth);
+
+        // Two tiles + margin/separator + 400 activity + margin + slack
+        Assert.True(withActivity > tilesOnly);
+        Assert.Equal(
+            tilesOnly - 8 + AgentActivitySummary.DesiredLogicalWidth + 8 + 8,
+            withActivity);
+        // Explicit: activity reservation is the full preferred strip, not a narrower clamp.
+        Assert.Equal(
+            225 + 4 + 7 + 225 + 4 + AgentActivitySummary.DesiredLogicalWidth + 8 + 8,
+            withActivity);
+    }
+
+    [Fact]
+    public void ComputeContentLogicalWidth_ShrinksWhenActivityHidden()
+    {
+        int withActivity = QuotaWidgetContent.ComputeContentLogicalWidth(
+            tileWidths: [300],
+            showActivity: true,
+            activityLogicalWidth: AgentActivitySummary.DesiredLogicalWidth);
+
+        int without = QuotaWidgetContent.ComputeContentLogicalWidth(
+            tileWidths: [300],
+            showActivity: false);
+
+        Assert.True(without < withActivity);
+        Assert.Equal(300 + 4 + 8, without);
+    }
+
+    [Fact]
+    public void ComputeContentLogicalWidth_EmptyUsesDefault()
+    {
+        int width = QuotaWidgetContent.ComputeContentLogicalWidth(
+            tileWidths: [],
+            showActivity: false);
+        Assert.Equal(172 + 8, width);
+    }
+}

--- a/tests/TaskbarQuota.Tests/FloatingWidgetLayoutTests.cs
+++ b/tests/TaskbarQuota.Tests/FloatingWidgetLayoutTests.cs
@@ -1,4 +1,5 @@
 using TaskbarQuota.Controls;
+using Windows.Graphics;
 
 namespace TaskbarQuota.Tests;
 
@@ -50,5 +51,25 @@ public class FloatingWidgetLayoutTests
             tileWidths: [],
             showActivity: false);
         Assert.Equal(172 + 8, width);
+    }
+
+    [Fact]
+    public void ConstrainBoundsToWorkArea_CapsOversizedWindowAndKeepsItVisible()
+    {
+        var result = FloatingUsageWindow.ConstrainBoundsToWorkArea(
+            new RectInt32(1200, 700, 1600, 900),
+            new RectInt32(0, 0, 1366, 728));
+
+        Assert.Equal(new RectInt32(0, 0, 1366, 728), result);
+    }
+
+    [Fact]
+    public void ConstrainBoundsToWorkArea_ClampsPositionWithoutResizingContentThatFits()
+    {
+        var result = FloatingUsageWindow.ConstrainBoundsToWorkArea(
+            new RectInt32(1800, 900, 450, 60),
+            new RectInt32(0, 0, 1920, 1040));
+
+        Assert.Equal(new RectInt32(1470, 900, 450, 60), result);
     }
 }

--- a/tests/TaskbarQuota.Tests/FlyoutLayoutTests.cs
+++ b/tests/TaskbarQuota.Tests/FlyoutLayoutTests.cs
@@ -64,4 +64,63 @@ public class FlyoutLayoutTests
             Environment.SetEnvironmentVariable(FlyoutLayout.ForceMinWidthEnvironmentVariable, previous);
         }
     }
+
+    [Fact]
+    public void ComputePlacement_PrefersAbove_WhenThereIsRoom()
+    {
+        // Work 1920x1080; anchor near bottom (taskbar-like); full flyout height fits above.
+        var result = FlyoutLayout.ComputePlacement(
+            anchorLeft: 1600, anchorTop: 1000, anchorRight: 1800, anchorBottom: 1040,
+            workLeft: 0, workTop: 0, workRight: 1920, workBottom: 1080,
+            width: 450, height: 800, gap: 8);
+
+        Assert.True(result.PlacedAbove);
+        Assert.Equal(800, result.Height);
+        Assert.Equal(1000 - 800 - 8, result.Y);
+        Assert.Equal(1800 - 450, result.X);
+    }
+
+    [Fact]
+    public void ComputePlacement_FlipsBelow_WhenAnchorIsNearTop()
+    {
+        // Anchor near top — not enough room above for full height; plenty below.
+        var result = FlyoutLayout.ComputePlacement(
+            anchorLeft: 100, anchorTop: 20, anchorRight: 300, anchorBottom: 60,
+            workLeft: 0, workTop: 0, workRight: 1920, workBottom: 1080,
+            width: 450, height: 800, gap: 8);
+
+        Assert.False(result.PlacedAbove);
+        Assert.Equal(800, result.Height);
+        Assert.Equal(60 + 8, result.Y);
+        // Right-align would be 300-450 = -150; clamp into work area.
+        Assert.Equal(0, result.X);
+    }
+
+    [Fact]
+    public void ComputePlacement_PrefersAbove_WhenBothSidesFit()
+    {
+        var result = FlyoutLayout.ComputePlacement(
+            anchorLeft: 500, anchorTop: 400, anchorRight: 700, anchorBottom: 440,
+            workLeft: 0, workTop: 0, workRight: 1920, workBottom: 1080,
+            width: 450, height: 300, gap: 8);
+
+        Assert.True(result.PlacedAbove);
+        Assert.Equal(300, result.Height);
+        Assert.Equal(400 - 300 - 8, result.Y);
+    }
+
+    [Fact]
+    public void ComputePlacement_UsesLargerSide_WhenNeitherFitsFullHeight()
+    {
+        // Anchor near top of a short work area; below has more room than above.
+        var result = FlyoutLayout.ComputePlacement(
+            anchorLeft: 100, anchorTop: 40, anchorRight: 280, anchorBottom: 80,
+            workLeft: 0, workTop: 0, workRight: 800, workBottom: 400,
+            width: 300, height: 500, gap: 8);
+
+        Assert.False(result.PlacedAbove);
+        // spaceBelow = 400 - 80 - 8 = 312
+        Assert.Equal(312, result.Height);
+        Assert.Equal(80 + 8, result.Y);
+    }
 }

--- a/tests/TaskbarQuota.Tests/FlyoutLayoutTests.cs
+++ b/tests/TaskbarQuota.Tests/FlyoutLayoutTests.cs
@@ -4,15 +4,20 @@ public class FlyoutLayoutTests
 {
     [Fact]
     public void LogicalHeight_IsSizedForTheExpandedFlyout()
-        => Assert.Equal(482, FlyoutLayout.LogicalHeight);
+        => Assert.Equal(
+            FlyoutLayout.MinLogicalContentHeight + FlyoutLayout.ChromeLogicalHeight + FlyoutLayout.HeightMeasureBuffer,
+            FlyoutLayout.LogicalHeight);
 
     [Fact]
     public void ComputeLogicalHeight_GrowsWithDetailContent()
-        => Assert.Equal(782, FlyoutLayout.ComputeLogicalHeight(620));
+        // Fixed content + ChromeLogicalHeight (incl. surface/opacity bar) + HeightMeasureBuffer
+        => Assert.Equal(620 + FlyoutLayout.ChromeLogicalHeight + FlyoutLayout.HeightMeasureBuffer,
+            FlyoutLayout.ComputeLogicalHeight(620));
 
     [Fact]
     public void ComputeLogicalHeight_ClampsTallContent()
-        => Assert.Equal(922, FlyoutLayout.ComputeLogicalHeight(1200));
+        => Assert.Equal(FlyoutLayout.MaxLogicalContentHeight + FlyoutLayout.ChromeLogicalHeight + FlyoutLayout.HeightMeasureBuffer,
+            FlyoutLayout.ComputeLogicalHeight(1200));
 
     [Fact]
     public void ComputeLogicalWidth_UsesWiderOfStripAndDetailContent()

--- a/tests/TaskbarQuota.Tests/WidgetSurfaceModeTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetSurfaceModeTests.cs
@@ -1,0 +1,62 @@
+using TaskbarQuota.Services;
+
+namespace TaskbarQuota.Tests;
+
+public class WidgetSurfaceModeTests
+{
+    [Fact]
+    public void Default_surface_is_taskbar()
+    {
+        // CurrentSurface is loaded from disk at process start. After other tests may have toggled it,
+        // force-apply taskbar and confirm ApplySurface is a no-op when already taskbar, then floating round-trips.
+        WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
+        Assert.Equal(WidgetSurfaceMode.Taskbar, WidgetSettingsService.CurrentSurface);
+    }
+
+    [Fact]
+    public void ApplySurface_switches_to_floating_and_back()
+    {
+        WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
+        Assert.Equal(WidgetSurfaceMode.Taskbar, WidgetSettingsService.CurrentSurface);
+
+        WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Floating);
+        Assert.Equal(WidgetSurfaceMode.Floating, WidgetSettingsService.CurrentSurface);
+        Assert.Equal(PinBudgetService.FloatingAvailableLogicalWidth, PinBudgetService.AvailableLogicalWidth);
+
+        WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
+        Assert.Equal(WidgetSurfaceMode.Taskbar, WidgetSettingsService.CurrentSurface);
+    }
+
+    [Fact]
+    public void ApplySurface_same_value_is_noop()
+    {
+        WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
+        int changed = 0;
+        void Handler(object? s, EventArgs e) => changed++;
+        WidgetSettingsService.Changed += Handler;
+        try
+        {
+            WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
+            Assert.Equal(0, changed);
+        }
+        finally
+        {
+            WidgetSettingsService.Changed -= Handler;
+        }
+    }
+
+    [Fact]
+    public void ApplyFloatingOpacity_clamps_and_round_trips()
+    {
+        WidgetSettingsService.ApplyFloatingOpacity(0.5);
+        Assert.Equal(0.5, WidgetSettingsService.FloatingOpacity, precision: 2);
+
+        WidgetSettingsService.ApplyFloatingOpacity(0.1); // below min
+        Assert.Equal(WidgetSettingsService.FloatingOpacityMin, WidgetSettingsService.FloatingOpacity, precision: 2);
+
+        WidgetSettingsService.ApplyFloatingOpacity(1.5); // above max
+        Assert.Equal(WidgetSettingsService.FloatingOpacityMax, WidgetSettingsService.FloatingOpacity, precision: 2);
+
+        WidgetSettingsService.ApplyFloatingOpacity(WidgetSettingsService.FloatingOpacityDefault);
+    }
+}

--- a/tests/TaskbarQuota.Tests/WidgetSurfaceModeTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetSurfaceModeTests.cs
@@ -40,7 +40,7 @@ public class WidgetSurfaceModeTests
     [Fact]
     public void ApplySurface_switches_to_floating_and_back()
     {
-        WithIsolatedSurfaceSettings(_ =>
+        WithIsolatedSurfaceSettings(directory =>
         {
             WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
             Assert.Equal(WidgetSurfaceMode.Taskbar, WidgetSettingsService.CurrentSurface);

--- a/tests/TaskbarQuota.Tests/WidgetSurfaceModeTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetSurfaceModeTests.cs
@@ -4,59 +4,88 @@ namespace TaskbarQuota.Tests;
 
 public class WidgetSurfaceModeTests
 {
+    /// <summary>
+    /// WidgetSettingsService is process-global. Capture and restore surface/opacity so these tests
+    /// cannot leak into others (or observe another test's mutations under parallel xUnit).
+    /// </summary>
+    private static void WithIsolatedSurfaceSettings(Action body)
+    {
+        var previousSurface = WidgetSettingsService.CurrentSurface;
+        var previousOpacity = WidgetSettingsService.FloatingOpacity;
+        try
+        {
+            body();
+        }
+        finally
+        {
+            WidgetSettingsService.ApplySurface(previousSurface);
+            WidgetSettingsService.ApplyFloatingOpacity(previousOpacity);
+        }
+    }
+
     [Fact]
     public void Default_surface_is_taskbar()
     {
-        // CurrentSurface is loaded from disk at process start. After other tests may have toggled it,
-        // force-apply taskbar and confirm ApplySurface is a no-op when already taskbar, then floating round-trips.
-        WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
-        Assert.Equal(WidgetSurfaceMode.Taskbar, WidgetSettingsService.CurrentSurface);
+        WithIsolatedSurfaceSettings(() =>
+        {
+            WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
+            Assert.Equal(WidgetSurfaceMode.Taskbar, WidgetSettingsService.CurrentSurface);
+        });
     }
 
     [Fact]
     public void ApplySurface_switches_to_floating_and_back()
     {
-        WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
-        Assert.Equal(WidgetSurfaceMode.Taskbar, WidgetSettingsService.CurrentSurface);
+        WithIsolatedSurfaceSettings(() =>
+        {
+            WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
+            Assert.Equal(WidgetSurfaceMode.Taskbar, WidgetSettingsService.CurrentSurface);
 
-        WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Floating);
-        Assert.Equal(WidgetSurfaceMode.Floating, WidgetSettingsService.CurrentSurface);
-        Assert.Equal(PinBudgetService.FloatingAvailableLogicalWidth, PinBudgetService.AvailableLogicalWidth);
+            WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Floating);
+            Assert.Equal(WidgetSurfaceMode.Floating, WidgetSettingsService.CurrentSurface);
+            Assert.Equal(PinBudgetService.FloatingAvailableLogicalWidth, PinBudgetService.AvailableLogicalWidth);
 
-        WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
-        Assert.Equal(WidgetSurfaceMode.Taskbar, WidgetSettingsService.CurrentSurface);
+            WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
+            Assert.Equal(WidgetSurfaceMode.Taskbar, WidgetSettingsService.CurrentSurface);
+        });
     }
 
     [Fact]
     public void ApplySurface_same_value_is_noop()
     {
-        WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
-        int changed = 0;
-        void Handler(object? s, EventArgs e) => changed++;
-        WidgetSettingsService.Changed += Handler;
-        try
+        WithIsolatedSurfaceSettings(() =>
         {
             WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
-            Assert.Equal(0, changed);
-        }
-        finally
-        {
-            WidgetSettingsService.Changed -= Handler;
-        }
+            int changed = 0;
+            void Handler(object? s, EventArgs e) => changed++;
+            WidgetSettingsService.Changed += Handler;
+            try
+            {
+                WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
+                Assert.Equal(0, changed);
+            }
+            finally
+            {
+                WidgetSettingsService.Changed -= Handler;
+            }
+        });
     }
 
     [Fact]
     public void ApplyFloatingOpacity_clamps_and_round_trips()
     {
-        WidgetSettingsService.ApplyFloatingOpacity(0.5);
-        Assert.Equal(0.5, WidgetSettingsService.FloatingOpacity, precision: 2);
+        WithIsolatedSurfaceSettings(() =>
+        {
+            WidgetSettingsService.ApplyFloatingOpacity(0.5);
+            Assert.Equal(0.5, WidgetSettingsService.FloatingOpacity, precision: 2);
 
-        WidgetSettingsService.ApplyFloatingOpacity(0.1); // below min
-        Assert.Equal(WidgetSettingsService.FloatingOpacityMin, WidgetSettingsService.FloatingOpacity, precision: 2);
+            WidgetSettingsService.ApplyFloatingOpacity(0.1); // below min
+            Assert.Equal(WidgetSettingsService.FloatingOpacityMin, WidgetSettingsService.FloatingOpacity, precision: 2);
 
-        WidgetSettingsService.ApplyFloatingOpacity(1.5); // above max
-        Assert.Equal(WidgetSettingsService.FloatingOpacityMax, WidgetSettingsService.FloatingOpacity, precision: 2);
+            WidgetSettingsService.ApplyFloatingOpacity(1.5); // above max
+            Assert.Equal(WidgetSettingsService.FloatingOpacityMax, WidgetSettingsService.FloatingOpacity, precision: 2);
 
-        WidgetSettingsService.ApplyFloatingOpacity(WidgetSettingsService.FloatingOpacityDefault);
+            WidgetSettingsService.ApplyFloatingOpacity(WidgetSettingsService.FloatingOpacityDefault);
+        });
     }
 }

--- a/tests/TaskbarQuota.Tests/WidgetSurfaceModeTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetSurfaceModeTests.cs
@@ -2,33 +2,37 @@ using TaskbarQuota.Services;
 
 namespace TaskbarQuota.Tests;
 
+[Collection(WidgetRowSettingsCollection.Name)]
 public class WidgetSurfaceModeTests
 {
     /// <summary>
     /// WidgetSettingsService is process-global. Capture and restore surface/opacity so these tests
     /// cannot leak into others (or observe another test's mutations under parallel xUnit).
     /// </summary>
-    private static void WithIsolatedSurfaceSettings(Action body)
+    private static void WithIsolatedSurfaceSettings(Action<string> body)
     {
         var previousSurface = WidgetSettingsService.CurrentSurface;
         var previousOpacity = WidgetSettingsService.FloatingOpacity;
+        var directory = Path.Combine(Path.GetTempPath(), "taskbarquota-surface-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
         try
         {
-            body();
+            using var storageOverride = AppStorage.OverrideAppDataDirectoryForTesting(directory);
+            WidgetSettingsService.ReloadSurfaceSettingsForTesting();
+            body(directory);
         }
         finally
         {
-            WidgetSettingsService.ApplySurface(previousSurface);
-            WidgetSettingsService.ApplyFloatingOpacity(previousOpacity);
+            WidgetSettingsService.RestoreSurfaceSettingsForTesting(previousSurface, previousOpacity);
+            Directory.Delete(directory, recursive: true);
         }
     }
 
     [Fact]
     public void Default_surface_is_taskbar()
     {
-        WithIsolatedSurfaceSettings(() =>
+        WithIsolatedSurfaceSettings(directory =>
         {
-            WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
             Assert.Equal(WidgetSurfaceMode.Taskbar, WidgetSettingsService.CurrentSurface);
         });
     }
@@ -36,7 +40,7 @@ public class WidgetSurfaceModeTests
     [Fact]
     public void ApplySurface_switches_to_floating_and_back()
     {
-        WithIsolatedSurfaceSettings(() =>
+        WithIsolatedSurfaceSettings(_ =>
         {
             WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
             Assert.Equal(WidgetSurfaceMode.Taskbar, WidgetSettingsService.CurrentSurface);
@@ -44,6 +48,10 @@ public class WidgetSurfaceModeTests
             WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Floating);
             Assert.Equal(WidgetSurfaceMode.Floating, WidgetSettingsService.CurrentSurface);
             Assert.Equal(int.MaxValue, PinBudgetService.AvailableLogicalWidth);
+            Assert.Equal("1", File.ReadAllText(Path.Combine(directory, "widget-surface-mode.txt")));
+
+            WidgetSettingsService.ReloadSurfaceSettingsForTesting();
+            Assert.Equal(WidgetSurfaceMode.Floating, WidgetSettingsService.CurrentSurface);
 
             WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
             Assert.Equal(WidgetSurfaceMode.Taskbar, WidgetSettingsService.CurrentSurface);
@@ -53,7 +61,7 @@ public class WidgetSurfaceModeTests
     [Fact]
     public void ApplySurface_same_value_is_noop()
     {
-        WithIsolatedSurfaceSettings(() =>
+        WithIsolatedSurfaceSettings(_ =>
         {
             WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
             int changed = 0;
@@ -74,9 +82,13 @@ public class WidgetSurfaceModeTests
     [Fact]
     public void ApplyFloatingOpacity_clamps_and_round_trips()
     {
-        WithIsolatedSurfaceSettings(() =>
+        WithIsolatedSurfaceSettings(directory =>
         {
             WidgetSettingsService.ApplyFloatingOpacity(0.5);
+            Assert.Equal(0.5, WidgetSettingsService.FloatingOpacity, precision: 2);
+            Assert.Equal("50", File.ReadAllText(Path.Combine(directory, "floating-opacity.txt")));
+
+            WidgetSettingsService.ReloadSurfaceSettingsForTesting();
             Assert.Equal(0.5, WidgetSettingsService.FloatingOpacity, precision: 2);
 
             WidgetSettingsService.ApplyFloatingOpacity(0.1); // below min

--- a/tests/TaskbarQuota.Tests/WidgetSurfaceModeTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetSurfaceModeTests.cs
@@ -114,6 +114,24 @@ public class WidgetSurfaceModeTests
         Assert.Equal(0.55, FloatingUsageWindow.StepOpacityFromWheel(0.50, +40), precision: 2);
     }
 
+    [Theory]
+    [InlineData(false, false, 120, false, true)]
+    [InlineData(false, false, -120, false, true)]
+    [InlineData(false, false, 120, true, false)]
+    [InlineData(true, false, 120, false, false)]
+    [InlineData(false, true, 120, false, false)]
+    [InlineData(false, false, 0, false, false)]
+    public void OpacityWheel_is_exclusive_with_agent_navigation(
+        bool isDragging,
+        bool isHorizontalWheel,
+        int wheelDelta,
+        bool overAgentActivity,
+        bool expected)
+    {
+        Assert.Equal(expected, FloatingUsageWindow.ShouldAdjustOpacityFromWheel(
+            isDragging, isHorizontalWheel, wheelDelta, overAgentActivity));
+    }
+
     [Fact]
     public void ComputeAcrylicMaterial_clamps_and_preserves_native_material_at_maximum()
     {

--- a/tests/TaskbarQuota.Tests/WidgetSurfaceModeTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetSurfaceModeTests.cs
@@ -43,7 +43,7 @@ public class WidgetSurfaceModeTests
 
             WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Floating);
             Assert.Equal(WidgetSurfaceMode.Floating, WidgetSettingsService.CurrentSurface);
-            Assert.Equal(PinBudgetService.FloatingAvailableLogicalWidth, PinBudgetService.AvailableLogicalWidth);
+            Assert.Equal(int.MaxValue, PinBudgetService.AvailableLogicalWidth);
 
             WidgetSettingsService.ApplySurface(WidgetSurfaceMode.Taskbar);
             Assert.Equal(WidgetSurfaceMode.Taskbar, WidgetSettingsService.CurrentSurface);

--- a/tests/TaskbarQuota.Tests/WidgetSurfaceModeTests.cs
+++ b/tests/TaskbarQuota.Tests/WidgetSurfaceModeTests.cs
@@ -88,4 +88,33 @@ public class WidgetSurfaceModeTests
             WidgetSettingsService.ApplyFloatingOpacity(WidgetSettingsService.FloatingOpacityDefault);
         });
     }
+
+    [Fact]
+    public void StepOpacityFromWheel_steps_by_five_percent_and_clamps()
+    {
+        Assert.Equal(0.55, FloatingUsageWindow.StepOpacityFromWheel(0.50, +120), precision: 2);
+        Assert.Equal(0.45, FloatingUsageWindow.StepOpacityFromWheel(0.50, -120), precision: 2);
+        Assert.Equal(WidgetSettingsService.FloatingOpacityMax,
+            FloatingUsageWindow.StepOpacityFromWheel(0.98, +120), precision: 2);
+        Assert.Equal(WidgetSettingsService.FloatingOpacityMin,
+            FloatingUsageWindow.StepOpacityFromWheel(0.36, -120), precision: 2);
+        // Sub-notch deltas still count as one step (precision touchpad).
+        Assert.Equal(0.55, FloatingUsageWindow.StepOpacityFromWheel(0.50, +40), precision: 2);
+    }
+
+    [Fact]
+    public void ComputeAcrylicMaterial_clamps_and_preserves_native_material_at_maximum()
+    {
+        var minimum = FloatingUsageWindow.ComputeAcrylicMaterial(0);
+        var middle = FloatingUsageWindow.ComputeAcrylicMaterial(0.675);
+        var maximum = FloatingUsageWindow.ComputeAcrylicMaterial(2);
+
+        Assert.Equal(0.25f, minimum.TintOpacity, precision: 3);
+        Assert.Equal(0.45f, minimum.LuminosityOpacity, precision: 3);
+        Assert.InRange(middle.TintOpacity, minimum.TintOpacity, maximum.TintOpacity);
+        Assert.InRange(middle.LuminosityOpacity, minimum.LuminosityOpacity, maximum.LuminosityOpacity);
+        Assert.Equal(0.80f, maximum.TintOpacity, precision: 3);
+        Assert.Equal(0.80f, maximum.LuminosityOpacity, precision: 3);
+        Assert.True(maximum.TintOpacity < 1, "Maximum strength must still reveal the native Acrylic material.");
+    }
 }


### PR DESCRIPTION
## Summary
- Add a **taskbar vs floating window** surface mode so the same compact usage UI can be shown either injected in the taskbar (existing behavior) or as a single always-on-top, draggable, semi-transparent overlay.
- Expose surface toggle and **opacity** (35–100%) in Settings and in the flyout quick bar.
- Keep parity for multi-tile layout, agent activity island, pins, hide-when-unfocused, and flyout click-to-open.
- Fix light-mode contrast on floating chrome (reset countdowns like `(6h 25m)` were invisible) and implement real layered-window opacity (XAML brush alpha alone cannot show the desktop).
- Pin budget uses a wider free-width when floating; re-enforces on switch back to taskbar.

## Why
Some users want live usage visible without relying on taskbar injection, or as an overlay that stays on top of other windows.

## How to test
1. Build/run; default should still be **taskbar** widgets only.
2. Settings → **Where to show usage** → **Floating always-on-top window**. Taskbar widgets disappear; one HUD appears (default near primary tray).
3. Click the floating window: flyout opens with Taskbar/Floating toggle and opacity slider.
4. Drag opacity toward ~50% — desktop shows through the HUD.
5. Light theme: labels, values, and reset times (e.g. `(6h 25m)`) remain readable.
6. Switch back to **Taskbar** in Settings or flyout; floating window closes; taskbar widgets return.
7. Agent activity island still appears when that setting is enabled (both surfaces).

## Notes
- Floating opacity uses `WS_EX_LAYERED` + `SetLayeredWindowAttributes` (whole-window alpha).
- Opacity slider is constructed in code because WinUI `RangeBase` rejects `Minimum=35` while default `Maximum=1` if set from XAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional floating, semi-transparent, always-on-top usage window.
  * Switch between taskbar and floating display modes in Appearance settings.
  * Adjust floating-window opacity, reposition it, or reset its location.
  * Provider usage, layouts, pinned items, and agent activity work in both modes.
  * Added floating-mode controls and improved flyout positioning.

* **Bug Fixes**
  * Improved theme-aware colors and visibility restoration.
  * Pin limits now adapt to the selected display mode.
  * Idle agent activity remains visible more reliably.

* **Documentation**
  * Documented the new floating display mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->