### PR TITLE
Use OpenCode Go public usage API instead of cookie scraping

### DIFF
--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -291,12 +291,13 @@ namespace TaskbarQuota.Controls
                 if (result.Id is ProviderId.OpenCode or ProviderId.OpenCodeGo
                     && result.ErrorKind == ProviderErrorKind.AuthRequired)
                 {
-                    _rows = new() { new WidgetUsageRow("Cookies", 0, "needed", HasBar: false) };
+                    bool isGo = result.Id == ProviderId.OpenCodeGo;
+                    _rows = new() { new WidgetUsageRow(isGo ? "API key" : "Cookies", 0, "needed", HasBar: false) };
                     RenderRows();
                     AnimateRender(isFirstReveal, providerSwitch: providerChanged);
                     var opencodeSourceText = result.Source.IsKnown ? $" {result.Source.ShortViaText}" : "";
                     ToolTipService.SetToolTip(this,
-                        $"{widgetName}{opencodeSourceText}: {result.Error ?? "No cookies detected. Manual cookie insertion is needed."}");
+                        $"{widgetName}{opencodeSourceText}: {result.Error ?? (isGo ? "OpenCode Go API key not found." : "No cookies detected. Manual cookie insertion is needed.")}");
                     return;
                 }
 

--- a/src/TaskbarQuota.App/Services/ProviderInstallDetector.cs
+++ b/src/TaskbarQuota.App/Services/ProviderInstallDetector.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using TaskbarQuota.Usage;
+using TaskbarQuota.Usage.Providers;
 
 namespace TaskbarQuota;
 
@@ -62,8 +63,9 @@ internal static class ProviderInstallDetector
         ProviderId.Copilot => IsCliAvailable("gh")
             || !string.IsNullOrWhiteSpace(CredentialStore.Instance.For(ProviderId.Copilot).ApiKey),
         ProviderId.Cursor => IsCursorInstalled(),
-        ProviderId.OpenCode or ProviderId.OpenCodeGo => IsCliAvailable("opencode")
+        ProviderId.OpenCode => IsCliAvailable("opencode")
             || !string.IsNullOrWhiteSpace(CredentialStore.Instance.For(ProviderId.OpenCode).CookieHeader),
+        ProviderId.OpenCodeGo => IsCliAvailable("opencode") || HasOpenCodeGoKey(),
         ProviderId.Cline or ProviderId.ClinePass => IsCliAvailable("cline") || File.Exists(ClineProvidersPath()),
         _ => true,
     };
@@ -83,15 +85,19 @@ internal static class ProviderInstallDetector
         ProviderId.Copilot => !string.IsNullOrWhiteSpace(CredentialStore.Instance.For(ProviderId.Copilot).ApiKey)
             || HasCachedCli("gh"),
         ProviderId.Cursor => IsCursorInstalled(),
-        ProviderId.OpenCode or ProviderId.OpenCodeGo =>
+        ProviderId.OpenCode =>
             !string.IsNullOrWhiteSpace(CredentialStore.Instance.For(ProviderId.OpenCode).CookieHeader)
             || HasCachedCli("opencode"),
+        ProviderId.OpenCodeGo => HasOpenCodeGoKey() || HasCachedCli("opencode"),
         ProviderId.Cline or ProviderId.ClinePass => File.Exists(ClineProvidersPath()) || HasCachedCli("cline"),
         _ => true,
     };
 
     private static bool HasCachedCli(string name)
         => CliAvailability.TryGetValue(name, out bool available) && available;
+
+    private static bool HasOpenCodeGoKey()
+        => OpenCodeGoProvider.TryLoadApiKey() is { Length: > 0 };
 
     public static string WaitingMessage(ProviderId id) => id switch
     {

--- a/src/TaskbarQuota.App/Services/ProviderInstallDetector.cs
+++ b/src/TaskbarQuota.App/Services/ProviderInstallDetector.cs
@@ -111,7 +111,8 @@ internal static class ProviderInstallDetector
         ProviderId.Claude => "Open Claude in your browser, or install the Claude CLI/app and sign in.",
         ProviderId.Copilot => "Install the GitHub CLI or add a token in Settings.",
         ProviderId.Cursor => "Install Cursor and sign in.",
-        ProviderId.OpenCode or ProviderId.OpenCodeGo => "Sign in at opencode.ai or paste cookies via Fix.",
+        ProviderId.OpenCode => "Sign in at opencode.ai or paste cookies via Fix.",
+        ProviderId.OpenCodeGo => "Sign in to OpenCode Go or set OPENCODE_API_KEY.",
         ProviderId.Cline or ProviderId.ClinePass => "Install the Cline CLI (npm i -g cline) and sign in.",
         _ => "Set up this provider to see usage here.",
     };

--- a/src/TaskbarQuota.App/Usage/Models.cs
+++ b/src/TaskbarQuota.App/Usage/Models.cs
@@ -382,5 +382,7 @@ namespace TaskbarQuota.Usage
     {
         public ProviderErrorKind Kind { get; }
         public ProviderException(ProviderErrorKind kind, string message) : base(message) => Kind = kind;
+        public ProviderException(ProviderErrorKind kind, string message, Exception innerException)
+            : base(message, innerException) => Kind = kind;
     }
 }

--- a/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -60,13 +62,6 @@ namespace TaskbarQuota.Usage.Providers
             var manual = NormalizeCookieHeader(CredentialStore.Instance.ManualCookieHeader(id));
             if (manual != null)
                 return new[] { new CookieCandidate(manual, "manual", true) };
-
-            if (id == ProviderId.OpenCodeGo)
-            {
-                manual = NormalizeCookieHeader(CredentialStore.Instance.ManualCookieHeader(ProviderId.OpenCode));
-                if (manual != null)
-                    return new[] { new CookieCandidate(manual, "manual (OpenCode)", true) };
-            }
 
             var candidates = CookieExtractor.GetCookieSources(domains)
                 .Where(source => source.Cookies.Any(cookie =>
@@ -654,10 +649,15 @@ namespace TaskbarQuota.Usage.Providers
         }
     }
 
-    /// <summary>OpenCode Go subscription usage from the workspace /go page: rolling, weekly and monthly windows.</summary>
+    /// <summary>
+    /// OpenCode Go subscription usage via the public usage API (rolling / weekly / monthly).
+    /// Auth is a bearer API key from OPENCODE_API_KEY, the credential store, or the opencode
+    /// CLI's local auth.json — no browser cookies or workspace page scraping.
+    /// </summary>
     public sealed class OpenCodeGoProvider : IUsageProvider
     {
-        private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(30) };
+        private const string UsageUrl = "https://opencode.ai/zen/go/v1/usage";
+        private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(20) };
 
         public ProviderId Id => ProviderId.OpenCodeGo;
         public string DisplayName => "OpenCode Go";
@@ -665,60 +665,108 @@ namespace TaskbarQuota.Usage.Providers
         public string WeeklyLabel => "Weekly";
         public BillingKind Billing => BillingKind.Subscription;
 
-        public Task<ProviderFetchResult> FetchUsageAsync(CancellationToken ct = default)
-            => CookieHelper.FetchWithCandidatesAsync(
-                Id,
-                "OpenCode Go cookies expired.",
-                (cookie, token) => FetchUsageAsync(cookie, token),
-                ct,
-                "opencode.ai");
-
-        private async Task<ProviderFetchResult> FetchUsageAsync(string cookie, CancellationToken ct)
+        public async Task<ProviderFetchResult> FetchUsageAsync(CancellationToken ct = default)
         {
-            string workspaceId = OpenCodeProvider.NormalizeWorkspaceId(CredentialStore.Instance.WorkspaceId(Id))
-                ?? OpenCodeProvider.NormalizeWorkspaceId(CredentialStore.Instance.WorkspaceId(ProviderId.OpenCode))
-                ?? await OpenCodeProvider.FetchWorkspaceId(cookie, ct, "OpenCode Go").ConfigureAwait(false);
+            var apiKey = LoadApiKey();
+            using var request = new HttpRequestMessage(HttpMethod.Get, UsageUrl);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+            request.Headers.Accept.ParseAdd("application/json");
 
-            string usageText = await GetPageText(
-                OpenCodeProvider.WorkspacePageUrl(workspaceId, "go"),
-                cookie,
-                ct).ConfigureAwait(false);
-            if (OpenCodeProvider.LooksSignedOut(usageText)) throw new ProviderException(ProviderErrorKind.AuthRequired, "OpenCode Go cookies expired.");
+            using var response = await Http.SendAsync(request, ct).ConfigureAwait(false);
+            if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+                throw new ProviderException(ProviderErrorKind.AuthRequired, "OpenCode Go API key invalid or expired.");
+            if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                throw new ProviderException(ProviderErrorKind.RateLimited, "OpenCode Go API rate limited. Try again later.");
+            if (!response.IsSuccessStatusCode)
+                throw new ProviderException(ProviderErrorKind.Other, $"OpenCode Go API returned {(int)response.StatusCode}");
 
-            var rolling = OpenCodeProvider.ExtractWindow(usageText, 300, "rollingUsage", "rolling_usage", "rolling")
-                ?? throw new ProviderException(ProviderErrorKind.Parse, "OpenCode Go: missing session usage.");
-            var weekly = OpenCodeProvider.ExtractWindow(usageText, 10080, "weeklyUsage", "weekly_usage", "weekly");
-            var monthly = OpenCodeProvider.ExtractWindow(usageText, 43200, "monthlyUsage", "monthly_usage", "monthly");
+            using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+            return BuildResult(doc.RootElement);
+        }
 
-            var usage = new UsageSnapshot(rolling)
+        internal static ProviderFetchResult BuildResult(JsonElement root)
+        {
+            if (!root.TryGetProperty("usage", out var usage) || usage.ValueKind != JsonValueKind.Object)
+                throw new ProviderException(ProviderErrorKind.Parse, "OpenCode Go: missing usage payload.");
+
+            var rolling = ParseWindow(usage, 300, "rolling")
+                ?? throw new ProviderException(ProviderErrorKind.Parse, "OpenCode Go: missing rolling usage.");
+            var weekly = ParseWindow(usage, 10080, "weekly");
+            var monthly = ParseWindow(usage, 43200, "monthly");
+
+            return new ProviderFetchResult(new UsageSnapshot(rolling)
             {
                 Secondary = weekly,
                 Monthly = monthly,
                 LoginMethod = "Go",
-                UsageDashboardUrl = OpenCodeProvider.WorkspacePageUrl(workspaceId, "go"),
-            };
-
-            return new ProviderFetchResult(usage, "opencode");
+            }, "api");
         }
 
-        private static async Task<string> GetPageText(string url, string cookie, CancellationToken ct)
+        private static RateWindow? ParseWindow(JsonElement usage, int windowMinutes, string key)
         {
-            using var req = new HttpRequestMessage(HttpMethod.Get, url);
-            req.Headers.TryAddWithoutValidation("Cookie", cookie);
-            req.Headers.TryAddWithoutValidation("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
-            req.Headers.TryAddWithoutValidation("Origin", "https://opencode.ai");
-            req.Headers.TryAddWithoutValidation("Referer", url);
-            req.Headers.TryAddWithoutValidation("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,text/javascript,application/json;q=0.8,*/*;q=0.7");
-            using var resp = await Http.SendAsync(req, ct).ConfigureAwait(false);
-            var text = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-            if (resp.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden || OpenCodeProvider.LooksSignedOut(text))
-                throw new ProviderException(ProviderErrorKind.AuthRequired, "OpenCode Go cookies expired.");
-            if (resp.StatusCode == HttpStatusCode.TooManyRequests)
-                throw new ProviderException(ProviderErrorKind.RateLimited, "OpenCode Go API rate limited.");
-            if (!resp.IsSuccessStatusCode)
-                throw new ProviderException(ProviderErrorKind.Other, $"OpenCode Go API {(int)resp.StatusCode}");
-            return text;
+            if (!usage.TryGetProperty(key, out var window) || window.ValueKind != JsonValueKind.Object)
+                return null;
+            if (!window.TryGetProperty("percent", out var percent) || percent.ValueKind != JsonValueKind.Number)
+                return null;
+
+            DateTimeOffset? resetAt = window.TryGetProperty("resetsAt", out var resetsAt)
+                && resetsAt.ValueKind == JsonValueKind.String
+                    ? ParseIsoDate(resetsAt.GetString())
+                    : null;
+
+            return new RateWindow(
+                Math.Clamp(percent.GetDouble(), 0, 100),
+                windowMinutes,
+                resetAt,
+                resetAt is null ? null : OpenCodeProvider.FormatTimeUntil(resetAt.Value));
         }
 
+        internal static string LoadApiKey() => LoadApiKey(null);
+
+        internal static string LoadApiKey(string? homeOverride)
+        {
+            var fromEnv = Environment.GetEnvironmentVariable("OPENCODE_API_KEY")?.Trim();
+            if (!string.IsNullOrEmpty(fromEnv)) return fromEnv!;
+
+            var fromStore = CredentialStore.Instance.ApiKey(ProviderId.OpenCodeGo, "OPENCODE_API_KEY");
+            if (!string.IsNullOrWhiteSpace(fromStore)) return fromStore!;
+
+            var fromAuth = TryLoadApiKeyFromAuth(homeOverride);
+            if (!string.IsNullOrWhiteSpace(fromAuth)) return fromAuth!;
+
+            throw new ProviderException(ProviderErrorKind.AuthRequired,
+                "OpenCode Go API key not found. Set OPENCODE_API_KEY or sign in to the OpenCode Go CLI.");
+        }
+
+        internal static string? TryLoadApiKeyFromAuth(string? homeOverride = null)
+        {
+            var profile = homeOverride
+                ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var path = Path.Combine(profile, ".local", "share", "opencode", "auth.json");
+            try
+            {
+                using var doc = JsonDocument.Parse(File.ReadAllText(path));
+                if (!doc.RootElement.TryGetProperty("opencode-go", out var go)
+                    || go.ValueKind != JsonValueKind.Object
+                    || !go.TryGetProperty("key", out var key)
+                    || key.ValueKind != JsonValueKind.String)
+                    return null;
+
+                var value = key.GetString()?.Trim();
+                return string.IsNullOrEmpty(value) ? null : value;
+            }
+            catch (IOException) { return null; }
+            catch (UnauthorizedAccessException) { return null; }
+            catch (JsonException) { return null; }
+        }
+
+        private static DateTimeOffset? ParseIsoDate(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw)) return null;
+            return DateTimeOffset.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed)
+                ? parsed
+                : null;
+        }
     }
 }

--- a/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CookieProviders.cs
@@ -681,8 +681,7 @@ namespace TaskbarQuota.Usage.Providers
                 throw new ProviderException(ProviderErrorKind.Other, $"OpenCode Go API returned {(int)response.StatusCode}");
 
             using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
-            return BuildResult(doc.RootElement);
+            return await ParseResponse(stream, ct).ConfigureAwait(false);
         }
 
         internal static ProviderFetchResult BuildResult(JsonElement root)
@@ -701,6 +700,19 @@ namespace TaskbarQuota.Usage.Providers
                 Monthly = monthly,
                 LoginMethod = "Go",
             }, "api");
+        }
+
+        internal static async Task<ProviderFetchResult> ParseResponse(Stream stream, CancellationToken ct)
+        {
+            try
+            {
+                using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+                return BuildResult(doc.RootElement);
+            }
+            catch (JsonException ex)
+            {
+                throw new ProviderException(ProviderErrorKind.Parse, $"OpenCode Go returned malformed JSON: {ex.Message}", ex);
+            }
         }
 
         private static RateWindow? ParseWindow(JsonElement usage, int windowMinutes, string key)
@@ -725,18 +737,19 @@ namespace TaskbarQuota.Usage.Providers
         internal static string LoadApiKey() => LoadApiKey(null);
 
         internal static string LoadApiKey(string? homeOverride)
+            => TryLoadApiKey(homeOverride)
+                ?? throw new ProviderException(ProviderErrorKind.AuthRequired,
+                    "OpenCode Go API key not found. Set OPENCODE_API_KEY or sign in to the OpenCode Go CLI.");
+
+        internal static string? TryLoadApiKey(string? homeOverride = null)
         {
             var fromEnv = Environment.GetEnvironmentVariable("OPENCODE_API_KEY")?.Trim();
-            if (!string.IsNullOrEmpty(fromEnv)) return fromEnv!;
+            if (!string.IsNullOrEmpty(fromEnv)) return fromEnv;
 
             var fromStore = CredentialStore.Instance.ApiKey(ProviderId.OpenCodeGo, "OPENCODE_API_KEY");
-            if (!string.IsNullOrWhiteSpace(fromStore)) return fromStore!;
+            if (!string.IsNullOrWhiteSpace(fromStore)) return fromStore;
 
-            var fromAuth = TryLoadApiKeyFromAuth(homeOverride);
-            if (!string.IsNullOrWhiteSpace(fromAuth)) return fromAuth!;
-
-            throw new ProviderException(ProviderErrorKind.AuthRequired,
-                "OpenCode Go API key not found. Set OPENCODE_API_KEY or sign in to the OpenCode Go CLI.");
+            return TryLoadApiKeyFromAuth(homeOverride);
         }
 
         internal static string? TryLoadApiKeyFromAuth(string? homeOverride = null)

--- a/src/TaskbarQuota.App/ViewModels/SettingsViewModel.cs
+++ b/src/TaskbarQuota.App/ViewModels/SettingsViewModel.cs
@@ -87,7 +87,7 @@ namespace TaskbarQuota.ViewModels
             var e = CredentialStore.Instance.For(_id);
             e.ApiKey = string.IsNullOrWhiteSpace(ApiKey) ? null : ApiKey.Trim();
             var cookieInput = string.IsNullOrWhiteSpace(CookieHeader) ? null : CookieHeader.Trim();
-            bool isOpenCode = _id is ProviderId.OpenCode or ProviderId.OpenCodeGo;
+            bool isOpenCode = _id is ProviderId.OpenCode;
             var normalizedCookie = isOpenCode
                 ? CookieHelper.NormalizeCookieHeader(cookieInput)
                 : cookieInput;

--- a/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
@@ -188,7 +188,7 @@ namespace TaskbarQuota.Views
 
             if (vm.IsApiKey)
             {
-                var pwd = new PasswordBox { Password = vm.ApiKey, MinWidth = 280, PlaceholderText = "Paste your GitHub token..." };
+                var pwd = new PasswordBox { Password = vm.ApiKey, MinWidth = 280, PlaceholderText = "Paste your API key..." };
                 pwd.PasswordChanged += (_, _) => vm.ApiKey = pwd.Password;
 
                 stack.Children.Add(new TextBlock { Text = "API key", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold });
@@ -366,8 +366,8 @@ namespace TaskbarQuota.Views
                 "Paste an opencode.ai Cookie header and optionally enter a Workspace ID (wrk_...).",
                 CredentialKind.Cookie),
             ProviderId.OpenCodeGo => new ProviderCredentialViewModel(id, "OpenCode Go",
-                "Paste an opencode.ai Cookie header and optionally enter a Workspace ID (wrk_...).",
-                CredentialKind.Cookie),
+                "Paste your OpenCode Go API key (OPENCODE_API_KEY). It is read automatically from the opencode CLI auth store when you are signed in.",
+                CredentialKind.ApiKey, "OPENCODE_API_KEY"),
             ProviderId.Kimi => new ProviderCredentialViewModel(id, "Kimi Code",
                 "Paste your Kimi Code API key (KIMI_CODE_API_KEY) to fetch Coding Plan usage without CLI login.",
                 CredentialKind.ApiKey, "KIMI_CODE_API_KEY"),

--- a/tests/TaskbarQuota.Tests/OpenCodeGoProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/OpenCodeGoProviderTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO;
+using System.Text.Json;
 using TaskbarQuota.Usage;
 using TaskbarQuota.Usage.Providers;
 
@@ -159,5 +161,78 @@ public class OpenCodeGoProviderTests
         Assert.Equal(1, OpenCodeProvider.ExtractWindow(html, 300, "rollingUsage")!.UsedPercent);
         Assert.Equal(1, OpenCodeProvider.ExtractWindow(html, 10080, "weeklyUsage")!.UsedPercent);
         Assert.Equal(1, OpenCodeProvider.ExtractWindow(html, 43200, "monthlyUsage")!.UsedPercent);
+    }
+
+    [Fact]
+    public void BuildResult_ParsesApiUsageJson()
+    {
+        const string json = "{\"usage\":{\"rolling\":{\"status\":\"ok\",\"percent\":12,\"resetsAt\":\"2026-08-12T22:13:10.85Z\"}," +
+                            "\"weekly\":{\"status\":\"ok\",\"percent\":8,\"resetsAt\":\"2026-08-17T00:00:00.85Z\"}," +
+                            "\"monthly\":{\"status\":\"ok\",\"percent\":35,\"resetsAt\":\"2026-09-07T14:16:57.85Z\"}}}";
+
+        using var doc = JsonDocument.Parse(json);
+        var result = OpenCodeGoProvider.BuildResult(doc.RootElement);
+
+        Assert.Equal("api", result.SourceLabel);
+        Assert.Equal(12, result.Usage.Primary.UsedPercent, 1);
+        Assert.Equal(300, result.Usage.Primary.WindowMinutes);
+        Assert.NotNull(result.Usage.Primary.ResetAt);
+        Assert.Equal(8, result.Usage.Secondary!.UsedPercent, 1);
+        Assert.Equal(10080, result.Usage.Secondary.WindowMinutes);
+        Assert.Equal(35, result.Usage.Monthly!.UsedPercent, 1);
+        Assert.Equal(43200, result.Usage.Monthly.WindowMinutes);
+        Assert.Equal("Go", result.Usage.LoginMethod);
+    }
+
+    [Fact]
+    public void BuildResult_MissingUsage_ThrowsParse()
+    {
+        using var doc = JsonDocument.Parse("{\"error\":\"nope\"}");
+        var ex = Assert.Throws<ProviderException>(() => OpenCodeGoProvider.BuildResult(doc.RootElement));
+        Assert.Equal(ProviderErrorKind.Parse, ex.Kind);
+    }
+
+    [Fact]
+    public void BuildResult_MissingRolling_ThrowsParse()
+    {
+        using var doc = JsonDocument.Parse("{\"usage\":{\"weekly\":{\"percent\":1},\"monthly\":{\"percent\":1}}}");
+        var ex = Assert.Throws<ProviderException>(() => OpenCodeGoProvider.BuildResult(doc.RootElement));
+        Assert.Equal(ProviderErrorKind.Parse, ex.Kind);
+    }
+
+    [Fact]
+    public void TryLoadApiKeyFromAuth_ReadsOpenCodeGoKey()
+    {
+        var profile = Path.Combine(Path.GetTempPath(), "wincheck-opencode-go-" + Guid.NewGuid().ToString("N"));
+        var authDir = Path.Combine(profile, ".local", "share", "opencode");
+        Directory.CreateDirectory(authDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(authDir, "auth.json"),
+                "{\"opencode-go\":{\"type\":\"api\",\"key\":\"sk-test-12345\"}}");
+
+            Assert.Equal("sk-test-12345", OpenCodeGoProvider.TryLoadApiKeyFromAuth(profile));
+        }
+        finally
+        {
+            try { Directory.Delete(profile, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void TryLoadApiKeyFromAuth_MissingEntry_ReturnsNull()
+    {
+        var profile = Path.Combine(Path.GetTempPath(), "wincheck-opencode-go-" + Guid.NewGuid().ToString("N"));
+        var authDir = Path.Combine(profile, ".local", "share", "opencode");
+        Directory.CreateDirectory(authDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(authDir, "auth.json"), "{\"something-else\":{\"key\":\"nope\"}}");
+            Assert.Null(OpenCodeGoProvider.TryLoadApiKeyFromAuth(profile));
+        }
+        finally
+        {
+            try { Directory.Delete(profile, recursive: true); } catch { }
+        }
     }
 }

--- a/tests/TaskbarQuota.Tests/OpenCodeGoProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/OpenCodeGoProviderTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
+using System.Text;
 using System.Text.Json;
+using System.Threading;
 using TaskbarQuota.Usage;
 using TaskbarQuota.Usage.Providers;
 
@@ -234,5 +236,17 @@ public class OpenCodeGoProviderTests
         {
             try { Directory.Delete(profile, recursive: true); } catch { }
         }
+    }
+
+    [Fact]
+    public async Task ParseResponse_MalformedJson_ThrowsParseWithInnerException()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("not json"));
+
+        var ex = await Assert.ThrowsAsync<ProviderException>(
+            () => OpenCodeGoProvider.ParseResponse(stream, CancellationToken.None));
+
+        Assert.Equal(ProviderErrorKind.Parse, ex.Kind);
+        Assert.IsAssignableFrom<JsonException>(ex.InnerException);
     }
 }


### PR DESCRIPTION
## Summary

OpenCode Go switches from scraping the workspace `/go` page with browser cookies to a single authenticated call to the public usage endpoint:

`GET https://opencode.ai/zen/go/v1/usage`

## Why

The Go plan now exposes a public usage API, so the cookie / workspace-ID / page-parsing path is unnecessary and brittle (Chromium 127+ App-Bound Encryption, cookie expiry, workspace-ID lookup). This removes cookie dependence for the Go surface entirely.

## Changes

- `OpenCodeGoProvider` now:
  - resolves a bearer key from `OPENCODE_API_KEY`, the credential store, or the opencode CLI's `~/.local/share/opencode/auth.json` (`opencode-go.key`);
  - calls the usage endpoint and maps `rolling` / `weekly` / `monthly` to Primary / Secondary / Monthly with the `resetsAt` timestamp;
  - maps 401/403 to auth-required, 429 to rate-limited, and malformed payloads to a parse error.
- The Go "Fix" dialog now prompts for an API key instead of a cookie header + workspace ID.
- Widget auth-required state shows "API key" for Go (cookies remain for Zen).
- Install messaging updated for Go.
- Tests added for JSON parsing and local key resolution.

## Verification

- `dotnet build` succeeds (only the pre-existing CS0649 warning).
- Full test suite: 676 passed, 0 failed.
- Live check against a real session: weekly and monthly match the old path exactly; rolling differs only by the sliding-window sampling instant.

## Notes

- Zen (`OpenCodeProvider`) is intentionally unchanged: there is no public Zen balance API yet (tracking upstream issue #10448), so it keeps the existing cookie / server-function path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OpenCode Go now retrieves usage through API-key authentication.
  - API keys can be detected from the `OPENCODE_API_KEY` environment variable, saved credentials, or the OpenCode CLI.
  - Added clear setup guidance for OpenCode Go authentication.

- **Bug Fixes**
  - OpenCode and OpenCode Go now display distinct authentication errors and setup instructions.
  - Updated credential entry text to use the generic “Paste your API key...” wording.
  - Improved handling of usage data, reset times, missing credentials, and API errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->