### PR TITLE
fix: refresh cost history on demand

### DIFF
--- a/src/TaskbarQuota.App/Usage/UsageHistoryService.cs
+++ b/src/TaskbarQuota.App/Usage/UsageHistoryService.cs
@@ -37,13 +37,34 @@ namespace TaskbarQuota.Usage
             string SessionId,
             string? DedupeKey);
 
-        public static bool TryLoad(ProviderId providerId, out UsageHistory history)
+        public static bool TryLoad(ProviderId providerId, out UsageHistory history, bool force = false)
         {
             lock (ProviderLocks[providerId])
-                return TryLoadCore(providerId, out history);
+                return TryLoadCore(providerId, out history, force);
         }
 
-        private static bool TryLoadCore(ProviderId providerId, out UsageHistory history)
+        /// <summary>
+        /// Returns the last successfully parsed history without touching the disk. Periodic refresh
+        /// paths (coordinator tick, widget sync, dashboard load) use this so the heavy per-provider
+        /// enumeration/parse only happens on demand: entering the cost view or an explicit refresh.
+        /// </summary>
+        public static bool TryGetCachedHistory(ProviderId providerId, out UsageHistory history)
+        {
+            lock (CacheLock)
+            {
+                if (Cache.TryGetValue(providerId, out var cached)
+                    && cached.History.Last90Days is not null)
+                {
+                    history = cached.History;
+                    return true;
+                }
+            }
+
+            history = new UsageHistory();
+            return false;
+        }
+
+        private static bool TryLoadCore(ProviderId providerId, out UsageHistory history, bool force = false)
         {
             var files = DiscoverFiles(providerId).ToArray();
             if (files.Length == 0)
@@ -53,17 +74,20 @@ namespace TaskbarQuota.Usage
             }
 
             var fingerprint = Fingerprint(files);
-            lock (CacheLock)
+            if (!force)
             {
-                if (Cache.TryGetValue(providerId, out var cached)
-                    && cached.LocalDay == DateTime.Today
-                    && cached.FileCount == fingerprint.FileCount
-                    && cached.TotalLength == fingerprint.TotalLength
-                    && cached.LatestWriteTicks == fingerprint.LatestWriteTicks
-                    && cached.PathHash == fingerprint.PathHash)
+                lock (CacheLock)
                 {
-                    history = cached.History;
-                    return history.Last90Days is not null;
+                    if (Cache.TryGetValue(providerId, out var cached)
+                        && cached.LocalDay == DateTime.Today
+                        && cached.FileCount == fingerprint.FileCount
+                        && cached.TotalLength == fingerprint.TotalLength
+                        && cached.LatestWriteTicks == fingerprint.LatestWriteTicks
+                        && cached.PathHash == fingerprint.PathHash)
+                    {
+                        history = cached.History;
+                        return history.Last90Days is not null;
+                    }
                 }
             }
 

--- a/src/TaskbarQuota.App/Usage/UsageService.cs
+++ b/src/TaskbarQuota.App/Usage/UsageService.cs
@@ -97,7 +97,7 @@ namespace TaskbarQuota.Usage
             try
             {
                 var fetch = await provider.FetchUsageAsync(ct).ConfigureAwait(false);
-                if (UsageHistoryService.TryLoad(id, out var history))
+                if (UsageHistoryService.TryGetCachedHistory(id, out var history))
                     fetch.Usage.UsageHistory = history;
                 var result = UsageResult.Success(id, provider, fetch);
                 if (TryGetLastSuccessfulLiveResult(id, out var lastSuccess) && IsSuspiciousClaudeZeroResult(result, lastSuccess))
@@ -309,7 +309,7 @@ namespace TaskbarQuota.Usage
             if (result.Fetch?.Usage is not { } usage)
                 return result;
 
-            if (UsageHistoryService.TryLoad(id, out var history))
+            if (UsageHistoryService.TryGetCachedHistory(id, out var history))
             {
                 usage.UsageHistory = history;
             }

--- a/src/TaskbarQuota.App/ViewModels/DashboardViewModel.cs
+++ b/src/TaskbarQuota.App/ViewModels/DashboardViewModel.cs
@@ -126,6 +126,26 @@ namespace TaskbarQuota.ViewModels
         /// <summary>Initial load using cached values (no forced network).</summary>
         public Task LoadAsync() => LoadProgressiveAsync(force: false);
 
+        /// <summary>
+        /// Refreshes the cost/history data for the cost view without forcing a network refresh or
+        /// re-hydrating the quota cards. This is the only on-demand path that re-reads provider
+        /// history from disk (besides the explicit refresh button).
+        /// </summary>
+        public async Task LoadHistoryAsync()
+        {
+            if (IsRefreshing) return;
+
+            var active = UsageCoordinator.Instance.ActiveProvider;
+            var results = _lastResults.Count > 0
+                ? _lastResults
+                : await Task.Run(() => BuildDashboardResults(active)).ConfigureAwait(false);
+            var usageResults = await Task.Run(
+                () => BuildUsageHistoryResults(results, refresh: true)).ConfigureAwait(false);
+
+            _dispatcher.TryEnqueue(() =>
+                UpdateCards(results, active, refreshUsageSnapshot: true, usageResults: usageResults));
+        }
+
         private void OnPercentageModeChanged(object? sender, EventArgs e)
             => _dispatcher.TryEnqueue(() => UpdateCards(_lastResults, _lastActive, force: true));
 
@@ -189,7 +209,7 @@ namespace TaskbarQuota.ViewModels
                     var completed = await Task.Run(() =>
                     {
                         var merged = BuildDashboardResults(finalActive, finalResults);
-                        return (Results: merged, UsageResults: BuildUsageHistoryResults(merged));
+                        return (Results: merged, UsageResults: BuildUsageHistoryResults(merged, force));
                     }).ConfigureAwait(false);
                     _dispatcher.TryEnqueue(() =>
                     {
@@ -410,7 +430,9 @@ namespace TaskbarQuota.ViewModels
             return OrderResults(merged.Values.ToArray(), active).ToList();
         }
 
-        private static IReadOnlyList<UsageResult> BuildUsageHistoryResults(IReadOnlyList<UsageResult> results)
+        private static IReadOnlyList<UsageResult> BuildUsageHistoryResults(
+            IReadOnlyList<UsageResult> results,
+            bool refresh = false)
         {
             var combined = results
                 .Where(result => result.Fetch?.Usage.UsageHistory is not null)
@@ -418,8 +440,24 @@ namespace TaskbarQuota.ViewModels
             var service = UsageCoordinator.Instance.Service;
             foreach (var provider in service.All)
             {
-                if (combined.ContainsKey(provider.Id)
-                    || !UsageHistoryService.TryLoad(provider.Id, out var history))
+                if (combined.ContainsKey(provider.Id))
+                {
+                    // Only an explicit refresh re-reads the provider's local files; periodic loads
+                    // keep whatever history the fetch already carried (served from memory).
+                    if (refresh
+                        && UsageHistoryService.TryLoad(provider.Id, out var fresh, force: true)
+                        && combined[provider.Id].Fetch?.Usage is { } refreshedUsage)
+                        refreshedUsage.UsageHistory = fresh;
+                    continue;
+                }
+
+                UsageHistory? history;
+                bool loaded;
+                if (refresh)
+                    loaded = UsageHistoryService.TryLoad(provider.Id, out history, force: true);
+                else
+                    loaded = UsageHistoryService.TryGetCachedHistory(provider.Id, out history);
+                if (!loaded)
                     continue;
 
                 var usage = new UsageSnapshot(new RateWindow(0)) { UsageHistory = history };

--- a/src/TaskbarQuota.App/Views/CostPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/CostPage.xaml.cs
@@ -21,7 +21,7 @@ namespace TaskbarQuota.Views
             Loaded -= CostPage_Loaded;
             DispatcherQueue.TryEnqueue(
                 Microsoft.UI.Dispatching.DispatcherQueuePriority.Low,
-                () => _ = ViewModel.LoadAsync());
+                () => _ = ViewModel.LoadHistoryAsync());
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)


### PR DESCRIPTION
## Summary
- avoid rereading provider history files during periodic usage refreshes
- refresh history from disk when opening or explicitly refreshing the cost view
- keep quota/network refreshes lightweight while preserving fresh cost data

## Validation
- `dotnet test tests/TaskbarQuota.Tests/TaskbarQuota.Tests.csproj --no-restore`
- 695 passed