### PR TITLE
fix/ghost-no-local-usage-history

### DIFF
--- a/src/TaskbarQuota.App/ViewModels/DashboardViewModel.cs
+++ b/src/TaskbarQuota.App/ViewModels/DashboardViewModel.cs
@@ -19,7 +19,7 @@ namespace TaskbarQuota.ViewModels
         private IReadOnlyList<UsageResult> _lastResults = Array.Empty<UsageResult>();
         private ProviderId? _lastActive;
         private ProviderId? _lastTopProvider;
-        private CancellationTokenSource? _loadCts;
+        private volatile CancellationTokenSource? _loadCts;
         private readonly Dictionary<ProviderId, string> _cardSignatures = new();
 
         public ObservableCollection<ProviderCardViewModel> Cards { get; } = new();
@@ -146,13 +146,20 @@ namespace TaskbarQuota.ViewModels
             TotalSpend.IsLoading = true;
             _loadCts?.Cancel();
             _loadCts?.Dispose();
-            _loadCts = new CancellationTokenSource();
-            var ct = _loadCts.Token;
+            var cts = new CancellationTokenSource();
+            _loadCts = cts;
+            var ct = cts.Token;
 
             var active = UsageCoordinator.Instance.ActiveProvider;
             var results = await Task.Run(() => BuildDashboardResults(active)).ConfigureAwait(false);
             _dispatcher.TryEnqueue(() =>
             {
+                // A newer load may have superseded this one while we were off-thread; only the
+                // newest load may touch shared state, or a cancelled load can flip IsLoading off
+                // mid-fetch and flash the "No local usage history found" empty state (spinner →
+                // empty → data).
+                if (!ReferenceEquals(_loadCts, cts))
+                    return;
                 UpdateCards(results, active);
                 StatusText = force ? "Refreshing..." : "Loading...";
             });
@@ -177,12 +184,17 @@ namespace TaskbarQuota.ViewModels
                         _ = Task.Run(() =>
                         {
                             var merged = BuildDashboardResults(current, snapshot);
-                            _dispatcher.TryEnqueue(() => UpdateCards(merged, current));
+                            _dispatcher.TryEnqueue(() =>
+                            {
+                                if (!ReferenceEquals(_loadCts, cts))
+                                    return;
+                                UpdateCards(merged, current);
+                            });
                         });
                     },
                     ct);
 
-                if (!ct.IsCancellationRequested)
+                if (!ct.IsCancellationRequested && ReferenceEquals(_loadCts, cts))
                 {
                     var finalActive = UsageCoordinator.Instance.ActiveProvider;
                     var finalResults = results.ToList();
@@ -193,6 +205,8 @@ namespace TaskbarQuota.ViewModels
                     }).ConfigureAwait(false);
                     _dispatcher.TryEnqueue(() =>
                     {
+                        if (!ReferenceEquals(_loadCts, cts))
+                            return;
                         UpdateCards(
                             completed.Results,
                             finalActive,
@@ -205,7 +219,11 @@ namespace TaskbarQuota.ViewModels
             }
             catch (OperationCanceledException)
             {
-                _dispatcher.TryEnqueue(() => TotalSpend.IsLoading = false);
+                // A superseded load (cancelled by a newer LoadAsync/RefreshAsync) must not clear
+                // the loading state of the load that replaced it — that would show the empty state
+                // while the current fetch is still running.
+                if (ReferenceEquals(_loadCts, cts))
+                    _dispatcher.TryEnqueue(() => TotalSpend.IsLoading = false);
             }
         }
 

--- a/src/TaskbarQuota.App/ViewModels/DashboardViewModel.cs
+++ b/src/TaskbarQuota.App/ViewModels/DashboardViewModel.cs
@@ -221,9 +221,14 @@ namespace TaskbarQuota.ViewModels
             {
                 // A superseded load (cancelled by a newer LoadAsync/RefreshAsync) must not clear
                 // the loading state of the load that replaced it — that would show the empty state
-                // while the current fetch is still running.
-                if (ReferenceEquals(_loadCts, cts))
-                    _dispatcher.TryEnqueue(() => TotalSpend.IsLoading = false);
+                // while the current fetch is still running. Evaluate the identity inside the
+                // callback (on the UI thread), not where the exception was caught, so a load that
+                // was superseded between the catch and the callback execution is skipped.
+                _dispatcher.TryEnqueue(() =>
+                {
+                    if (ReferenceEquals(_loadCts, cts))
+                        TotalSpend.IsLoading = false;
+                });
             }
         }
 


### PR DESCRIPTION
## What

Fixes the startup flash on the Cost page where the total-spend surface briefly shows **"No local usage history found"** after the loading spinner, before the cost ring/token cards suddenly pop in.

## Root cause

The main window's Cost page and the taskbar flyout's mini-dashboard share one `DashboardViewModel`, and each page's `Loaded` event fires `LoadAsync()`. A new load cancels the previous one, and the cancelled load's `catch (OperationCanceledException)` unconditionally set `TotalSpend.IsLoading = false` — even while the newer load was still fetching with `HasSpendData == false`. That transiently satisfies the empty-state condition (`!IsLoading && !HasSpendData`), flashing "No local usage history found" until the newer load's final pass flips `HasSpendData` and the cost card appears.

## Fix

Only the newest load may touch shared state. Each load captures its own `CancellationTokenSource`, and every dispatcher-enqueued mutation (initial cards, progressive card updates, final results + `IsLoading = false`, and the cancellation fallback) now checks `ReferenceEquals(_loadCts, cts)` first, so a superseded load silently drops out instead of clearing the spinner mid-fetch. `_loadCts` is `volatile` so the guard reliably sees the newest load from threadpool continuations.

## Verification

- App builds clean
- All 758 tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard loading behavior when multiple refreshes overlap.
  * Prevented outdated loading operations from overwriting current dashboard data or loading indicators.
  * Ensured loading status is cleared correctly when the active refresh is canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->