### PR TITLE
Fix OpenCode Go percentages below 2%

### DIFF
--- a/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
@@ -551,7 +551,9 @@ namespace TaskbarQuota.Usage.Providers
                 if (used is { } u && limit is { } l && l > 0) pct = u / l * 100.0;
             }
             if (pct is null) return null;
-            double p = pct.Value <= 1.0 ? pct.Value * 100.0 : pct.Value;
+            // OpenCode's usagePercent values are already percentages in the 0-100 range.
+            // Treating values <= 1 as fractions turns a legitimate 1% reading into 100%.
+            double p = pct.Value;
             var resetAt = ResetAt(obj);
             return new RateWindow(Math.Clamp(p, 0, 100), windowMinutes, resetAt, resetAt is null ? null : FormatTimeUntil(resetAt.Value));
         }
@@ -570,7 +572,9 @@ namespace TaskbarQuota.Usage.Providers
                 string resetPattern = $@"{Regex.Escape(name)}[^}}]*?(?:resetInSec|resetInSeconds|resetSeconds|reset_sec|reset_in_sec|resetsInSec|resetsInSeconds|resetIn|resetSec)\s*[:=]\s*([0-9]+)";
                 var resetSeconds = ExtractNumber(resetPattern, text);
                 DateTimeOffset? resetAt = resetSeconds is null ? null : DateTimeOffset.Now.AddSeconds(Math.Max(0, resetSeconds.Value));
-                var p = pct.Value <= 1.0 ? pct.Value * 100.0 : pct.Value;
+                // OpenCode's usagePercent values are already percentages in the 0-100 range.
+                // Treating values <= 1 as fractions turns a legitimate 1% reading into 100%.
+                var p = pct.Value;
                 return new RateWindow(Math.Clamp(p, 0, 100), windowMinutes, resetAt, resetAt is null ? null : FormatTimeUntil(resetAt.Value));
             }
             return null;

--- a/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
@@ -505,7 +505,7 @@ namespace TaskbarQuota.Usage.Providers
         private static double NormalizeMoney(double raw)
             => Math.Abs(raw) >= 1_000_000 ? raw / 100_000_000d : raw;
 
-        private static (RateWindow? rolling, RateWindow? weekly, DateTimeOffset? renewsAt) ParseUsage(string text)
+        internal static (RateWindow? rolling, RateWindow? weekly, DateTimeOffset? renewsAt) ParseUsage(string text)
         {
             try
             {

--- a/tests/TaskbarQuota.Tests/OpenCodeGoProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/OpenCodeGoProviderTests.cs
@@ -148,4 +148,16 @@ public class OpenCodeGoProviderTests
         Assert.Equal(51, OpenCodeProvider.ExtractWindow(html, 10080, "weeklyUsage")!.UsedPercent, 1);
         Assert.Equal(12, OpenCodeProvider.ExtractWindow(html, 43200, "monthlyUsage")!.UsedPercent, 1);
     }
+
+    [Fact]
+    public void GoPagePayload_OnePercentWindowIsNotExpandedToOneHundredPercent()
+    {
+        var html = "<script>window.__data={rollingUsage:{usagePercent:1,resetInSec:7200}," +
+                   "weeklyUsage:{usagePercent:1,resetInSec:172800}," +
+                   "monthlyUsage:{usagePercent:1,resetInSec:1209600}}</script>";
+
+        Assert.Equal(1, OpenCodeProvider.ExtractWindow(html, 300, "rollingUsage")!.UsedPercent);
+        Assert.Equal(1, OpenCodeProvider.ExtractWindow(html, 10080, "weeklyUsage")!.UsedPercent);
+        Assert.Equal(1, OpenCodeProvider.ExtractWindow(html, 43200, "monthlyUsage")!.UsedPercent);
+    }
 }

--- a/tests/TaskbarQuota.Tests/OpenCodeProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/OpenCodeProviderTests.cs
@@ -225,12 +225,21 @@ public class OpenCodeProviderTests
     }
 
     [Fact]
-    public void ExtractWindow_WithFractionalPercent_NormalizesToPercentage()
+    public void ExtractWindow_WithFractionalPercent_PreservesPercentage()
     {
         var text = "rollingUsage,usagePercent:0.653,resetInSec:14400";
         var window = OpenCodeProvider.ExtractWindow(text, 300, "rollingUsage");
         Assert.NotNull(window);
-        Assert.Equal(65.3, window!.UsedPercent, 1);
+        Assert.Equal(0.653, window!.UsedPercent, 3);
+    }
+
+    [Fact]
+    public void ExtractWindow_WithOnePercent_PreservesOnePercent()
+    {
+        var text = "monthlyUsage,usagePercent:1,resetInSec:2592000";
+        var window = OpenCodeProvider.ExtractWindow(text, 43200, "monthlyUsage");
+        Assert.NotNull(window);
+        Assert.Equal(1, window!.UsedPercent);
     }
 
     [Fact]

--- a/tests/TaskbarQuota.Tests/OpenCodeProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/OpenCodeProviderTests.cs
@@ -243,6 +243,24 @@ public class OpenCodeProviderTests
     }
 
     [Fact]
+    public void ParseUsage_WithJsonPercentages_PreservesPercentageScale()
+    {
+        var json = """
+            {
+              "rollingUsage": { "usagePercent": 0.653, "resetInSec": 14400 },
+              "weeklyUsage": { "usagePercent": 1, "resetInSec": 259200 }
+            }
+            """;
+
+        var (rolling, weekly, _) = OpenCodeProvider.ParseUsage(json);
+
+        Assert.NotNull(rolling);
+        Assert.Equal(0.653, rolling!.UsedPercent, 3);
+        Assert.NotNull(weekly);
+        Assert.Equal(1, weekly!.UsedPercent);
+    }
+
+    [Fact]
     public void ExtractWindow_WithNoMatch_ReturnsNull()
     {
         var text = "plan:free,active:true";


### PR DESCRIPTION
OpenCode already returns usagePercent on a 0-100 scale. Remove the fraction-normalization heuristic that converted legitimate values at or below 1% into values up to 100%, affecting rolling, weekly, and monthly meters. Add regression coverage for exact 1% readings and fractional percentages. Verification: staged diff check passes; clean CI should run the test suite. Local test execution was blocked by unrelated uncommitted dashboard/history work in the primary worktree, which is not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected OpenCode usage reporting so percentage values are displayed as provided.
  * Prevented low values, such as 1%, from being incorrectly converted to 100%.
  * Continued enforcing valid usage limits between 0% and 100%.

* **Tests**
  * Added coverage for rolling, weekly, and monthly usage calculations.
  * Added regression tests for fractional and one-percent usage values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->