### PR TITLE
Preserve OpenCode disable state

### DIFF
--- a/src/TaskbarQuota.App/Services/ProviderDiscoveryService.cs
+++ b/src/TaskbarQuota.App/Services/ProviderDiscoveryService.cs
@@ -31,22 +31,25 @@ public static class ProviderDiscoveryService
     {
         ProviderInstallDetector.WarmCliCache();
 
-        bool widgetChanged = false;
-        bool dashboardChanged = false;
-        foreach (ProviderId id in Enum.GetValues<ProviderId>())
+        lock (SyncRoot)
         {
-            if (!ProviderInstallDetector.IsInstalled(id) || IsExplicitlyDisabled(id))
-                continue;
+            bool widgetChanged = false;
+            bool dashboardChanged = false;
+            foreach (ProviderId id in Enum.GetValues<ProviderId>())
+            {
+                if (!ProviderInstallDetector.IsInstalled(id) || ExplicitlyDisabled.Contains(id))
+                    continue;
 
-            widgetChanged |= TryEnableProviderSilent(id, out bool dashChanged);
-            dashboardChanged |= dashChanged;
+                widgetChanged |= TryEnableProviderSilent(id, out bool dashChanged);
+                dashboardChanged |= dashChanged;
+            }
+
+            if (widgetChanged)
+                WidgetSettingsService.SaveProviderVisibilityAndNotify();
+
+            if (dashboardChanged)
+                WidgetSettingsService.SaveDashboardProviderVisibilityAndNotify();
         }
-
-        if (widgetChanged)
-            WidgetSettingsService.SaveProviderVisibilityAndNotify();
-
-        if (dashboardChanged)
-            WidgetSettingsService.SaveDashboardProviderVisibilityAndNotify();
     }
 
     public static void RecordFetchResult(UsageResult result)
@@ -63,7 +66,7 @@ public static class ProviderDiscoveryService
             if (result.Ok || result.ErrorKind == ProviderErrorKind.AuthRequired)
                 Configured.Add(result.Id);
 
-            if (result.Ok)
+            if (!ExplicitlyDisabled.Contains(result.Id) && result.Ok)
             {
                 if (!WidgetSettingsService.IsProviderDashboardVisible(result.Id))
                     WidgetSettingsService.SetProviderDashboardVisible(result.Id, true);
@@ -75,7 +78,8 @@ public static class ProviderDiscoveryService
             }
 
             if (result.ErrorKind == ProviderErrorKind.NotRunning
-                && ProviderInstallDetector.IsInstalled(result.Id))
+                && ProviderInstallDetector.IsInstalled(result.Id)
+                && !ExplicitlyDisabled.Contains(result.Id))
             {
                 if (!WidgetSettingsService.IsProviderDashboardVisible(result.Id))
                     WidgetSettingsService.SetProviderDashboardVisible(result.Id, true);

--- a/tests/TaskbarQuota.Tests/ProviderDiscoveryServiceTests.cs
+++ b/tests/TaskbarQuota.Tests/ProviderDiscoveryServiceTests.cs
@@ -62,6 +62,29 @@ public class ProviderDiscoveryServiceTests
         Assert.True(WidgetSettingsService.IsProviderDashboardVisible(ProviderId.Grok));
     }
 
+    [Theory]
+    [InlineData(ProviderId.OpenCode)]
+    [InlineData(ProviderId.OpenCodeGo)]
+    public void RecordFetchResult_DoesNotRestoreExplicitlyDisabledProvider(ProviderId id)
+    {
+        ProviderInstallDetector.IsInstalledOverrideForTesting = installedId => installedId == id;
+        WidgetSettingsService.SetProviderVisibleForTesting(id, false);
+        WidgetSettingsService.SetProviderDashboardVisibleForTesting(id, false);
+        ProviderDiscoveryService.MarkExplicitlyDisabledForTesting(id);
+
+        var provider = new UsageService().Get(id)!;
+        ProviderDiscoveryService.RecordFetchResult(UsageResult.Success(
+            id,
+            provider,
+            new ProviderFetchResult(new UsageSnapshot(new RateWindow(10)), "test")));
+        ProviderDiscoveryService.RecordFetchResult(
+            UsageResult.Failure(id, "waiting", kind: ProviderErrorKind.NotRunning));
+
+        Assert.True(ProviderDiscoveryService.IsConfigured(id));
+        Assert.False(WidgetSettingsService.IsProviderDashboardVisible(id));
+        Assert.False(WidgetSettingsService.IsProviderVisible(id));
+    }
+
     [Fact]
     public void ShouldShowInAvailable_ReturnsHiddenNotInstalled()
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider visibility now remains hidden when a provider has been explicitly disabled, including after successful or not-running status updates.
  * Provider configuration status continues to be tracked correctly for disabled providers.
  * Improved synchronization prevents inconsistent provider visibility updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->