### PR TITLE
feat(zai): support quota multipliers, peak hours indicator, and credit plans

### DIFF
--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -199,15 +199,16 @@ namespace TaskbarQuota.Controls
             foreach (var row in _renderedRows)
             {
                 row.Track.Background = track;
-                row.Value.Foreground = Foreground;
+                var rowFg = row.Source.ForegroundBrush ?? Foreground;
+                row.Value.Foreground = rowFg;
                 if (row.Label is TextBlock labelBlock)
-                    labelBlock.Foreground = Foreground;
+                    labelBlock.Foreground = rowFg;
                 else if (row.Label is Panel labelPanel)
                 {
                     foreach (var child in labelPanel.Children)
                     {
                         if (child is TextBlock tb)
-                            tb.Foreground = Foreground;
+                            tb.Foreground = rowFg;
                     }
                 }
                 if (row.Reset is { } resetBlock)
@@ -329,7 +330,7 @@ namespace TaskbarQuota.Controls
                 ApplyAntigravityDisplay(result, usage, providerChanged);
                 return;
             }
-            if (result.Id is ProviderId.Copilot or ProviderId.Grok && usage.Cost is { Label: "Credits" } credits)
+            if (result.Id is ProviderId.Copilot or ProviderId.Grok or ProviderId.Zai && usage.Cost is { Label: "Credits" } credits)
             {
                 ApplyCreditsDisplay(result, usage, credits, providerChanged);
                 return;
@@ -539,6 +540,8 @@ namespace TaskbarQuota.Controls
             if (result.Id is ProviderId.Claude or ProviderId.Zai)
             {
                 var rows = BuildBaseRows(result, usage);
+                if (result.Id == ProviderId.Zai && usage.Pricing is { } pricing)
+                    rows.Insert(0, new WidgetUsageRow(pricing.Period, 0, pricing.MultiplierText, HasBar: false, ForegroundBrush: PricingBrush(pricing)));
                 if (WidgetSettingsService.IsRowVisible(result.Id, WidgetSettingsService.RowExtra))
                 {
                     rows.AddRange(usage.ExtraRateWindows.Select(w => new WidgetUsageRow(
@@ -772,6 +775,10 @@ namespace TaskbarQuota.Controls
 
             var widgetName = WidgetDisplayName(result.DisplayName);
             var rows = new List<WidgetUsageRow>();
+            if (result.Id == ProviderId.Zai && usage.Pricing is { } pricing)
+            {
+                rows.Add(new WidgetUsageRow(pricing.Period, 0, pricing.MultiplierText, HasBar: false, ForegroundBrush: PricingBrush(pricing)));
+            }
             if (WidgetSettingsService.IsRowVisible(result.Id, WidgetSettingsService.RowCredits))
             {
                 rows.Add(new WidgetUsageRow(
@@ -812,6 +819,8 @@ namespace TaskbarQuota.Controls
                 tooltip += $"\nAdditional usage: {addl.StatusText} ({addl.SpendText})";
             if (usage.Primary.ResetDescription is { } resetDesc)
                 tooltip += $"\nresets in {resetDesc}";
+            if (usage.Pricing is { } pricingState)
+                tooltip += $"\n{pricingState.Display}";
             tooltip += WidgetUsageHistoryTooltipLine(usage.UsageHistory);
             tooltip += StaleTooltipLine(result);
             ToolTipService.SetToolTip(this, tooltip);
@@ -1348,7 +1357,7 @@ namespace TaskbarQuota.Controls
                 0.86,
                 compactTextOnlyValue ? TextAlignment.Left : TextAlignment.Center,
                 textSize);
-            value.Foreground = Foreground;
+            value.Foreground = usageRow.ForegroundBrush ?? Foreground;
             var reset = CreateResetText(usageRow, textSize);
 
             FrameworkElement label;
@@ -1508,7 +1517,7 @@ namespace TaskbarQuota.Controls
             baseLabel.TextTrimming = TextTrimming.None;
             // Explicit brush: inheritance is unreliable once Application theme resources disagree
             // with the floating window's light/dark chrome.
-            baseLabel.Foreground = Foreground;
+            baseLabel.Foreground = row.ForegroundBrush ?? Foreground;
             return baseLabel;
         }
 
@@ -1602,6 +1611,7 @@ namespace TaskbarQuota.Controls
             parts.Add(usage.LoginMethod ?? string.Empty);
             parts.Add(usage.Email ?? string.Empty);
             parts.Add(usage.Cost?.Display ?? string.Empty);
+            parts.Add(usage.Pricing?.Display ?? string.Empty);
             if (usage.AdditionalUsage is { Enabled: true } additional)
             {
                 parts.Add(additional.SpentUsd.ToString(CultureInfo.InvariantCulture));
@@ -1727,6 +1737,16 @@ namespace TaskbarQuota.Controls
             return (Brush)Application.Current.Resources[key];
         }
 
+        private static Brush? PricingBrush(UsagePricingSnapshot pricing)
+        {
+            if (pricing.Period != "PEAK")
+                return null;
+
+            return Application.Current?.Resources is { } res && res.TryGetValue("SystemFillColorCautionBrush", out var caution) && caution is Brush b
+                ? b
+                : new SolidColorBrush(Color.FromArgb(255, 255, 150, 20));
+        }
+
         private static int? TryParseResetMinutes(string resetDescription)
         {
             if (resetDescription == "now")
@@ -1783,7 +1803,8 @@ namespace TaskbarQuota.Controls
             string Value,
             string? ResetDescription = null,
             bool HasBar = true,
-            string? GlyphData = null);
+            string? GlyphData = null,
+            Brush? ForegroundBrush = null);
 
         private sealed record RenderedRow(
             WidgetUsageRow Source,

--- a/src/TaskbarQuota.App/Services/DashboardLayoutMetrics.cs
+++ b/src/TaskbarQuota.App/Services/DashboardLayoutMetrics.cs
@@ -19,6 +19,31 @@ internal static class DashboardLayoutMetrics
     private const double CardVerticalPadding = 32;
     private const double SetupCardHeight = 112;
     private const double ErrorCardHeight = 72;
+    private const double HeaderCardHorizontalPadding = 42;
+    private const double HeaderColumnSpacing = 12;
+    private const double HeaderActionSpacing = 8;
+    private const double HeaderActionWidth =
+        (14 + 6 + (7 * CharWidth) + 24) // Refresh icon + label + button padding
+        + (14 + 6 + (6 * CharWidth) + 24) // Pinned icon + label + button padding
+        + 76 // Widget toggle's minimum width
+        + (14 + 24) // Share icon + button padding
+        + (HeaderActionSpacing * 3);
+    private const double HeaderWidthSlack = 24;
+
+    /// <summary>
+    /// Width needed by the provider title and its header actions when they remain on one line.
+    /// The flyout uses this value alongside the detail-card measurement so a narrow provider strip
+    /// cannot squeeze the title into one-character wrapping.
+    /// </summary>
+    public static double EstimateHeaderWidth(ProviderCardViewModel? card)
+    {
+        if (card is null)
+            return 0;
+
+        double titleWidth = Math.Max(Estimate(card.PageTitle), Estimate(card.PageTitleAccent));
+        return titleWidth + HeaderActionWidth + HeaderColumnSpacing
+            + HeaderCardHorizontalPadding + HeaderWidthSlack;
+    }
 
     public static double EstimateDetailWidth(ProviderCardViewModel? card)
     {
@@ -41,6 +66,9 @@ internal static class DashboardLayoutMetrics
             maxLine = Math.Max(maxLine,
                 Estimate(card.CreditLeftText) + Estimate(card.CreditLimitText) + 24);
         }
+
+        if (!string.IsNullOrEmpty(card.PricingText))
+            maxLine = Math.Max(maxLine, Estimate("Pricing") + Estimate(card.PricingText) + 24);
 
         if (!string.IsNullOrEmpty(card.AdditionalUsageStatusText))
         {
@@ -91,6 +119,12 @@ internal static class DashboardLayoutMetrics
         {
             sections++;
             height += 104;
+        }
+
+        if (card.PricingVisibility == Microsoft.UI.Xaml.Visibility.Visible)
+        {
+            sections++;
+            height += 56;
         }
 
         if (!string.IsNullOrEmpty(card.ResetCreditsCountText))

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -467,6 +467,7 @@ public static class WidgetSettingsService
             [
                 new(RowPrimary, "Session"),
                 new(RowSecondary, "Weekly"),
+                new(RowCredits, "Credits"),
                 new(RowExtra, "MCP"),
             ],
             ProviderId.Claude =>
@@ -827,7 +828,7 @@ public static class WidgetSettingsService
         => $"{provider}:{rowId}";
 
     private static bool DefaultRowVisible(ProviderId provider, string rowId)
-        => provider == ProviderId.Zai && rowId == RowExtra
+        => provider == ProviderId.Zai && rowId is RowExtra or RowCredits
             || provider != ProviderId.Codex
               || rowId == RowPrimary
               || rowId == RowSecondary

--- a/src/TaskbarQuota.App/Usage/Models.cs
+++ b/src/TaskbarQuota.App/Usage/Models.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace TaskbarQuota.Usage
 {
@@ -85,6 +86,21 @@ namespace TaskbarQuota.Usage
             string.Equals(Currency, "USD", StringComparison.OrdinalIgnoreCase) ? $"${v:0.00}" : $"{v:0.00} {Currency}";
 
         public string Display => Limit is double lim ? $"{Money(Amount)} / {Money(lim)}" : Money(Amount);
+    }
+
+    /// <summary>Current Z.ai Coding Plan quota coefficient for the active time window.</summary>
+    public sealed class UsagePricingSnapshot
+    {
+        public string Period { get; }
+        public double Multiplier { get; }
+        public string MultiplierText => Multiplier.ToString("0.##", CultureInfo.InvariantCulture) + "×";
+        public string Display => $"{Period} · {MultiplierText}";
+
+        public UsagePricingSnapshot(string period, double multiplier)
+        {
+            Period = period;
+            Multiplier = multiplier;
+        }
     }
 
     /// <summary>
@@ -178,6 +194,7 @@ namespace TaskbarQuota.Usage
         public string? LoginMethod { get; set; }
         public string? Email { get; set; }
         public CostSnapshot? Cost { get; set; }
+        public UsagePricingSnapshot? Pricing { get; set; }
         public AdditionalUsageSnapshot? AdditionalUsage { get; set; }
         public ResetCreditsSnapshot? ResetCredits { get; set; }
         /// <summary>Provider-specific usage dashboard link when known (e.g. OpenCode workspace /go or /usage).</summary>

--- a/src/TaskbarQuota.App/Usage/Providers/ZaiProvider.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/ZaiProvider.cs
@@ -17,8 +17,18 @@ namespace TaskbarQuota.Usage.Providers
     {
         private const string DefaultGlobalBaseUrl = "https://api.z.ai";
         private const string QuotaPath = "api/monitor/usage/quota/limit";
+        private const string SubscriptionPath = "api/biz/subscription/list";
+        private static readonly TimeSpan SubscriptionMetadataTimeout = TimeSpan.FromSeconds(2);
         private const string DashboardUrl = "https://z.ai/manage-apikey/coding-plan/personal/my-plan";
         private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(20) };
+        // Current Z.ai individual credit products published by ZCode's live client catalogue on
+        // 2026-08-13. Tier names are deliberately not enough: legacy products reused Lite/Pro/Max.
+        private static readonly HashSet<string> CurrentCreditProductIds = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "product-52c6b5", "product-448ee2", "product-7e6099", // monthly
+            "product-1c613e", "product-9194ae", "product-7642bb", // quarterly
+            "product-2d5858", "product-074f43", "product-1f179d", // annual
+        };
 
         public ProviderId Id => ProviderId.Zai;
         public string DisplayName => "Z.ai";
@@ -32,10 +42,23 @@ namespace TaskbarQuota.Usage.Providers
             var apiKey = LoadApiKey();
             var baseUrl = ResolveBaseUrl();
             var quotaUrl = BuildQuotaUrl(baseUrl);
-            using var request = new HttpRequestMessage(HttpMethod.Get, quotaUrl);
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
-            request.Headers.Accept.ParseAdd("application/json");
-            using var response = await Http.SendAsync(request, ct).ConfigureAwait(false);
+            var subscriptionUrl = BuildSubscriptionUrl(quotaUrl);
+
+            // The quota endpoint owns balances while the subscription endpoint owns product identity.
+            // Start both together so pairing the responses does not add another network round trip.
+            var quotaTask = FetchRequiredJsonAsync(quotaUrl, apiKey, ct);
+            using var subscriptionTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            subscriptionTimeoutCts.CancelAfter(SubscriptionMetadataTimeout);
+            var subscriptionTask = FetchOptionalJsonAsync(subscriptionUrl, apiKey, subscriptionTimeoutCts.Token, ct);
+            await Task.WhenAll((Task)quotaTask, subscriptionTask).ConfigureAwait(false);
+            using var quotaDoc = quotaTask.Result;
+            using var subscriptionDoc = subscriptionTask.Result;
+            return BuildResult(quotaDoc.RootElement, subscriptionDoc?.RootElement);
+        }
+
+        private static async Task<JsonDocument> FetchRequiredJsonAsync(string url, string apiKey, CancellationToken ct)
+        {
+            using var response = await SendAsync(url, apiKey, ct).ConfigureAwait(false);
             if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
                 throw new ProviderException(ProviderErrorKind.AuthRequired, "z.ai API key invalid or expired. Update your API key.");
             if ((int)response.StatusCode == 429)
@@ -46,12 +69,49 @@ namespace TaskbarQuota.Usage.Providers
                 throw new ProviderException(ProviderErrorKind.Other, $"z.ai API returned {code2}");
             }
             using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
-            return BuildResult(doc.RootElement);
+            return await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+        }
+
+        private static async Task<JsonDocument?> FetchOptionalJsonAsync(
+            string url,
+            string apiKey,
+            CancellationToken requestCt,
+            CancellationToken callerCt)
+        {
+            try
+            {
+                using var response = await SendAsync(url, apiKey, requestCt).ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode)
+                    return null;
+                using var stream = await response.Content.ReadAsStreamAsync(requestCt).ConfigureAwait(false);
+                return await JsonDocument.ParseAsync(stream, cancellationToken: requestCt).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (callerCt.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                // Metadata is optional and has its own short timeout; quota data remains usable when it expires.
+                return null;
+            }
+            catch (Exception ex) when (ex is HttpRequestException or JsonException)
+            {
+                // Subscription metadata enriches the quota response but must never make usage unavailable.
+                return null;
+            }
+        }
+
+        private static async Task<HttpResponseMessage> SendAsync(string url, string apiKey, CancellationToken ct)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+            request.Headers.Accept.ParseAdd("application/json");
+            return await Http.SendAsync(request, ct).ConfigureAwait(false);
         }
 
 
-        internal static ProviderFetchResult BuildResult(JsonElement root)
+        internal static ProviderFetchResult BuildResult(JsonElement root, JsonElement? subscriptionRoot = null)
         {
             if (!root.TryGetProperty("success", out var successEl) || !successEl.GetBoolean())
             {
@@ -60,15 +120,23 @@ namespace TaskbarQuota.Usage.Providers
             }
             if (!root.TryGetProperty("data", out var data) || data.ValueKind == JsonValueKind.Null)
                 throw new ProviderException(ProviderErrorKind.Parse, "z.ai API returned no data.");
-            string? planName = null;
+            var subscription = ParseCurrentSubscription(subscriptionRoot);
+            string? planName = subscription?.ProductName;
             foreach (var key in new[] { "planName", "plan", "plan_type", "packageName" })
             {
+                if (!string.IsNullOrWhiteSpace(planName)) break;
                 if (data.TryGetProperty(key, out var p) && p.ValueKind == JsonValueKind.String)
                 {
                     var raw = p.GetString()?.Trim();
                     if (!string.IsNullOrEmpty(raw)) { planName = raw; break; }
                 }
             }
+            if (string.IsNullOrWhiteSpace(planName)
+                && data.TryGetProperty("level", out var level)
+                && level.ValueKind == JsonValueKind.String
+                && !string.IsNullOrWhiteSpace(level.GetString()))
+                planName = $"GLM Coding {ToTitleCase(level.GetString()!)}";
+
             var tokenLimits = new List<LimitEntry>();
             LimitEntry? timeLimit = null;
             if (data.TryGetProperty("limits", out var limitsArr) && limitsArr.ValueKind == JsonValueKind.Array)
@@ -81,6 +149,8 @@ namespace TaskbarQuota.Usage.Providers
                     else if (entry.Value.Type == "TIME_LIMIT") timeLimit = entry;
                 }
             }
+            bool isCreditPlan = IsCurrentCreditPlan(subscription, tokenLimits);
+            var pricing = ResolvePricing(isCreditPlan, subscription?.ProductName, DateTimeOffset.UtcNow);
             LimitEntry? primaryLimit;
             LimitEntry? sessionTokenLimit = null;
             if (tokenLimits.Count >= 2)
@@ -95,12 +165,28 @@ namespace TaskbarQuota.Usage.Providers
             // longer token window in the weekly secondary row. TIME_LIMIT is the
             // separate monthly MCP/tool-call pool.
             var mainLimit = sessionTokenLimit ?? primaryLimit ?? timeLimit;
-            var primary = mainLimit.HasValue ? MakeRateWindow(mainLimit.Value) : new RateWindow(0, windowMinutes: null, resetAt: null, resetDescription: null);
+            var primary = mainLimit.HasValue
+                ? MakeRateWindow(mainLimit.Value)
+                : new RateWindow(0, windowMinutes: null, resetAt: null, resetDescription: null);
             var usage = new UsageSnapshot(primary);
+            usage.Pricing = pricing;
             if (sessionTokenLimit.HasValue && primaryLimit.HasValue)
                 usage.Secondary = MakeRateWindow(primaryLimit.Value);
             if (timeLimit.HasValue)
                 usage.ExtraRateWindows.Add(new NamedRateWindow("zai-mcp", "MCP", MakeRateWindow(timeLimit.Value, label: "MCP")));
+            // Credit plans reuse the Copilot credits meter: the 5-hour pool is the dynamic rolling cap
+            // (remaining in Cost.Amount, cap in Cost.Limit) and its reset becomes the card countdown.
+            // The 7-day window stays as a percentage bar beside it.
+            if (isCreditPlan && sessionTokenLimit is { } sessionLimit)
+            {
+                usage.HasPrimaryWindow = false;
+                var credits = new CostSnapshot(sessionLimit.Remaining ?? 0, "credits", "Credits");
+                if (sessionLimit.Usage is { } cap && cap > 0)
+                    credits.Limit = cap;
+                if (sessionLimit.NextResetTime is { } resetAt)
+                    credits = credits.WithResetsAt(resetAt);
+                usage.Cost = credits;
+            }
             if (!string.IsNullOrWhiteSpace(planName)) usage.LoginMethod = planName;
             usage.UsageDashboardUrl = DashboardUrl;
             return new ProviderFetchResult(usage, "api");
@@ -115,6 +201,111 @@ namespace TaskbarQuota.Usage.Providers
                 : null;
             return new RateWindow(percent, windowMinutes: windowMinutes, resetAt: entry.NextResetTime, resetDescription: resetDesc, label: label);
         }
+
+        private static SubscriptionEntry? ParseCurrentSubscription(JsonElement? root)
+        {
+            if (root is not { } envelope
+                || envelope.TryGetProperty("success", out var success) && success.ValueKind == JsonValueKind.False
+                || envelope.TryGetProperty("code", out var code) && code.ValueKind == JsonValueKind.Number
+                    && code.TryGetInt32(out int codeValue) && codeValue is not 0 and not 200
+                || !envelope.TryGetProperty("data", out var data)
+                || data.ValueKind != JsonValueKind.Array)
+                return null;
+
+            SubscriptionEntry? current = null;
+            int currentPriority = 0;
+            foreach (var item in data.EnumerateArray())
+            {
+                string? productId = StringProperty(item, "productId");
+                string? productName = StringProperty(item, "productName");
+                if (string.IsNullOrWhiteSpace(productId) && string.IsNullOrWhiteSpace(productName))
+                    continue;
+
+                bool inCurrentPeriod = BoolProperty(item, "inCurrentPeriod");
+                bool valid = string.Equals(StringProperty(item, "status"), "VALID", StringComparison.OrdinalIgnoreCase);
+                int priority = inCurrentPeriod && valid ? 3 : inCurrentPeriod ? 2 : valid ? 1 : 0;
+                if (priority > currentPriority)
+                {
+                    current = new SubscriptionEntry(productId, productName);
+                    currentPriority = priority;
+                }
+            }
+            return current;
+        }
+
+        private static bool IsCurrentCreditPlan(SubscriptionEntry? subscription, IReadOnlyList<LimitEntry> tokenLimits)
+        {
+            if (subscription is { } value)
+            {
+                string identity = $"{value.ProductId} {value.ProductName}";
+                if (identity.Contains("legacy", StringComparison.OrdinalIgnoreCase)
+                    || identity.Contains("team edition", StringComparison.OrdinalIgnoreCase))
+                    return false;
+                if (value.ProductId is { } productId && CurrentCreditProductIds.Contains(productId))
+                    return true;
+            }
+
+            // New individual and team plans publish fixed credit allowances. This catches newly issued
+            // product IDs without mistaking a legacy Lite/Pro/Max name for a current credit product.
+            return tokenLimits.Any(static limit => limit is
+            {
+                Unit: 3,
+                Number: 5,
+                Usage: 2_000 or 12_000 or 15_000 or 28_000 or 35_000,
+            }) && tokenLimits.Any(static limit => limit is
+            {
+                Unit: 6,
+                Number: 1,
+                Usage: 10_000 or 60_000 or 66_000 or 140_000 or 155_000,
+            });
+        }
+
+        /// <summary>
+        /// Resolves the current Z.ai coefficient in Singapore time (UTC+8, no DST). New credit plans
+        /// charge 1x at peak and 0.5x off-peak; legacy V2/team plans charge 3x and 1x respectively.
+        /// </summary>
+        internal static UsagePricingSnapshot? ResolvePricing(bool isCreditPlan, string? productName, DateTimeOffset now)
+        {
+            double peakMultiplier;
+            double offPeakMultiplier;
+            if (isCreditPlan)
+            {
+                peakMultiplier = 1.0;
+                offPeakMultiplier = 0.5;
+            }
+            else if (productName?.Contains("Legacy Plan V2", StringComparison.OrdinalIgnoreCase) == true
+                || productName?.Contains("Team Edition", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                peakMultiplier = 3.0;
+                offPeakMultiplier = 1.0;
+            }
+            else
+            {
+                return null;
+            }
+
+            var singaporeTime = now.ToOffset(TimeSpan.FromHours(8));
+            bool isWeekday = singaporeTime.DayOfWeek is not DayOfWeek.Saturday and not DayOfWeek.Sunday;
+            bool isPeak = isWeekday
+                && singaporeTime.TimeOfDay >= TimeSpan.FromHours(14)
+                && singaporeTime.TimeOfDay < TimeSpan.FromHours(18);
+            return new UsagePricingSnapshot(isPeak ? "PEAK" : "OFF-PEAK", isPeak ? peakMultiplier : offPeakMultiplier);
+        }
+
+        private static string? StringProperty(JsonElement element, string name)
+            => element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+                ? value.GetString()?.Trim()
+                : null;
+
+        private static bool BoolProperty(JsonElement element, string name)
+            => element.TryGetProperty(name, out var value)
+                && (value.ValueKind == JsonValueKind.True
+                    || value.ValueKind == JsonValueKind.Number && value.TryGetInt32(out int number) && number == 1);
+
+        private static string ToTitleCase(string value)
+            => value.Length == 0 ? value : char.ToUpperInvariant(value[0]) + value[1..].ToLowerInvariant();
+
+        private readonly record struct SubscriptionEntry(string? ProductId, string? ProductName);
 
 
         private static LimitEntry? ParseLimitEntry(JsonElement el)
@@ -228,6 +419,16 @@ namespace TaskbarQuota.Usage.Providers
             var trimmed = baseUrl.TrimEnd('/');
             if (trimmed.Contains(QuotaPath, StringComparison.OrdinalIgnoreCase)) return trimmed;
             return $"{trimmed}/{QuotaPath}";
+        }
+
+        internal static string BuildSubscriptionUrl(string quotaUrl)
+        {
+            var builder = new UriBuilder(quotaUrl)
+            {
+                Path = "/" + SubscriptionPath,
+                Query = string.Empty,
+            };
+            return builder.Uri.ToString();
         }
     }
 }

--- a/src/TaskbarQuota.App/Usage/UsageSnapshotStore.cs
+++ b/src/TaskbarQuota.App/Usage/UsageSnapshotStore.cs
@@ -127,6 +127,9 @@ namespace TaskbarQuota.Usage
                 Email = stored.Email,
                 UsageDashboardUrl = stored.UsageDashboardUrl,
                 Cost = ToCost(stored.Cost),
+                Pricing = stored.Pricing is { } pricing
+                    ? new UsagePricingSnapshot(pricing.Period ?? string.Empty, pricing.Multiplier)
+                    : null,
                 AdditionalUsage = stored.AdditionalUsage is { } a
                     ? new AdditionalUsageSnapshot
                     {
@@ -168,6 +171,9 @@ namespace TaskbarQuota.Usage
             UsageDashboardUrl = usage.UsageDashboardUrl,
             Cost = usage.Cost is { } c
                 ? new StoredCost { Amount = c.Amount, Currency = c.Currency, Label = c.Label, Limit = c.Limit, ResetsAt = c.ResetsAt }
+                : null,
+            Pricing = usage.Pricing is { } pricing
+                ? new StoredPricing { Period = pricing.Period, Multiplier = pricing.Multiplier }
                 : null,
             AdditionalUsage = usage.AdditionalUsage is { } a
                 ? new StoredAdditionalUsage { Enabled = a.Enabled, SpentUsd = a.SpentUsd, BudgetUsd = a.BudgetUsd, IsCredits = a.IsCredits }
@@ -249,6 +255,7 @@ namespace TaskbarQuota.Usage
             public string? Email { get; set; }
             public string? UsageDashboardUrl { get; set; }
             public StoredCost? Cost { get; set; }
+            public StoredPricing? Pricing { get; set; }
             public StoredAdditionalUsage? AdditionalUsage { get; set; }
             public StoredResetCredits? ResetCredits { get; set; }
         }
@@ -277,6 +284,12 @@ namespace TaskbarQuota.Usage
             public string? Label { get; set; }
             public double? Limit { get; set; }
             public DateTimeOffset? ResetsAt { get; set; }
+        }
+
+        private sealed class StoredPricing
+        {
+            public string? Period { get; set; }
+            public double Multiplier { get; set; }
         }
 
         private sealed class StoredAdditionalUsage

--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -413,6 +413,14 @@ namespace TaskbarQuota
                 return false;
             _lastUiaModelName = buttonName;
 
+            // The model-button name changed (model switch / thread navigation), but Chromium may not
+            // have flushed the new localStorage record to the LevelDB log yet, so the file watcher has
+            // not fired and the snapshot cache still holds the pre-switch selection. Invalidate it now:
+            // the next disk read rebuilds from the current log tail, so the authoritative state reader
+            // reflects the new model as soon as the write lands instead of serving the stale snapshot
+            // (which can linger for seconds until the flush reaches disk).
+            SynaraStateReader.InvalidateDraftCache();
+
             if (SynaraModelClassifier.Classify(buttonName) is not { } classification)
                 return false; // Bare model on an unlabelled build; state reader is authoritative.
 

--- a/src/TaskbarQuota.App/ViewModels/DashboardViewModel.cs
+++ b/src/TaskbarQuota.App/ViewModels/DashboardViewModel.cs
@@ -374,10 +374,13 @@ namespace TaskbarQuota.ViewModels
 
         private void UpdateDetailContentMetrics(ProviderCardViewModel? card)
         {
-            // Option A: fixed flyout. Width stays at FlyoutLayout.BaseLogicalWidth regardless of how
-            // many providers are installed; the strip only pushes the window wider once its icons
-            // overflow that base. Content is laid out inside the resulting width.
-            int flyoutWidth = FlyoutLayout.ComputeLogicalWidth(Cards.Count, 0);
+            // Keep the title and header actions on one line. The provider strip may be narrow when
+            // only a few providers are installed, so include the widest provider header in the flyout
+            // width calculation instead of letting the title column collapse and wrap vertically.
+            double widestHeader = Cards.Count == 0
+                ? 0
+                : Cards.Max(DashboardLayoutMetrics.EstimateHeaderWidth);
+            int flyoutWidth = FlyoutLayout.ComputeLogicalWidth(Cards.Count, widestHeader);
             DetailContentWidth = flyoutWidth - FlyoutLayout.DetailContentPadding;
 
             DetailContentHeight = FlyoutLayout.FixedLogicalContentHeight;

--- a/src/TaskbarQuota.App/ViewModels/ProviderCardViewModel.cs
+++ b/src/TaskbarQuota.App/ViewModels/ProviderCardViewModel.cs
@@ -168,6 +168,9 @@ namespace TaskbarQuota.ViewModels
         public Brush CreditBrush { get; }
         public Visibility CreditVisibility { get; }
         public double CreditOpacity { get; }
+        public string PricingText { get; }
+        public Brush PricingBrush { get; }
+        public Visibility PricingVisibility { get; }
 
         public string SourceText { get; }
         public Visibility SourceVisibility { get; }
@@ -258,12 +261,23 @@ namespace TaskbarQuota.ViewModels
             CreditPercent = 0;
             CreditBrush = Ui.ConsumedUsageBrush(0);
             CreditOpacity = 1.0;
+            PricingText = string.Empty;
+            PricingBrush = Ui.Res("TextFillColorSecondaryBrush");
+            PricingVisibility = Visibility.Collapsed;
             CreditWidgetToggle = new WidgetRowToggleViewModel(r.Id, new WidgetRowOption(WidgetSettingsService.RowCredits, "Credits"));
             AdditionalUsageWidgetToggle = new WidgetRowToggleViewModel(r.Id, new WidgetRowOption(WidgetSettingsService.RowAdditionalUsage, "Additional usage"));
             ResetCreditsWidgetToggle = new WidgetRowToggleViewModel(r.Id, new WidgetRowOption(WidgetSettingsService.RowResetCredits, "Reset credits"));
             if (r.Ok && r.Fetch is { } f)
             {
                 var u = f.Usage;
+                if (r.Id == ProviderId.Zai && u.Pricing is { } pricing)
+                {
+                    PricingText = pricing.Display;
+                    PricingBrush = Ui.Res(pricing.Period == "PEAK"
+                        ? "SystemFillColorCautionBrush"
+                        : "AccentFillColorSecondaryBrush");
+                    PricingVisibility = Visibility.Visible;
+                }
                 if (r.Id == ProviderId.OpenCode)
                 {
                     var usageVal = u.Cost != null ? u.Cost.Display : "—";
@@ -285,7 +299,7 @@ namespace TaskbarQuota.ViewModels
                 }
                 else
                 {
-                    bool creditsOnly = r.Id is ProviderId.Copilot or ProviderId.Grok && u.Cost is { Label: "Credits" };
+                    bool creditsOnly = r.Id is ProviderId.Copilot or ProviderId.Grok or ProviderId.Zai && u.Cost is { Label: "Credits" };
                     if (!creditsOnly)
                     {
                         if (u.HasPrimaryWindow)
@@ -295,7 +309,7 @@ namespace TaskbarQuota.ViewModels
                         }
                         if (u.Secondary != null)
                         {
-                            var secondaryLabel = r.Provider?.WeeklyLabel ?? "Weekly";
+                            var secondaryLabel = u.Secondary.Label ?? r.Provider?.WeeklyLabel ?? "Weekly";
                             bars.Add(new BarViewModel(r.Id, WidgetSettingsService.RowSecondary, secondaryLabel, u.Secondary));
                         }
                         if (u.ModelSpecific != null) bars.Add(new BarViewModel(r.Id, WidgetSettingsService.RowModelSpecific, u.ModelSpecific.Label ?? ModelSpecificLabel(r.Id), u.ModelSpecific));

--- a/src/TaskbarQuota.App/Views/DashboardPage.xaml
+++ b/src/TaskbarQuota.App/Views/DashboardPage.xaml
@@ -186,7 +186,32 @@
                         <muxc:ItemsRepeater.Layout>
                             <muxc:StackLayout Spacing="20"/>
                         </muxc:ItemsRepeater.Layout>
-                    </muxc:ItemsRepeater>
+                        </muxc:ItemsRepeater>
+                </Border>
+
+                <Border Visibility="{x:Bind PricingVisibility}"
+                        HorizontalAlignment="Stretch"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        Padding="20,12">
+                    <Grid ColumnSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0"
+                                   Text="Quota pricing"
+                                   Style="{StaticResource BodyStrongTextBlockStyle}"
+                                   VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="1"
+                                   Text="{x:Bind PricingText}"
+                                   Foreground="{x:Bind PricingBrush}"
+                                   Style="{StaticResource BodyStrongTextBlockStyle}"
+                                   TextAlignment="Right"
+                                   VerticalAlignment="Center"/>
+                    </Grid>
                 </Border>
 
                 <Border Visibility="{x:Bind CreditVisibility}"
@@ -498,12 +523,16 @@
                         <StackPanel x:Name="TitlePanel" Grid.Row="0" Grid.Column="0" Spacing="2" VerticalAlignment="Center">
                             <TextBlock Text="{x:Bind ViewModel.SelectedCard.PageTitle, Mode=OneWay}"
                                        Style="{StaticResource SubtitleTextBlockStyle}"
+                                       TextWrapping="NoWrap"
+                                       TextTrimming="CharacterEllipsis"
                                        VerticalAlignment="Center"/>
                             <TextBlock Text="{x:Bind ViewModel.SelectedCard.PageTitleAccent, Mode=OneWay}"
                                        Visibility="{x:Bind ViewModel.SelectedCard.PageTitleAccentVisibility, Mode=OneWay}"
                                        Style="{StaticResource BodyStrongTextBlockStyle}"
                                        FontSize="14"
                                        Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                       TextWrapping="NoWrap"
+                                       TextTrimming="CharacterEllipsis"
                                        VerticalAlignment="Center"/>
                         </StackPanel>
 
@@ -577,32 +606,6 @@
                             </Button>
                         </StackPanel>
 
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup>
-                                <VisualState>
-                                    <VisualState.StateTriggers>
-                                        <AdaptiveTrigger MinWindowWidth="0"/>
-                                    </VisualState.StateTriggers>
-                                    <VisualState.Setters>
-                                        <Setter Target="HeaderActionsPanel.(Grid.Row)" Value="2"/>
-                                        <Setter Target="HeaderActionsPanel.(Grid.Column)" Value="0"/>
-                                        <Setter Target="HeaderActionsPanel.(Grid.ColumnSpan)" Value="2"/>
-                                        <Setter Target="ActionsPanel.Orientation" Value="Vertical"/>
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState>
-                                    <VisualState.StateTriggers>
-                                        <AdaptiveTrigger MinWindowWidth="520"/>
-                                    </VisualState.StateTriggers>
-                                    <VisualState.Setters>
-                                        <Setter Target="HeaderActionsPanel.(Grid.Row)" Value="0"/>
-                                        <Setter Target="HeaderActionsPanel.(Grid.Column)" Value="1"/>
-                                        <Setter Target="HeaderActionsPanel.(Grid.ColumnSpan)" Value="1"/>
-                                        <Setter Target="ActionsPanel.Orientation" Value="Horizontal"/>
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                        </VisualStateManager.VisualStateGroups>
                     </Grid>
                 </Border>
 

--- a/tests/TaskbarQuota.Tests/UsageSnapshotStoreTests.cs
+++ b/tests/TaskbarQuota.Tests/UsageSnapshotStoreTests.cs
@@ -53,6 +53,38 @@ public class UsageSnapshotStoreTests : IDisposable
     }
 
     [Fact]
+    public void Save_ThenLoad_RestoresCreditWindowDisplayValues()
+    {
+        var usage = new UsageSnapshot(new RateWindow(20, 300))
+        {
+            Secondary = new RateWindow(25, 10080),
+            Cost = new CostSnapshot(9_600, "USD", "Credits")
+            {
+                Limit = 12_000,
+            },
+            Pricing = new UsagePricingSnapshot("OFF-PEAK", 0.5),
+        };
+        UsageSnapshotStore.Save(_dir, new Dictionary<ProviderId, UsageResult>
+        {
+            [ProviderId.Zai] = UsageResult.Success(
+                ProviderId.Zai,
+                Provider(ProviderId.Zai),
+                new ProviderFetchResult(usage, "api")),
+        });
+
+        var restored = UsageSnapshotStore.Load(_dir, id => Provider(id))[ProviderId.Zai];
+
+        Assert.Equal(20d, restored.Fetch!.Usage.Primary.UsedPercent, 0);
+        Assert.Equal(25d, restored.Fetch.Usage.Secondary!.UsedPercent, 0);
+        Assert.NotNull(restored.Fetch.Usage.Cost);
+        Assert.Equal("Credits", restored.Fetch.Usage.Cost!.Label);
+        Assert.Equal(9_600d, restored.Fetch.Usage.Cost.Amount, 0);
+        Assert.Equal(12_000d, restored.Fetch.Usage.Cost.Limit!.Value, 0);
+        Assert.Equal("OFF-PEAK", restored.Fetch.Usage.Pricing!.Period);
+        Assert.Equal(0.5d, restored.Fetch.Usage.Pricing.Multiplier);
+    }
+
+    [Fact]
     public void Load_DropsSnapshotWhoseWindowAlreadyReset()
     {
         UsageSnapshotStore.Save(_dir, new Dictionary<ProviderId, UsageResult>

--- a/tests/TaskbarQuota.Tests/ZaiProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/ZaiProviderTests.cs
@@ -185,6 +185,218 @@ public class ZaiProviderTests
     }
 
     [Fact]
+    public void BuildResult_PairsCurrentSubscriptionWithCreditWindows()
+    {
+        const string quotaJson = """
+        {
+          "code": 200,
+          "success": true,
+          "data": {
+            "level": "pro",
+            "limits": [
+              {
+                "type": "TOKENS_LIMIT",
+                "unit": 3,
+                "number": 5,
+                "usage": 12000,
+                "currentValue": 2400,
+                "remaining": 9600,
+                "percentage": 20
+              },
+              {
+                "type": "TOKENS_LIMIT",
+                "unit": 6,
+                "number": 1,
+                "usage": 60000,
+                "currentValue": 15000,
+                "remaining": 45000,
+                "percentage": 25
+              }
+            ]
+          }
+        }
+        """;
+        const string subscriptionJson = """
+        {
+          "code": 200,
+          "success": true,
+          "data": [
+            {
+              "productId": "expired-product",
+              "productName": "GLM Coding Lite",
+              "inCurrentPeriod": false,
+              "status": "EXPIRED"
+            },
+            {
+              "productId": "product-448ee2",
+              "productName": "GLM Coding Pro",
+              "inCurrentPeriod": true,
+              "status": "VALID"
+            }
+          ]
+        }
+        """;
+
+        using var quota = JsonDocument.Parse(quotaJson);
+        using var subscription = JsonDocument.Parse(subscriptionJson);
+        var result = ZaiProvider.BuildResult(quota.RootElement, subscription.RootElement);
+
+        Assert.Equal("GLM Coding Pro", result.Usage.LoginMethod);
+        Assert.Equal(20d, result.Usage.Primary.UsedPercent, 0);
+        Assert.Equal(25d, result.Usage.Secondary!.UsedPercent, 0);
+        Assert.False(result.Usage.HasPrimaryWindow);
+        Assert.NotNull(result.Usage.Cost);
+        Assert.Equal("Credits", result.Usage.Cost!.Label);
+        Assert.Equal("credits", result.Usage.Cost.Currency);
+        Assert.Equal(9_600d, result.Usage.Cost.Amount, 0);
+        Assert.Equal(12_000d, result.Usage.Cost.Limit!.Value, 0);
+    }
+
+    [Fact]
+    public void BuildResult_LegacySubscriptionKeepsPercentageDisplay()
+    {
+        const string quotaJson = """
+        {
+          "code": 200,
+          "success": true,
+          "data": {
+            "limits": [
+              {
+                "type": "TOKENS_LIMIT",
+                "unit": 3,
+                "number": 5,
+                "usage": 1000,
+                "currentValue": 250,
+                "remaining": 750,
+                "percentage": 25
+              }
+            ]
+          }
+        }
+        """;
+        const string subscriptionJson = """
+        {
+          "code": 200,
+          "success": true,
+          "data": [
+            {
+              "productId": "legacy-v2",
+              "productName": "Legacy Plan V2",
+              "inCurrentPeriod": true,
+              "status": "VALID"
+            }
+          ]
+        }
+        """;
+
+        using var quota = JsonDocument.Parse(quotaJson);
+        using var subscription = JsonDocument.Parse(subscriptionJson);
+        var result = ZaiProvider.BuildResult(quota.RootElement, subscription.RootElement);
+
+        Assert.Equal("Legacy Plan V2", result.Usage.LoginMethod);
+        Assert.Null(result.Usage.Cost);
+    }
+
+    [Fact]
+    public void BuildResult_GenericLegacyTierNameDoesNotImplyCredits()
+    {
+        const string quotaJson = """
+        {
+          "code": 200,
+          "success": true,
+          "data": {
+            "limits": [
+              { "type": "TOKENS_LIMIT", "unit": 3, "number": 5, "usage": 1000, "remaining": 750, "percentage": 25 }
+            ]
+          }
+        }
+        """;
+        const string subscriptionJson = """
+        {
+          "code": 200,
+          "success": true,
+          "data": [
+            {
+              "productId": "older-product-id",
+              "productName": "GLM Coding Pro",
+              "inCurrentPeriod": true,
+              "status": "VALID"
+            }
+          ]
+        }
+        """;
+
+        using var quota = JsonDocument.Parse(quotaJson);
+        using var subscription = JsonDocument.Parse(subscriptionJson);
+        var result = ZaiProvider.BuildResult(quota.RootElement, subscription.RootElement);
+
+        Assert.Equal("GLM Coding Pro", result.Usage.LoginMethod);
+        Assert.Null(result.Usage.Cost);
+    }
+
+    [Fact]
+    public void BuildResult_FallsBackToQuotaLevelWithoutSubscription()
+    {
+        const string json = """
+        {
+          "code": 200,
+          "success": true,
+          "data": { "level": "MAX", "limits": [] }
+        }
+        """;
+
+        using var doc = JsonDocument.Parse(json);
+        var result = ZaiProvider.BuildResult(doc.RootElement);
+
+        Assert.Equal("GLM Coding Max", result.Usage.LoginMethod);
+        Assert.Null(result.Usage.Cost);
+    }
+
+    [Fact]
+    public void BuildSubscriptionUrl_ReplacesQuotaPathAndQuery()
+    {
+        Assert.Equal(
+            "https://api.z.ai/api/biz/subscription/list",
+            ZaiProvider.BuildSubscriptionUrl("https://api.z.ai/api/monitor/usage/quota/limit?ignored=1"));
+    }
+
+    [Fact]
+    public void ResolvePricing_CreditPlansUseOneXPeakAndHalfXOffPeak()
+    {
+        var peak = ZaiProvider.ResolvePricing(
+            isCreditPlan: true,
+            productName: "GLM Coding Pro",
+            new DateTimeOffset(2026, 8, 14, 6, 0, 0, TimeSpan.Zero)); // 14:00 Singapore
+        var offPeak = ZaiProvider.ResolvePricing(
+            isCreditPlan: true,
+            productName: "GLM Coding Pro",
+            new DateTimeOffset(2026, 8, 14, 10, 0, 0, TimeSpan.Zero)); // 18:00 Singapore
+
+        Assert.Equal("PEAK", peak!.Period);
+        Assert.Equal(1d, peak.Multiplier);
+        Assert.Equal("OFF-PEAK", offPeak!.Period);
+        Assert.Equal(0.5d, offPeak.Multiplier);
+    }
+
+    [Fact]
+    public void ResolvePricing_LegacyV2UsesThreeXPeakAndOneXOffPeak()
+    {
+        var peak = ZaiProvider.ResolvePricing(
+            isCreditPlan: false,
+            productName: "Legacy Plan V2",
+            new DateTimeOffset(2026, 8, 14, 6, 0, 0, TimeSpan.Zero));
+        var offPeak = ZaiProvider.ResolvePricing(
+            isCreditPlan: false,
+            productName: "Legacy Plan V2",
+            new DateTimeOffset(2026, 8, 14, 10, 0, 0, TimeSpan.Zero));
+
+        Assert.Equal("PEAK", peak!.Period);
+        Assert.Equal(3d, peak.Multiplier);
+        Assert.Equal("OFF-PEAK", offPeak!.Period);
+        Assert.Equal(1d, offPeak.Multiplier);
+    }
+
+    [Fact]
     public void BuildResult_ComputesUsedPercentFromRemaining()
     {
         const string json = """
@@ -207,7 +419,7 @@ public class ZaiProviderTests
         """;
         using var doc = JsonDocument.Parse(json);
         var result = ZaiProvider.BuildResult(doc.RootElement);
-        Assert.Equal(25, result.Usage.Primary.UsedPercent, 0);
+        Assert.Equal(25d, result.Usage.Primary.UsedPercent, 0);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Resolves #66

This PR adds support for Z.ai dynamic quota multipliers, Peak/Off-Peak indicator, and credit-based coding plans:

- **Timezone-aware Peak Hour Resolution**: Evaluates Singapore Standard Time (SGT, UTC+8, no DST) universally from UTC (`DateTimeOffset.UtcNow.ToOffset(TimeSpan.FromHours(8))`) to detect weekday 14:00-18:00 SGT peak windows regardless of local PC timezone.
- **Dynamic Multiplier Coefficients**:
  - Credit Plans: `1.0x` during Peak, `0.5x` during Off-Peak (50% discount).
  - Legacy Token / Team Plans: `3.0x` during Peak, `1.0x` during Off-Peak.
- **Taskbar Widget & Visual Highlight**:
  - Automatically displays current `PEAK` / `OFF-PEAK` period and active multiplier in the widget rows.
  - `PEAK` row is highlighted in **Orange / Caution** (`SystemFillColorCautionBrush`), and `OFF-PEAK` renders in standard text.
  - Detail card flyout displays the active badge with corresponding color indicator.
  - Widget hover tooltip includes the active rate and period.
- **Automated Tests**: Added comprehensive unit tests covering credit plans, legacy plans, SGT peak window calculations, and usage store snapshots.

## Also fixes

Fixes #67 (vertical text-wrapping of provider name in the dashboard card). With few providers installed, the flyout width ignored the header, so the star-sized title column collapsed and provider names wrapped one character per line next to the header action buttons. Now:

- The flyout width calculation includes the widest provider header via the new `DashboardLayoutMetrics.EstimateHeaderWidth`, keeping the title and its actions on one line.
- Header titles use `TextWrapping="NoWrap"` with character ellipsis trimming, so vertical wrapping can no longer occur regardless of width.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Z.ai credit-plan pricing details, including peak and off-peak rates, to provider cards and tooltips.
  * Z.ai credits now appear by default with clearer quota and cost information.
  * Preserved custom colors for usage rows and pricing indicators.
* **Improvements**
  * Dashboard cards now size dynamically to fit headers and pricing content.
  * Usage and pricing details persist when snapshots are saved and restored.
* **Bug Fixes**
  * Prevented stale Synara selections from being reused after switching models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
