### PR TITLE
feat: add dual-monitor taskbar control

### DIFF
--- a/src/TaskbarQuota.App/ActiveApp/ForegroundWatcher.cs
+++ b/src/TaskbarQuota.App/ActiveApp/ForegroundWatcher.cs
@@ -12,10 +12,12 @@ namespace TaskbarQuota.ActiveApp
     internal sealed class ForegroundWatcher : IDisposable
     {
         private readonly User32.WinEventProc _callback;
-        private IntPtr _hook;
+        private IntPtr _foregroundHook;
+        private IntPtr _moveSizeHook;
         private bool _disposed;
 
-        public event Action? ForegroundChanged;
+        public event Action<IntPtr>? ForegroundChanged;
+        public event Action<IntPtr>? WindowMoveSizeEnded;
 
         public ForegroundWatcher()
         {
@@ -26,10 +28,10 @@ namespace TaskbarQuota.ActiveApp
 
         public void Start()
         {
-            if (_hook != IntPtr.Zero || _disposed)
+            if (_foregroundHook != IntPtr.Zero || _disposed)
                 return;
 
-            _hook = User32.SetWinEventHook(
+            _foregroundHook = User32.SetWinEventHook(
                 User32.EVENT_SYSTEM_FOREGROUND,
                 User32.EVENT_SYSTEM_FOREGROUND,
                 IntPtr.Zero,
@@ -38,19 +40,33 @@ namespace TaskbarQuota.ActiveApp
                 idThread: 0,
                 User32.WINEVENT_OUTOFCONTEXT);
 
-            if (_hook == IntPtr.Zero)
+            _moveSizeHook = User32.SetWinEventHook(
+                User32.EVENT_SYSTEM_MOVESIZEEND,
+                User32.EVENT_SYSTEM_MOVESIZEEND,
+                IntPtr.Zero,
+                _callback,
+                idProcess: 0,
+                idThread: 0,
+                User32.WINEVENT_OUTOFCONTEXT);
+
+            if (_foregroundHook == IntPtr.Zero)
                 Diagnostics.Log.Warning("[focus] foreground hook could not be installed; falling back to the detect tick");
+            if (_moveSizeHook == IntPtr.Zero)
+                Diagnostics.Log.Warning("[adaptive] move/size hook could not be installed; falling back to foreground observations");
         }
 
         private void OnWinEvent(IntPtr hook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint thread, uint time)
         {
             // idObject/idChild filter out the per-control accessibility noise that shares this event id.
-            if (eventType != User32.EVENT_SYSTEM_FOREGROUND || hwnd == IntPtr.Zero || idObject != 0)
+            if (hwnd == IntPtr.Zero || idObject != 0)
                 return;
 
             try
             {
-                ForegroundChanged?.Invoke();
+                if (eventType == User32.EVENT_SYSTEM_FOREGROUND)
+                    ForegroundChanged?.Invoke(hwnd);
+                else if (eventType == User32.EVENT_SYSTEM_MOVESIZEEND)
+                    WindowMoveSizeEnded?.Invoke(hwnd);
             }
             catch (Exception ex)
             {
@@ -64,12 +80,18 @@ namespace TaskbarQuota.ActiveApp
                 return;
 
             _disposed = true;
-            if (_hook == IntPtr.Zero)
-                return;
-
-            try { User32.UnhookWinEvent(_hook); }
-            catch { }
-            _hook = IntPtr.Zero;
+            if (_foregroundHook != IntPtr.Zero)
+            {
+                try { User32.UnhookWinEvent(_foregroundHook); }
+                catch { }
+                _foregroundHook = IntPtr.Zero;
+            }
+            if (_moveSizeHook != IntPtr.Zero)
+            {
+                try { User32.UnhookWinEvent(_moveSizeHook); }
+                catch { }
+                _moveSizeHook = IntPtr.Zero;
+            }
         }
     }
 }

--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -19,6 +19,7 @@ using TaskbarQuota.AgentActivity;
 using TaskbarQuota.Diagnostics;
 using TaskbarQuota.Interop;
 using TaskbarQuota.Services;
+using TaskbarQuota.Taskbar;
 using TaskbarQuota.Usage;
 using TaskbarQuota.ViewModels;
 using TaskbarQuota.Views;
@@ -222,6 +223,8 @@ namespace TaskbarQuota
             _selectedActivityId = showActivity ? selectedActivityId : null;
             _showingCost = false;
             EnsureDashboardLoaded();
+            if (ContentFrame.Content is DashboardPage dashboard)
+                dashboard.SetPinHereDisplay(TaskbarWindowTarget.GetDisplayKeyForWindow(widgetHandle));
             if (showActivity)
                 ShowActivityPanel();
             else
@@ -833,7 +836,19 @@ namespace TaskbarQuota
             if (_providerStripItems.TryGetValue(id, out var item))
                 item.Pin.Visibility = pinned ? Visibility.Visible : Visibility.Collapsed;
 
-            ToolTipService.SetToolTip(button, pinned ? $"{displayName} — pinned in the usage widget" : displayName);
+            string? fixedDisplay = WidgetSettingsService.GetPinnedProviderDisplay(id);
+            string pinDescription = fixedDisplay is null
+                ? "pinned — follows app screen"
+                : $"pinned to {DisplayLabel(fixedDisplay)}";
+            ToolTipService.SetToolTip(button, pinned ? $"{displayName} — {pinDescription}" : displayName);
+        }
+
+        private static string DisplayLabel(string displayKey)
+        {
+            if (displayKey == WidgetSettingsService.AllDisplaysPinDestination)
+                return "all screens";
+            int number = TaskbarWindowTarget.TryGetDisplayNumber(displayKey);
+            return number > 0 ? $"Screen {number}" : displayKey;
         }
 
         /// <summary>

--- a/src/TaskbarQuota.App/Interop/Native.cs
+++ b/src/TaskbarQuota.App/Interop/Native.cs
@@ -15,6 +15,12 @@ namespace TaskbarQuota.Interop
         public static extern uint GetDpiForWindow([In] IntPtr hWnd);
 
         [DllImport("user32.dll")]
+        public static extern IntPtr GetWindowDpiAwarenessContext([In] IntPtr hWnd);
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr SetThreadDpiAwarenessContext([In] IntPtr dpiContext);
+
+        [DllImport("user32.dll")]
         public static extern bool GetWindowRect([In] IntPtr hWnd, [Out] out RECT lpRect);
 
         [DllImport("user32.dll")]
@@ -32,6 +38,13 @@ namespace TaskbarQuota.Interop
 
         [DllImport("user32.dll")]
         public static extern bool UnregisterClass([In] string lpClassName, [In, Optional] IntPtr hInstance);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool DestroyWindow([In] IntPtr hWnd);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern uint RegisterWindowMessage([In] string lpString);
 
         [DllImport("user32.dll")]
         public static extern IntPtr SetParent([In] IntPtr hWndChild, [In] IntPtr hWndNewParent);
@@ -66,6 +79,7 @@ namespace TaskbarQuota.Interop
         public static extern bool EnumChildWindows(IntPtr hWndParent, EnumWindowProc lpEnumFunc, IntPtr lParam);
 
         public const uint EVENT_SYSTEM_FOREGROUND = 0x0003;
+        public const uint EVENT_SYSTEM_MOVESIZEEND = 0x000B;
         public const uint WINEVENT_OUTOFCONTEXT = 0x0000;
         public const uint WINEVENT_SKIPOWNPROCESS = 0x0002;
 
@@ -165,6 +179,15 @@ namespace TaskbarQuota.Interop
         public static extern IntPtr SendMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
 
         public const uint WM_SETICON = 0x0080;
+        public const uint WM_NCDESTROY = 0x0082;
+        public const uint WM_DISPLAYCHANGE = 0x007E;
+        public const uint WM_DEVICECHANGE = 0x0219;
+        public const uint WM_WTSSESSION_CHANGE = 0x02B1;
+        public const uint WM_POWERBROADCAST = 0x0218;
+        public const uint WM_DPICHANGED = 0x02E0;
+        public const uint WM_DPICHANGED_BEFOREPARENT = 0x02E2;
+        public const uint WM_DPICHANGED_AFTERPARENT = 0x02E3;
+        public static readonly IntPtr HWND_MESSAGE = new(-3);
         public const IntPtr ICON_SMALL = (IntPtr)0;
         public const IntPtr ICON_BIG = (IntPtr)1;
 
@@ -198,6 +221,19 @@ namespace TaskbarQuota.Interop
 
         [DllImport("user32.dll", CharSet = CharSet.Auto, EntryPoint = "GetMonitorInfo")]
         public static extern bool GetMonitorInfo([In] IntPtr hMonitor, ref MONITORINFOEX lpmi);
+    }
+
+    public static class WtsApi32
+    {
+        public const uint NOTIFY_FOR_THIS_SESSION = 0;
+
+        [DllImport("wtsapi32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool WTSRegisterSessionNotification(IntPtr hWnd, uint dwFlags);
+
+        [DllImport("wtsapi32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool WTSUnRegisterSessionNotification(IntPtr hWnd);
     }
 
     public static class DwmApi

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -31,6 +31,14 @@ public enum WidgetSurfaceMode
     Floating = 1,
 }
 
+/// <summary>How taskbar-hosted usage is distributed across available displays.</summary>
+public enum TaskbarPlacementMode
+{
+    AllDisplays = 0,
+    SelectedDisplay = 1,
+    Adaptive = 2,
+}
+
 public readonly record struct WidgetRowOption(string Id, string Label);
 
 public static class WidgetSettingsService
@@ -54,6 +62,15 @@ public static class WidgetSettingsService
 
     private static string FloatingOpacityPath =>
         Path.Combine(AppStorage.AppDataDirectory, "floating-opacity.txt");
+
+    private static string TaskbarPlacementModePath =>
+        Path.Combine(AppStorage.AppDataDirectory, "taskbar-placement-mode.txt");
+
+    private static string SelectedTaskbarDisplayPath =>
+        Path.Combine(AppStorage.AppDataDirectory, "taskbar-placement-display.txt");
+
+    private static string AdaptiveProviderDisplaysPath =>
+        Path.Combine(AppStorage.AppDataDirectory, "adaptive-provider-displays.json");
 
     private static readonly string PercentageDisplayModePath =
         Path.Combine(AppStorage.AppDataDirectory, "percentage-display-mode.txt");
@@ -85,6 +102,7 @@ public static class WidgetSettingsService
     private static readonly Dictionary<string, bool> ProviderVisibility = LoadProviderVisibility();
     private static readonly Dictionary<string, bool> DashboardProviderVisibility = LoadDashboardProviderVisibility();
     private static readonly Dictionary<string, bool> ProviderPins = LoadProviderPins();
+    private static readonly Dictionary<string, string> AdaptiveProviderDisplays = LoadAdaptiveProviderDisplays();
 
     /// <summary>Minimum material strength for the floating usage window (35%).</summary>
     public const double FloatingOpacityMin = 0.35;
@@ -95,6 +113,8 @@ public static class WidgetSettingsService
 
     public static WidgetDisplayMode Current { get; private set; } = LoadWidgetDisplayMode();
     public static WidgetSurfaceMode CurrentSurface { get; private set; } = LoadWidgetSurfaceMode();
+    public static TaskbarPlacementMode CurrentTaskbarPlacement { get; private set; } = LoadTaskbarPlacementMode();
+    public static string SelectedTaskbarDisplayKey { get; private set; } = LoadSelectedTaskbarDisplayKey();
     /// <summary>Floating window Acrylic strength in the range [<see cref="FloatingOpacityMin"/>, <see cref="FloatingOpacityMax"/>].</summary>
     public static double FloatingOpacity { get; private set; } = LoadFloatingOpacity();
     public static PercentageDisplayMode CurrentPercentageMode { get; private set; } = LoadPercentageDisplayMode();
@@ -118,6 +138,27 @@ public static class WidgetSettingsService
     {
         CurrentSurface = LoadWidgetSurfaceMode();
         FloatingOpacity = LoadFloatingOpacity();
+    }
+
+    internal static void ReloadTaskbarPlacementForTesting()
+    {
+        CurrentTaskbarPlacement = LoadTaskbarPlacementMode();
+        SelectedTaskbarDisplayKey = LoadSelectedTaskbarDisplayKey();
+        AdaptiveProviderDisplays.Clear();
+        foreach (var pair in LoadAdaptiveProviderDisplays())
+            AdaptiveProviderDisplays[pair.Key] = pair.Value;
+    }
+
+    internal static void RestoreTaskbarPlacementForTesting(
+        TaskbarPlacementMode mode,
+        string selectedDisplayKey,
+        IReadOnlyDictionary<string, string> adaptiveDisplays)
+    {
+        CurrentTaskbarPlacement = mode;
+        SelectedTaskbarDisplayKey = selectedDisplayKey;
+        AdaptiveProviderDisplays.Clear();
+        foreach (var pair in adaptiveDisplays)
+            AdaptiveProviderDisplays[pair.Key] = pair.Value;
     }
 
     internal static void RestoreSurfaceSettingsForTesting(
@@ -147,6 +188,45 @@ public static class WidgetSettingsService
         // TaskBarManager enforces the taskbar budget after a current widget measurement exists.
         // Doing it here would use the span cached before floating mode and could remove valid pins.
         Changed?.Invoke(null, EventArgs.Empty);
+    }
+
+    public static void ApplyTaskbarPlacement(TaskbarPlacementMode mode, string? selectedDisplayKey = null)
+    {
+        string normalizedKey = mode == TaskbarPlacementMode.SelectedDisplay
+            ? selectedDisplayKey?.Trim() ?? string.Empty
+            : string.Empty;
+        if (CurrentTaskbarPlacement == mode
+            && string.Equals(SelectedTaskbarDisplayKey, normalizedKey, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        CurrentTaskbarPlacement = mode;
+        SelectedTaskbarDisplayKey = normalizedKey;
+        Save(TaskbarPlacementModePath, (int)mode);
+        SaveText(SelectedTaskbarDisplayPath, normalizedKey);
+        Changed?.Invoke(null, EventArgs.Empty);
+    }
+
+    public static string? GetAdaptiveProviderDisplay(ProviderId provider)
+        => AdaptiveProviderDisplays.TryGetValue(provider.ToString(), out string? displayKey)
+            && !string.IsNullOrWhiteSpace(displayKey)
+                ? displayKey
+                : null;
+
+    /// <summary>Remembers the last display on which a provider window was observed.</summary>
+    internal static bool SetAdaptiveProviderDisplay(ProviderId provider, string displayKey)
+    {
+        displayKey = displayKey.Trim();
+        if (displayKey.Length == 0
+            || string.Equals(GetAdaptiveProviderDisplay(provider), displayKey, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        AdaptiveProviderDisplays[provider.ToString()] = displayKey;
+        SaveAdaptiveProviderDisplays();
+        return true;
     }
 
     /// <summary>
@@ -578,6 +658,39 @@ public static class WidgetSettingsService
         }
     }
 
+    private static TaskbarPlacementMode LoadTaskbarPlacementMode()
+    {
+        try
+        {
+            if (!File.Exists(TaskbarPlacementModePath))
+                return TaskbarPlacementMode.AllDisplays;
+
+            string raw = File.ReadAllText(TaskbarPlacementModePath);
+            return int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value)
+                && Enum.IsDefined(typeof(TaskbarPlacementMode), value)
+                ? (TaskbarPlacementMode)value
+                : TaskbarPlacementMode.AllDisplays;
+        }
+        catch
+        {
+            return TaskbarPlacementMode.AllDisplays;
+        }
+    }
+
+    private static string LoadSelectedTaskbarDisplayKey()
+    {
+        try
+        {
+            return File.Exists(SelectedTaskbarDisplayPath)
+                ? File.ReadAllText(SelectedTaskbarDisplayPath).Trim()
+                : string.Empty;
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
     private static double LoadFloatingOpacity()
     {
         try
@@ -636,6 +749,53 @@ public static class WidgetSettingsService
         catch
         {
             // Best effort. The widget can still use the in-memory value for this run.
+        }
+    }
+
+    private static void SaveText(string path, string value)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, value);
+        }
+        catch
+        {
+            // Best effort. The widget can still use the in-memory value for this run.
+        }
+    }
+
+    private static Dictionary<string, string> LoadAdaptiveProviderDisplays()
+    {
+        try
+        {
+            if (!File.Exists(AdaptiveProviderDisplaysPath))
+                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            var loaded = JsonSerializer.Deserialize<Dictionary<string, string>>(
+                File.ReadAllText(AdaptiveProviderDisplaysPath));
+            return loaded is null
+                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(loaded, StringComparer.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    private static void SaveAdaptiveProviderDisplays()
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(AdaptiveProviderDisplaysPath)!);
+            File.WriteAllText(
+                AdaptiveProviderDisplaysPath,
+                JsonSerializer.Serialize(AdaptiveProviderDisplays, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch
+        {
+            // Best effort. Adaptive routing still works for the current process.
         }
     }
 

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -43,6 +43,9 @@ public readonly record struct WidgetRowOption(string Id, string Label);
 
 public static class WidgetSettingsService
 {
+    /// <summary>Persisted pin destination meaning every available taskbar display.</summary>
+    public const string AllDisplaysPinDestination = "*";
+
     public const string RowPrimary = "primary";
     public const string RowSecondary = "secondary";
     public const string RowModelSpecific = "model";
@@ -71,6 +74,9 @@ public static class WidgetSettingsService
 
     private static string AdaptiveProviderDisplaysPath =>
         Path.Combine(AppStorage.AppDataDirectory, "adaptive-provider-displays.json");
+
+    private static string PinnedProviderDisplaysPath =>
+        Path.Combine(AppStorage.AppDataDirectory, "pinned-provider-displays.json");
 
     private static readonly string PercentageDisplayModePath =
         Path.Combine(AppStorage.AppDataDirectory, "percentage-display-mode.txt");
@@ -103,6 +109,7 @@ public static class WidgetSettingsService
     private static readonly Dictionary<string, bool> DashboardProviderVisibility = LoadDashboardProviderVisibility();
     private static readonly Dictionary<string, bool> ProviderPins = LoadProviderPins();
     private static readonly Dictionary<string, string> AdaptiveProviderDisplays = LoadAdaptiveProviderDisplays();
+    private static readonly Dictionary<string, string> PinnedProviderDisplays = LoadPinnedProviderDisplays();
 
     /// <summary>Minimum material strength for the floating usage window (35%).</summary>
     public const double FloatingOpacityMin = 0.35;
@@ -147,18 +154,26 @@ public static class WidgetSettingsService
         AdaptiveProviderDisplays.Clear();
         foreach (var pair in LoadAdaptiveProviderDisplays())
             AdaptiveProviderDisplays[pair.Key] = pair.Value;
+        PinnedProviderDisplays.Clear();
+        foreach (var pair in LoadPinnedProviderDisplays())
+            PinnedProviderDisplays[pair.Key] = pair.Value;
     }
 
     internal static void RestoreTaskbarPlacementForTesting(
         TaskbarPlacementMode mode,
         string selectedDisplayKey,
-        IReadOnlyDictionary<string, string> adaptiveDisplays)
+        IReadOnlyDictionary<string, string> adaptiveDisplays,
+        IReadOnlyDictionary<string, string>? pinnedDisplays = null)
     {
         CurrentTaskbarPlacement = mode;
         SelectedTaskbarDisplayKey = selectedDisplayKey;
         AdaptiveProviderDisplays.Clear();
         foreach (var pair in adaptiveDisplays)
             AdaptiveProviderDisplays[pair.Key] = pair.Value;
+        PinnedProviderDisplays.Clear();
+        if (pinnedDisplays is not null)
+            foreach (var pair in pinnedDisplays)
+                PinnedProviderDisplays[pair.Key] = pair.Value;
     }
 
     internal static void RestoreSurfaceSettingsForTesting(
@@ -227,6 +242,33 @@ public static class WidgetSettingsService
         AdaptiveProviderDisplays[provider.ToString()] = displayKey;
         SaveAdaptiveProviderDisplays();
         return true;
+    }
+
+    /// <summary>
+    /// A fixed display for a pinned provider in Adaptive mode. Null means the pin follows the provider's
+    /// last observed app display, preserving the behavior used before per-screen pinning was introduced.
+    /// </summary>
+    public static string? GetPinnedProviderDisplay(ProviderId provider)
+        => PinnedProviderDisplays.TryGetValue(provider.ToString(), out string? displayKey)
+            && !string.IsNullOrWhiteSpace(displayKey)
+                ? displayKey
+                : null;
+
+    public static void SetPinnedProviderDisplay(ProviderId provider, string? displayKey)
+    {
+        string normalized = displayKey?.Trim() ?? string.Empty;
+        string key = provider.ToString();
+        string current = GetPinnedProviderDisplay(provider) ?? string.Empty;
+        if (string.Equals(current, normalized, StringComparison.OrdinalIgnoreCase))
+            return;
+
+        if (normalized.Length == 0)
+            PinnedProviderDisplays.Remove(key);
+        else
+            PinnedProviderDisplays[key] = normalized;
+
+        SavePinnedProviderDisplays();
+        Changed?.Invoke(null, EventArgs.Empty);
     }
 
     /// <summary>
@@ -796,6 +838,40 @@ public static class WidgetSettingsService
         catch
         {
             // Best effort. Adaptive routing still works for the current process.
+        }
+    }
+
+    private static Dictionary<string, string> LoadPinnedProviderDisplays()
+    {
+        try
+        {
+            if (!File.Exists(PinnedProviderDisplaysPath))
+                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            var loaded = JsonSerializer.Deserialize<Dictionary<string, string>>(
+                File.ReadAllText(PinnedProviderDisplaysPath));
+            return loaded is null
+                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(loaded, StringComparer.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    private static void SavePinnedProviderDisplays()
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(PinnedProviderDisplaysPath)!);
+            File.WriteAllText(
+                PinnedProviderDisplaysPath,
+                JsonSerializer.Serialize(PinnedProviderDisplays, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch
+        {
+            // Best effort. The selected pin destination remains active for the current process.
         }
     }
 

--- a/src/TaskbarQuota.App/Taskbar/AdaptiveDisplayProviderState.cs
+++ b/src/TaskbarQuota.App/Taskbar/AdaptiveDisplayProviderState.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.Taskbar;
+
+/// <summary>
+/// Remembers the last provider window focused on each display. Windows exposes one system foreground
+/// window, so adaptive mode keeps one independent last-foreground slot per display instead of replacing
+/// every taskbar's provider whenever focus crosses a monitor boundary.
+/// </summary>
+internal sealed class AdaptiveDisplayProviderState
+{
+    private readonly Dictionary<string, Entry> _providers =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly record struct Entry(ProviderId Provider, IntPtr Window);
+
+    public ProviderId? GetProvider(string displayKey, Func<IntPtr, bool>? windowIsValid = null)
+    {
+        if (!_providers.TryGetValue(displayKey, out var entry))
+            return null;
+
+        if (windowIsValid is not null && !windowIsValid(entry.Window))
+        {
+            _providers.Remove(displayKey);
+            return null;
+        }
+
+        return entry.Provider;
+    }
+
+    public IReadOnlyCollection<ProviderId> Providers
+    {
+        get
+        {
+            var result = new List<ProviderId>(_providers.Values.Count);
+            foreach (var entry in _providers.Values)
+                result.Add(entry.Provider);
+            return result;
+        }
+    }
+
+    public bool Observe(ProviderId provider, string displayKey, IntPtr window)
+    {
+        displayKey = displayKey.Trim();
+        if (displayKey.Length == 0)
+            return false;
+
+        bool changed = false;
+        foreach (string previousDisplay in new List<string>(_providers.Keys))
+        {
+            if (!string.Equals(previousDisplay, displayKey, StringComparison.OrdinalIgnoreCase)
+                && _providers[previousDisplay].Provider == provider)
+            {
+                _providers.Remove(previousDisplay);
+                changed = true;
+            }
+        }
+
+        var next = new Entry(provider, window);
+        if (_providers.TryGetValue(displayKey, out var current) && current == next)
+            return changed;
+
+        _providers[displayKey] = next;
+        return true;
+    }
+
+    public void Clear() => _providers.Clear();
+}

--- a/src/TaskbarQuota.App/Taskbar/AdaptiveDisplayProviderState.cs
+++ b/src/TaskbarQuota.App/Taskbar/AdaptiveDisplayProviderState.cs
@@ -5,38 +5,43 @@ using TaskbarQuota.Usage;
 namespace TaskbarQuota.Taskbar;
 
 /// <summary>
-/// Remembers the last provider window focused on each display. Windows exposes one system foreground
-/// window, so adaptive mode keeps one independent last-foreground slot per display instead of replacing
-/// every taskbar's provider whenever focus crosses a monitor boundary.
+/// Remembers provider windows focused on each display in most-recent-first order. Windows exposes one
+/// system foreground window, so adaptive mode keeps independent per-display history and can restore the
+/// previous valid provider when the current one moves to another monitor or closes.
 /// </summary>
 internal sealed class AdaptiveDisplayProviderState
 {
-    private readonly Dictionary<string, Entry> _providers =
+    private readonly Dictionary<string, List<Entry>> _providers =
         new(StringComparer.OrdinalIgnoreCase);
 
     private readonly record struct Entry(ProviderId Provider, IntPtr Window);
 
     public ProviderId? GetProvider(string displayKey, Func<IntPtr, bool>? windowIsValid = null)
     {
-        if (!_providers.TryGetValue(displayKey, out var entry))
+        if (!_providers.TryGetValue(displayKey, out var entries))
             return null;
 
-        if (windowIsValid is not null && !windowIsValid(entry.Window))
+        for (int i = entries.Count - 1; i >= 0; i--)
         {
-            _providers.Remove(displayKey);
-            return null;
+            var entry = entries[i];
+            if (windowIsValid is null || windowIsValid(entry.Window))
+                return entry.Provider;
+
+            entries.RemoveAt(i);
         }
 
-        return entry.Provider;
+        _providers.Remove(displayKey);
+        return null;
     }
 
     public IReadOnlyCollection<ProviderId> Providers
     {
         get
         {
-            var result = new List<ProviderId>(_providers.Values.Count);
-            foreach (var entry in _providers.Values)
-                result.Add(entry.Provider);
+            var result = new HashSet<ProviderId>();
+            foreach (var entries in _providers.Values)
+                foreach (var entry in entries)
+                    result.Add(entry.Provider);
             return result;
         }
     }
@@ -47,22 +52,49 @@ internal sealed class AdaptiveDisplayProviderState
         if (displayKey.Length == 0)
             return false;
 
-        bool changed = false;
+        var next = new Entry(provider, window);
+        bool alreadyCurrent = _providers.TryGetValue(displayKey, out var currentEntries)
+            && currentEntries.Count > 0
+            && currentEntries[^1] == next;
+        bool hasConflictingEntry = false;
+        foreach (var pair in _providers)
+        {
+            for (int i = 0; i < pair.Value.Count; i++)
+            {
+                var entry = pair.Value[i];
+                bool isCurrent = string.Equals(pair.Key, displayKey, StringComparison.OrdinalIgnoreCase)
+                    && i == pair.Value.Count - 1
+                    && entry == next;
+                if (!isCurrent && (entry.Provider == provider || entry.Window == window))
+                {
+                    hasConflictingEntry = true;
+                    break;
+                }
+            }
+            if (hasConflictingEntry)
+                break;
+        }
+        if (alreadyCurrent && !hasConflictingEntry)
+            return false;
+
         foreach (string previousDisplay in new List<string>(_providers.Keys))
         {
-            if (!string.Equals(previousDisplay, displayKey, StringComparison.OrdinalIgnoreCase)
-                && _providers[previousDisplay].Provider == provider)
+            var entries = _providers[previousDisplay];
+            // A window can change provider without moving (for example, switching tools inside one
+            // terminal). Its previous classification must not survive as a fallback entry.
+            entries.RemoveAll(entry => entry.Provider == provider || entry.Window == window);
+            if (entries.Count == 0)
             {
                 _providers.Remove(previousDisplay);
-                changed = true;
             }
         }
 
-        var next = new Entry(provider, window);
-        if (_providers.TryGetValue(displayKey, out var current) && current == next)
-            return changed;
-
-        _providers[displayKey] = next;
+        if (!_providers.TryGetValue(displayKey, out var targetEntries))
+        {
+            targetEntries = new List<Entry>();
+            _providers[displayKey] = targetEntries;
+        }
+        targetEntries.Add(next);
         return true;
     }
 

--- a/src/TaskbarQuota.App/Taskbar/DpiChangeDebouncer.cs
+++ b/src/TaskbarQuota.App/Taskbar/DpiChangeDebouncer.cs
@@ -1,0 +1,41 @@
+namespace TaskbarQuota.Taskbar;
+
+/// <summary>Rejects one-off DPI readings while accepting a stable changed value promptly.</summary>
+internal sealed class DpiChangeDebouncer
+{
+    private readonly int requiredSamples;
+    private uint candidate;
+    private int samples;
+
+    public DpiChangeDebouncer(int requiredSamples = 2)
+    {
+        this.requiredSamples = requiredSamples < 1 ? 1 : requiredSamples;
+    }
+
+    public bool Observe(uint appliedDpi, uint observedDpi)
+    {
+        if (observedDpi == 0 || observedDpi == appliedDpi)
+        {
+            Reset();
+            return false;
+        }
+
+        if (candidate != observedDpi)
+        {
+            candidate = observedDpi;
+            samples = 1;
+        }
+        else
+        {
+            samples++;
+        }
+
+        return samples >= requiredSamples;
+    }
+
+    public void Reset()
+    {
+        candidate = 0;
+        samples = 0;
+    }
+}

--- a/src/TaskbarQuota.App/Taskbar/SessionTopologyWatcher.cs
+++ b/src/TaskbarQuota.App/Taskbar/SessionTopologyWatcher.cs
@@ -1,0 +1,211 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using TaskbarQuota.Diagnostics;
+using TaskbarQuota.Interop;
+
+namespace TaskbarQuota.Taskbar;
+
+internal enum TopologyChangeKind
+{
+    Display,
+    SessionConnect,
+    SessionDisconnect,
+    SessionUnlock,
+    ExplorerRestart,
+    Resume,
+}
+
+internal readonly record struct TopologyChange(TopologyChangeKind Kind, string Reason)
+{
+    public bool RequiresHostReset => Kind is
+        TopologyChangeKind.SessionConnect or
+        TopologyChangeKind.SessionDisconnect or
+        TopologyChangeKind.SessionUnlock or
+        TopologyChangeKind.ExplorerRestart or
+        TopologyChangeKind.Resume;
+}
+
+/// <summary>
+/// Owns a hidden top-level window so broadcast shell/display messages remain independent of taskbar HWNDs
+/// and recovery does not depend on a taskbar-injected HWND surviving
+/// Remote Desktop, Explorer restart, sleep, or a display-topology replacement.
+/// </summary>
+internal sealed class SessionTopologyWatcher : IDisposable
+{
+    internal const int WtsConsoleConnect = 0x1;
+    internal const int WtsConsoleDisconnect = 0x2;
+    internal const int WtsRemoteConnect = 0x3;
+    internal const int WtsRemoteDisconnect = 0x4;
+    internal const int WtsSessionLogon = 0x5;
+    internal const int WtsSessionUnlock = 0x8;
+    internal const int PbtApmResumeAutomatic = 0x12;
+
+    private readonly string className = $"TaskbarQuotaSessionTopology-{Environment.ProcessId}";
+    private readonly WndProc windowProc;
+    private readonly uint taskbarCreatedMessage;
+    private IntPtr hwnd;
+    private bool classRegistered;
+    private bool sessionRegistered;
+    private bool disposed;
+
+    public event Action<TopologyChange>? Changed;
+
+    public SessionTopologyWatcher()
+    {
+        windowProc = WindowProc;
+        taskbarCreatedMessage = User32.RegisterWindowMessage("TaskbarCreated");
+    }
+
+    public void Start()
+    {
+        if (disposed || hwnd != IntPtr.Zero)
+            return;
+
+        var windowClass = new WNDCLASSEX
+        {
+            cbSize = (uint)Marshal.SizeOf<WNDCLASSEX>(),
+            hInstance = Kernel32.GetModuleHandle(null),
+            lpfnWndProc = windowProc,
+            lpszClassName = className,
+        };
+        if (User32.RegisterClassEx(ref windowClass) == 0)
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Could not register the session topology window class.");
+        classRegistered = true;
+
+        hwnd = User32.CreateWindowEx(
+            WindowStylesExtended.Default,
+            className,
+            "TaskbarQuota session topology watcher",
+            WindowStyles.WS_POPUP,
+            0,
+            0,
+            0,
+            0,
+            IntPtr.Zero,
+            IntPtr.Zero,
+            Kernel32.GetModuleHandle(null),
+            IntPtr.Zero);
+        if (hwnd == IntPtr.Zero)
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Could not create the session topology message window.");
+
+        sessionRegistered = WtsApi32.WTSRegisterSessionNotification(
+            hwnd,
+            WtsApi32.NOTIFY_FOR_THIS_SESSION);
+        if (!sessionRegistered)
+            Log.Warning(new Win32Exception(Marshal.GetLastWin32Error()), "Could not register for session topology notifications");
+    }
+
+    private IntPtr WindowProc(IntPtr hWnd, uint message, IntPtr wParam, IntPtr lParam)
+    {
+        if (message == taskbarCreatedMessage && taskbarCreatedMessage != 0)
+            Raise(new(TopologyChangeKind.ExplorerRestart, "Explorer taskbar created"));
+        else if (message == User32.WM_DISPLAYCHANGE || message == User32.WM_DEVICECHANGE)
+            Raise(new(TopologyChangeKind.Display, "display topology changed"));
+        else if (message == User32.WM_WTSSESSION_CHANGE
+                 && TryMapSessionChange(wParam.ToInt32(), out var change))
+            Raise(change);
+        else if (message == User32.WM_POWERBROADCAST
+                 && wParam.ToInt32() == PbtApmResumeAutomatic)
+            Raise(new(TopologyChangeKind.Resume, "system resumed"));
+
+        return User32.DefWindowProc(hWnd, message, wParam, lParam);
+    }
+
+    private void Raise(TopologyChange change)
+    {
+        try
+        {
+            Changed?.Invoke(change);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, $"Topology change handler failed ({change.Reason})");
+        }
+    }
+
+    internal static bool TryMapSessionChange(int code, out TopologyChange change)
+    {
+        change = code switch
+        {
+            WtsConsoleConnect => new(TopologyChangeKind.SessionConnect, "console session connected"),
+            WtsRemoteConnect => new(TopologyChangeKind.SessionConnect, "Remote Desktop connected"),
+            WtsSessionLogon => new(TopologyChangeKind.SessionConnect, "session logged on"),
+            WtsConsoleDisconnect => new(TopologyChangeKind.SessionDisconnect, "console session disconnected"),
+            WtsRemoteDisconnect => new(TopologyChangeKind.SessionDisconnect, "Remote Desktop disconnected"),
+            WtsSessionUnlock => new(TopologyChangeKind.SessionUnlock, "session unlocked"),
+            _ => default,
+        };
+        return code is WtsConsoleConnect
+            or WtsRemoteConnect
+            or WtsSessionLogon
+            or WtsConsoleDisconnect
+            or WtsRemoteDisconnect
+            or WtsSessionUnlock;
+    }
+
+    internal static TimeSpan RetryDelay(int completedAttempts)
+    {
+        int exponent = Math.Clamp(completedAttempts, 0, 4);
+        return TimeSpan.FromMilliseconds(Math.Min(4000, 250 * (1 << exponent)));
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+            return;
+        disposed = true;
+
+        if (sessionRegistered && hwnd != IntPtr.Zero)
+        {
+            try { WtsApi32.WTSUnRegisterSessionNotification(hwnd); }
+            catch { }
+            sessionRegistered = false;
+        }
+        if (hwnd != IntPtr.Zero)
+        {
+            try { User32.DestroyWindow(hwnd); }
+            catch { }
+            hwnd = IntPtr.Zero;
+        }
+        if (classRegistered)
+        {
+            try { User32.UnregisterClass(className, Kernel32.GetModuleHandle(null)); }
+            catch { }
+            classRegistered = false;
+        }
+
+        Changed = null;
+    }
+}
+
+/// <summary>Requires the same non-empty taskbar topology twice before recovery commits to it.</summary>
+internal sealed class TopologyStabilityTracker
+{
+    private string? candidate;
+    private int samples;
+
+    public bool Observe(string signature)
+    {
+        if (string.IsNullOrWhiteSpace(signature))
+        {
+            Reset();
+            return false;
+        }
+
+        if (!string.Equals(candidate, signature, StringComparison.Ordinal))
+        {
+            candidate = signature;
+            samples = 1;
+            return false;
+        }
+
+        return ++samples >= 2;
+    }
+
+    public void Reset()
+    {
+        candidate = null;
+        samples = 0;
+    }
+}

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -527,14 +527,19 @@ namespace TaskbarQuota.Taskbar
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
             string primary = PrimaryWidget()?.DisplayKey ?? widget.DisplayKey;
             var mode = WidgetSettingsService.CurrentTaskbarPlacement;
-            if (mode == TaskbarPlacementMode.Adaptive
-                && AdaptiveProviderForDisplay(widget.DisplayKey) is { } displayActive
-                && WidgetSettingsService.IsProviderVisible(displayActive))
+            ProviderId? displayActive = mode == TaskbarPlacementMode.Adaptive
+                ? AdaptiveProviderForDisplay(widget.DisplayKey)
+                : null;
+            if (mode == TaskbarPlacementMode.Adaptive)
             {
-                providers = new[] { displayActive }
-                    .Concat(providers)
-                    .Distinct()
-                    .ToArray();
+                // The per-display history is authoritative for unpinned content. Keeping every global
+                // candidate here lets a provider's stale persisted destination briefly join the restored
+                // provider during a move, rendering two unpinned tiles on one taskbar.
+                providers = TaskbarContentRouter.AdaptiveCandidatesForDisplay(
+                    providers,
+                    displayActive,
+                    WidgetSettingsService.IsProviderVisible,
+                    WidgetSettingsService.IsProviderPinned);
             }
 
             return TaskbarContentRouter.ProvidersForDisplay(
@@ -544,7 +549,9 @@ namespace TaskbarQuota.Taskbar
                 widget.DisplayKey,
                 primary,
                 available,
-                WidgetSettingsService.GetAdaptiveProviderDisplay,
+                provider => displayActive == provider
+                    ? widget.DisplayKey
+                    : WidgetSettingsService.GetAdaptiveProviderDisplay(provider),
                 WidgetSettingsService.IsProviderPinned,
                 WidgetSettingsService.GetPinnedProviderDisplay);
         }

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -710,14 +710,9 @@ namespace TaskbarQuota.Taskbar
             // animation run over an empty window and turns a cross-screen handoff into a visible blink.
             if (providers.Count == 0)
             {
-                widget.SetDisplayProviders(Array.Empty<ProviderId>(), ActiveProviderForWidget(widget, coordinator.ActiveProvider));
-                if (widget.HasVisibleActivity)
-                {
-                    widget.SetVisible(true);
-                    widget.SetQuotaVisible(false);
-                }
-                else
-                    widget.SetVisible(false);
+                widget.HideDisplayProviders(
+                    ActiveProviderForWidget(widget, coordinator.ActiveProvider),
+                    keepActivityVisible: widget.HasVisibleActivity);
                 return;
             }
 
@@ -930,14 +925,9 @@ namespace TaskbarQuota.Taskbar
                 // completion callback, guarded so an interrupted hide cannot erase a returning provider.
                 if (providers.Count == 0)
                 {
-                    widget.SetDisplayProviders(Array.Empty<ProviderId>(), ActiveProviderForWidget(widget, coordinator.ActiveProvider));
-                    if (widget.HasVisibleActivity)
-                    {
-                        widget.SetVisible(true);
-                        widget.SetQuotaVisible(false);
-                    }
-                    else
-                        widget.SetVisible(false);
+                    widget.HideDisplayProviders(
+                        ActiveProviderForWidget(widget, coordinator.ActiveProvider),
+                        keepActivityVisible: widget.HasVisibleActivity);
                     continue;
                 }
 

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -46,6 +46,7 @@ namespace TaskbarQuota.Taskbar
         private const int MaxTopologyRecoveryAttempts = 12;
         private static readonly TopologyStabilityTracker TopologyStability = new();
         private static readonly Dictionary<IntPtr, int> MissingTaskbarObservations = new();
+        private static readonly AdaptiveDisplayProviderState AdaptiveDisplayProviders = new();
         private static ProviderId? _lastLoggedWidgetApplyProvider;
         private static WidgetSurfaceMode _activeSurface = WidgetSurfaceMode.Taskbar;
         // Foreground hook: fires the instant Windows switches windows so the focus-follows-provider
@@ -525,15 +526,42 @@ namespace TaskbarQuota.Taskbar
                 .Select(candidate => candidate.DisplayKey)
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
             string primary = PrimaryWidget()?.DisplayKey ?? widget.DisplayKey;
+            var mode = WidgetSettingsService.CurrentTaskbarPlacement;
+            if (mode == TaskbarPlacementMode.Adaptive
+                && AdaptiveProviderForDisplay(widget.DisplayKey) is { } displayActive
+                && WidgetSettingsService.IsProviderVisible(displayActive))
+            {
+                providers = new[] { displayActive }
+                    .Concat(providers)
+                    .Distinct()
+                    .ToArray();
+            }
+
             return TaskbarContentRouter.ProvidersForDisplay(
                 providers,
-                WidgetSettingsService.CurrentTaskbarPlacement,
+                mode,
                 WidgetSettingsService.SelectedTaskbarDisplayKey,
                 widget.DisplayKey,
                 primary,
                 available,
-                WidgetSettingsService.GetAdaptiveProviderDisplay);
+                WidgetSettingsService.GetAdaptiveProviderDisplay,
+                WidgetSettingsService.IsProviderPinned,
+                WidgetSettingsService.GetPinnedProviderDisplay);
         }
+
+        private static ProviderId? ActiveProviderForWidget(TaskBarWidget widget, ProviderId? globalActive)
+            => WidgetSettingsService.CurrentTaskbarPlacement == TaskbarPlacementMode.Adaptive
+                ? AdaptiveProviderForDisplay(widget.DisplayKey)
+                : globalActive;
+
+        private static ProviderId? AdaptiveProviderForDisplay(string displayKey)
+            => AdaptiveDisplayProviders.GetProvider(
+                displayKey,
+                hwnd => User32.IsWindow(hwnd)
+                    && string.Equals(
+                        TaskbarWindowTarget.GetDisplayKeyForWindow(hwnd),
+                        displayKey,
+                        StringComparison.OrdinalIgnoreCase));
 
         internal static bool ShouldRemoveMissingTaskbar(int consecutiveMisses, bool hostAlive)
             => !hostAlive || consecutiveMisses >= 2;
@@ -681,7 +709,7 @@ namespace TaskbarQuota.Taskbar
             // back in either — the set below runs first on show.
             if (providers.Count == 0)
             {
-                widget.SetDisplayProviders(Array.Empty<ProviderId>(), coordinator.ActiveProvider);
+                widget.SetDisplayProviders(Array.Empty<ProviderId>(), ActiveProviderForWidget(widget, coordinator.ActiveProvider));
                 if (widget.HasVisibleActivity)
                 {
                     widget.SetVisible(true);
@@ -692,7 +720,7 @@ namespace TaskbarQuota.Taskbar
                 return;
             }
 
-            widget.SetDisplayProviders(providers, coordinator.ActiveProvider);
+            widget.SetDisplayProviders(providers, ActiveProviderForWidget(widget, coordinator.ActiveProvider));
             widget.SetVisible(true);
 
             bool needsFetch = false;
@@ -743,7 +771,11 @@ namespace TaskbarQuota.Taskbar
         private static void RefreshPinnedTiles()
         {
             var coordinator = UsageCoordinator.Instance;
-            foreach (var provider in coordinator.WidgetDisplayProviders)
+            IEnumerable<ProviderId> providers = coordinator.WidgetDisplayProviders;
+            if (WidgetSettingsService.CurrentTaskbarPlacement == TaskbarPlacementMode.Adaptive)
+                providers = providers.Concat(AdaptiveDisplayProviders.Providers).Distinct();
+
+            foreach (var provider in providers)
             {
                 if (provider != coordinator.ActiveProvider)
                     _ = coordinator.RefreshWidgetProviderAsync(provider);
@@ -897,7 +929,7 @@ namespace TaskbarQuota.Taskbar
                 // provider return cannot reveal stale tiles.
                 if (providers.Count == 0)
                 {
-                    widget.SetDisplayProviders(Array.Empty<ProviderId>(), coordinator.ActiveProvider);
+                    widget.SetDisplayProviders(Array.Empty<ProviderId>(), ActiveProviderForWidget(widget, coordinator.ActiveProvider));
                     if (widget.HasVisibleActivity)
                     {
                         widget.SetVisible(true);
@@ -908,7 +940,7 @@ namespace TaskbarQuota.Taskbar
                     continue;
                 }
 
-                widget.SetDisplayProviders(providers, coordinator.ActiveProvider);
+                widget.SetDisplayProviders(providers, ActiveProviderForWidget(widget, coordinator.ActiveProvider));
                 widget.SetVisible(true);
                 if (!isDisplayedOnWidget)
                     continue;
@@ -959,7 +991,7 @@ namespace TaskbarQuota.Taskbar
             if (displayKey.Length == 0)
                 return;
 
-            _dispatcher?.TryEnqueue(() => RecordAdaptiveProviderDisplay(provider, displayKey));
+            _dispatcher?.TryEnqueue(() => RecordAdaptiveProviderDisplay(provider, displayKey, hwnd));
         }
 
         private static void OnWindowMoveSizeEnded(IntPtr hwnd)
@@ -971,15 +1003,18 @@ namespace TaskbarQuota.Taskbar
 
             string displayKey = TaskbarWindowTarget.GetDisplayKeyForWindow(hwnd);
             if (displayKey.Length != 0)
-                RecordAdaptiveProviderDisplay(provider, displayKey);
+                RecordAdaptiveProviderDisplay(provider, displayKey, hwnd);
         }
 
-        private static void RecordAdaptiveProviderDisplay(ProviderId provider, string displayKey)
+        private static void RecordAdaptiveProviderDisplay(ProviderId provider, string displayKey, IntPtr hwnd)
         {
-            if (!WidgetSettingsService.SetAdaptiveProviderDisplay(provider, displayKey))
+            bool activeChanged = AdaptiveDisplayProviders.Observe(provider, displayKey, hwnd);
+            bool destinationChanged = WidgetSettingsService.SetAdaptiveProviderDisplay(provider, displayKey);
+            if (!activeChanged && !destinationChanged)
                 return;
 
-            Log.Information($"Adaptive placement: provider={provider}, display={displayKey}");
+            if (destinationChanged)
+                Log.Information($"Adaptive placement: provider={provider}, display={displayKey}");
             if (!IsFloatingSurface
                 && WidgetSettingsService.CurrentTaskbarPlacement == TaskbarPlacementMode.Adaptive)
             {
@@ -1038,6 +1073,7 @@ namespace TaskbarQuota.Taskbar
             _topologyRecoveryReason = string.Empty;
             TopologyStability.Reset();
             MissingTaskbarObservations.Clear();
+            AdaptiveDisplayProviders.Clear();
             _activityTimer?.Stop();
             _activityTimer = null;
             _activityCts?.Cancel();

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -9,6 +9,7 @@ using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
 using TaskbarQuota.Diagnostics;
+using TaskbarQuota.Interop;
 using TaskbarQuota.Usage;
 using TaskbarQuota.AgentActivity;
 
@@ -31,17 +32,26 @@ namespace TaskbarQuota.Taskbar
         private static DispatcherQueue? _dispatcher;
         private static Action? _showMainWindow;
         private static DispatcherTimer? _widgetHealthTimer;
+        private static DispatcherTimer? _topologyRecoveryTimer;
         private static DispatcherTimer? _activityTimer;
         private static CancellationTokenSource? _activityCts;
         private static readonly TimeSpan ActiveActivityInterval = TimeSpan.FromSeconds(2);
         private static readonly TimeSpan IdleActivityInterval = TimeSpan.FromSeconds(10);
         private static bool _initialized;
         private static bool _isReconcilingWidgets;
+        private static bool _topologyRecoveryPending;
+        private static bool _topologyForceReset;
+        private static int _topologyRecoveryAttempts;
+        private static string _topologyRecoveryReason = string.Empty;
+        private const int MaxTopologyRecoveryAttempts = 12;
+        private static readonly TopologyStabilityTracker TopologyStability = new();
+        private static readonly Dictionary<IntPtr, int> MissingTaskbarObservations = new();
         private static ProviderId? _lastLoggedWidgetApplyProvider;
         private static WidgetSurfaceMode _activeSurface = WidgetSurfaceMode.Taskbar;
         // Foreground hook: fires the instant Windows switches windows so the focus-follows-provider
         // widget reacts on the switch itself instead of waiting for the next 500 ms detect tick.
         private static ActiveApp.ForegroundWatcher? _foregroundWatcher;
+        private static SessionTopologyWatcher? _sessionTopologyWatcher;
 
         private static bool IsFloatingSurface => _activeSurface == WidgetSurfaceMode.Floating;
 
@@ -58,6 +68,7 @@ namespace TaskbarQuota.Taskbar
                 UsageCoordinator.Instance.StateChanged += OnStateChanged;
                 UsageCoordinator.Instance.ActiveProviderChanged += OnActiveProviderChanged;
                 UsageCoordinator.Instance.ActiveToolPresenceChanged += OnActiveToolPresenceChanged;
+                UsageCoordinator.Instance.ProviderWindowObserved += OnProviderWindowObserved;
                 AgentActivityService.Instance.Changed += OnActivityChanged;
                 UsageCoordinator.Instance.ProviderForegroundChanged += OnProviderForegroundChanged;
                 // Lets the coordinator's focus tracker treat our flyout and an active widget drag as neutral
@@ -73,7 +84,24 @@ namespace TaskbarQuota.Taskbar
                 // that thread's message pump, which this one has and background threads do not.
                 _foregroundWatcher = new ActiveApp.ForegroundWatcher();
                 _foregroundWatcher.ForegroundChanged += OnForegroundChanged;
+                _foregroundWatcher.WindowMoveSizeEnded += OnWindowMoveSizeEnded;
                 _foregroundWatcher.Start();
+                try
+                {
+                    _sessionTopologyWatcher = new SessionTopologyWatcher();
+                    _sessionTopologyWatcher.Changed += OnTopologyChanged;
+                    _sessionTopologyWatcher.Start();
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, "Session/display recovery watcher could not be started; periodic health recovery remains active");
+                    if (_sessionTopologyWatcher is { } topologyWatcher)
+                    {
+                        topologyWatcher.Changed -= OnTopologyChanged;
+                        topologyWatcher.Dispose();
+                        _sessionTopologyWatcher = null;
+                    }
+                }
                 _initialized = true;
             }
 
@@ -96,7 +124,15 @@ namespace TaskbarQuota.Taskbar
             {
                 DisposeFloatingWindow();
                 _activeSurface = WidgetSurfaceMode.Taskbar;
-                EnsureWidgets();
+                if (_topologyRecoveryPending)
+                {
+                    if (TryRecoverTaskbarTopology())
+                        CompleteTopologyRecovery();
+                }
+                else
+                {
+                    EnsureWidgets();
+                }
                 SyncWidgetState();
                 ScheduleFloatingPrewarm();
             }
@@ -388,19 +424,38 @@ namespace TaskbarQuota.Taskbar
 
                 foreach (var pair in Widgets.ToArray())
                 {
-                    if (targetsByHandle.TryGetValue(pair.Key, out var target)
-                        && pair.Value.IsAlive
-                        // A window whose host content was never built renders nothing and cannot recover on
-                        // its own — it is dead in every way that matters to the user, so recreate it.
-                        && pair.Value.IsHostContentReady
-                        && pair.Value.IsDpiCurrent
-                        && pair.Value.MatchesTarget(target))
+                    string? recreateReason = null;
+                    if (!pair.Value.IsAlive)
+                        recreateReason = "host window unavailable";
+                    else if (!targetsByHandle.TryGetValue(pair.Key, out var target))
                     {
+                        int misses = MissingTaskbarObservations.TryGetValue(pair.Key, out int previous)
+                            ? previous + 1
+                            : 1;
+                        MissingTaskbarObservations[pair.Key] = misses;
+                        if (ShouldRemoveMissingTaskbar(misses, hostAlive: true))
+                            recreateReason = $"taskbar absent for {misses} consecutive scans";
+                    }
+                    else if (!pair.Value.IsHostContentReady)
+                        recreateReason = "XAML host content unavailable";
+                    else if (pair.Value.IsConfirmedTargetMismatch(target))
+                        recreateReason = $"display identity changed ({pair.Value.DisplayKey}->{target.DisplayKey})";
+
+                    if (targetsByHandle.ContainsKey(pair.Key))
+                        MissingTaskbarObservations.Remove(pair.Key);
+
+                    if (recreateReason is null)
+                    {
+                        // A stable host can absorb per-monitor DPI changes in place. Recreating the complete
+                        // XAML island on one anomalous reading caused mixed-DPI systems to enter a slow
+                        // destroy/create loop whenever Explorer was rebuilding its display topology.
+                        pair.Value.RefreshDpiFromWindows();
                         continue;
                     }
 
                     Widgets.Remove(pair.Key);
-                    Log.Warning($"Taskbar widget, target taskbar, or DPI changed; recreating taskbar=0x{pair.Key.ToInt64():X}");
+                    MissingTaskbarObservations.Remove(pair.Key);
+                    Log.Warning($"Taskbar widget recreating: taskbar=0x{pair.Key.ToInt64():X}, reason={recreateReason}");
                     try { pair.Value.Dispose(); }
                     catch (Exception ex) { Log.Warning(ex, "Failed to dispose missing taskbar widget"); }
                 }
@@ -410,6 +465,9 @@ namespace TaskbarQuota.Taskbar
                     if (!Widgets.ContainsKey(target.Handle))
                         CreateWidget(target);
                 }
+
+                foreach (var handle in MissingTaskbarObservations.Keys.Where(handle => !Widgets.ContainsKey(handle)).ToArray())
+                    MissingTaskbarObservations.Remove(handle);
             }
             finally
             {
@@ -458,6 +516,143 @@ namespace TaskbarQuota.Taskbar
             => Widgets.Values.FirstOrDefault(widget => widget.IsAlive && widget.IsPrimaryTaskbar)
                 ?? Widgets.Values.FirstOrDefault(widget => widget.IsAlive);
 
+        private static IReadOnlyList<ProviderId> ProvidersForWidget(
+            TaskBarWidget widget,
+            IReadOnlyList<ProviderId> providers)
+        {
+            var available = Widgets.Values
+                .Where(candidate => candidate.IsAlive)
+                .Select(candidate => candidate.DisplayKey)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            string primary = PrimaryWidget()?.DisplayKey ?? widget.DisplayKey;
+            return TaskbarContentRouter.ProvidersForDisplay(
+                providers,
+                WidgetSettingsService.CurrentTaskbarPlacement,
+                WidgetSettingsService.SelectedTaskbarDisplayKey,
+                widget.DisplayKey,
+                primary,
+                available,
+                WidgetSettingsService.GetAdaptiveProviderDisplay);
+        }
+
+        internal static bool ShouldRemoveMissingTaskbar(int consecutiveMisses, bool hostAlive)
+            => !hostAlive || consecutiveMisses >= 2;
+
+        private static void OnTopologyChanged(TopologyChange change)
+            => _dispatcher?.TryEnqueue(() => ScheduleTopologyRecovery(change));
+
+        private static void ScheduleTopologyRecovery(TopologyChange change)
+        {
+            _topologyRecoveryPending = true;
+            _topologyForceReset |= change.RequiresHostReset;
+            _topologyRecoveryAttempts = 0;
+            _topologyRecoveryReason = change.Reason;
+            TopologyStability.Reset();
+
+            _topologyRecoveryTimer ??= CreateTopologyRecoveryTimer();
+            ArmTopologyRecoveryTimer();
+            Log.Information($"Taskbar topology recovery scheduled: reason={change.Reason}, resetHosts={change.RequiresHostReset}");
+        }
+
+        private static DispatcherTimer CreateTopologyRecoveryTimer()
+        {
+            var timer = new DispatcherTimer();
+            timer.Tick += (_, _) =>
+            {
+                timer.Stop();
+                if (!_topologyRecoveryPending)
+                    return;
+
+                if (TryRecoverTaskbarTopology())
+                {
+                    CompleteTopologyRecovery();
+                    return;
+                }
+
+                _topologyRecoveryAttempts++;
+                if (_topologyRecoveryAttempts < MaxTopologyRecoveryAttempts)
+                    ArmTopologyRecoveryTimer();
+                else
+                    Log.Warning($"Taskbar topology did not stabilize after {_topologyRecoveryAttempts} attempts; health checks will continue recovery ({_topologyRecoveryReason})");
+            };
+            return timer;
+        }
+
+        private static void ArmTopologyRecoveryTimer()
+        {
+            if (_topologyRecoveryTimer is not { } timer)
+                return;
+
+            timer.Stop();
+            timer.Interval = SessionTopologyWatcher.RetryDelay(_topologyRecoveryAttempts);
+            timer.Start();
+        }
+
+        private static bool TryRecoverTaskbarTopology()
+        {
+            if (IsFloatingSurface)
+                return true;
+
+            if (!TaskbarWindowTarget.TryFindAll(out var targets) || targets.Count == 0)
+            {
+                TopologyStability.Reset();
+                return false;
+            }
+
+            string signature = string.Join(
+                "|",
+                targets.Select(target => $"{target.Handle.ToInt64():X}:{target.DisplayKey}:{target.IsPrimary}"));
+            if (!TopologyStability.Observe(signature))
+                return false;
+
+            if (_topologyForceReset)
+            {
+                Log.Information($"Rebuilding taskbar hosts after {_topologyRecoveryReason}");
+                DisposeAllTaskbarWidgets();
+                MissingTaskbarObservations.Clear();
+                _topologyForceReset = false;
+            }
+
+            EnsureWidgets();
+            SyncWidgetState();
+
+            return targets.All(target =>
+                Widgets.TryGetValue(target.Handle, out var widget)
+                && widget.IsAlive
+                && widget.IsHostContentReady
+                && string.Equals(widget.DisplayKey, target.DisplayKey, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static void CompleteTopologyRecovery()
+        {
+            _topologyRecoveryTimer?.Stop();
+            _topologyRecoveryPending = false;
+            _topologyForceReset = false;
+            _topologyRecoveryAttempts = 0;
+            TopologyStability.Reset();
+            Log.Information($"Taskbar topology recovery completed ({_topologyRecoveryReason})");
+            _topologyRecoveryReason = string.Empty;
+        }
+
+        private static AgentActivitySnapshot ActivityForWidget(
+            TaskBarWidget widget,
+            AgentActivitySnapshot snapshot)
+        {
+            var available = Widgets.Values
+                .Where(candidate => candidate.IsAlive)
+                .Select(candidate => candidate.DisplayKey)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            string primary = PrimaryWidget()?.DisplayKey ?? widget.DisplayKey;
+            return TaskbarContentRouter.ActivityForDisplay(
+                snapshot,
+                WidgetSettingsService.CurrentTaskbarPlacement,
+                WidgetSettingsService.SelectedTaskbarDisplayKey,
+                widget.DisplayKey,
+                primary,
+                available,
+                WidgetSettingsService.GetAdaptiveProviderDisplay);
+        }
+
         private static void SyncWidgetState()
         {
             if (IsFloatingSurface)
@@ -476,8 +671,8 @@ namespace TaskbarQuota.Taskbar
                 return;
 
             var coordinator = UsageCoordinator.Instance;
-            var providers = coordinator.WidgetDisplayProviders;
-            var activity = AgentActivityService.Instance.Snapshot;
+            var providers = ProvidersForWidget(widget, coordinator.WidgetDisplayProviders);
+            var activity = ActivityForWidget(widget, AgentActivityService.Instance.Snapshot);
 
             widget.SetActivitySnapshot(activity);
             // window over the notification area (#10). The tiles are deliberately left bound while it
@@ -488,7 +683,10 @@ namespace TaskbarQuota.Taskbar
             {
                 widget.SetDisplayProviders(Array.Empty<ProviderId>(), coordinator.ActiveProvider);
                 if (widget.HasVisibleActivity)
+                {
+                    widget.SetVisible(true);
                     widget.SetQuotaVisible(false);
+                }
                 else
                     widget.SetVisible(false);
                 return;
@@ -667,9 +865,9 @@ namespace TaskbarQuota.Taskbar
         private static void ApplyStateChanged(UsageResult result)
         {
             var coordinator = UsageCoordinator.Instance;
-            var providers = coordinator.WidgetDisplayProviders;
+            var allProviders = coordinator.WidgetDisplayProviders;
             var activity = AgentActivityService.Instance.Snapshot;
-            bool isDisplayed = providers.Contains(result.Id);
+            bool isDisplayed = allProviders.Contains(result.Id);
 
             if (IsFloatingSurface)
             {
@@ -688,16 +886,23 @@ namespace TaskbarQuota.Taskbar
                 if (!widget.IsAlive)
                     continue;
 
+                var providers = ProvidersForWidget(widget, allProviders);
+                var routedActivity = ActivityForWidget(widget, activity);
+                bool isDisplayedOnWidget = providers.Contains(result.Id);
+
                 // Reconcile the tile set first, so a provider that just became active already owns a slot
                 // before its result is routed. SetDisplayProviders is a cheap no-op when nothing changed.
-                widget.SetActivitySnapshot(activity);
+                widget.SetActivitySnapshot(routedActivity);
                 // As in SyncWidgetState, clear the quota slots before hiding the quota host so a later
                 // provider return cannot reveal stale tiles.
                 if (providers.Count == 0)
                 {
                     widget.SetDisplayProviders(Array.Empty<ProviderId>(), coordinator.ActiveProvider);
                     if (widget.HasVisibleActivity)
+                    {
+                        widget.SetVisible(true);
                         widget.SetQuotaVisible(false);
+                    }
                     else
                         widget.SetVisible(false);
                     continue;
@@ -705,7 +910,7 @@ namespace TaskbarQuota.Taskbar
 
                 widget.SetDisplayProviders(providers, coordinator.ActiveProvider);
                 widget.SetVisible(true);
-                if (!isDisplayed)
+                if (!isDisplayedOnWidget)
                     continue;
 
                 widget.ApplyResult(result);
@@ -745,8 +950,42 @@ namespace TaskbarQuota.Taskbar
         /// coordinator so it can re-detect whether a provider is in front without waiting for the
         /// next 500 ms tick — this is what makes "switch away" hide the widget right away.
         /// </summary>
-        private static void OnForegroundChanged()
+        private static void OnForegroundChanged(IntPtr _)
             => UsageCoordinator.Instance.NotifyForegroundChanged();
+
+        private static void OnProviderWindowObserved(ProviderId provider, IntPtr hwnd)
+        {
+            string displayKey = TaskbarWindowTarget.GetDisplayKeyForWindow(hwnd);
+            if (displayKey.Length == 0)
+                return;
+
+            _dispatcher?.TryEnqueue(() => RecordAdaptiveProviderDisplay(provider, displayKey));
+        }
+
+        private static void OnWindowMoveSizeEnded(IntPtr hwnd)
+        {
+            if (hwnd == IntPtr.Zero || User32.GetForegroundWindow() != hwnd)
+                return;
+            if (UsageCoordinator.Instance.ActiveProvider is not { } provider)
+                return;
+
+            string displayKey = TaskbarWindowTarget.GetDisplayKeyForWindow(hwnd);
+            if (displayKey.Length != 0)
+                RecordAdaptiveProviderDisplay(provider, displayKey);
+        }
+
+        private static void RecordAdaptiveProviderDisplay(ProviderId provider, string displayKey)
+        {
+            if (!WidgetSettingsService.SetAdaptiveProviderDisplay(provider, displayKey))
+                return;
+
+            Log.Information($"Adaptive placement: provider={provider}, display={displayKey}");
+            if (!IsFloatingSurface
+                && WidgetSettingsService.CurrentTaskbarPlacement == TaskbarPlacementMode.Adaptive)
+            {
+                SyncWidgetState();
+            }
+        }
 
         private static void OnActiveToolPresenceChanged(bool isPresent)
             => _dispatcher?.TryEnqueue(() => ApplyActiveToolPresenceChanged(isPresent));
@@ -763,37 +1002,8 @@ namespace TaskbarQuota.Taskbar
             SyncWidgetState();
         }
 
-        private static void OnActivityChanged(AgentActivitySnapshot snapshot)
-            => _dispatcher?.TryEnqueue(() =>
-            {
-                if (IsFloatingSurface)
-                {
-                    SyncFloatingState();
-                    return;
-                }
-
-                foreach (var widget in Widgets.Values.ToArray())
-                {
-                    if (!widget.IsAlive)
-                        continue;
-
-                    widget.SetActivitySnapshot(snapshot);
-                    var providers = UsageCoordinator.Instance.WidgetDisplayProviders;
-                    if (providers.Count == 0)
-                    {
-                        widget.SetDisplayProviders(Array.Empty<ProviderId>(), UsageCoordinator.Instance.ActiveProvider);
-                        if (widget.HasVisibleActivity)
-                            widget.SetQuotaVisible(false);
-                        else
-                            widget.SetVisible(false);
-                    }
-                    else
-                    {
-                        widget.SetDisplayProviders(providers, UsageCoordinator.Instance.ActiveProvider);
-                        widget.SetVisible(true);
-                    }
-                }
-            });
+        private static void OnActivityChanged(AgentActivitySnapshot _)
+            => _dispatcher?.TryEnqueue(SyncWidgetState);
 
         private static void OnWidgetSettingsChanged(object? sender, EventArgs e)
         {
@@ -812,6 +1022,7 @@ namespace TaskbarQuota.Taskbar
             UsageCoordinator.Instance.StateChanged -= OnStateChanged;
             UsageCoordinator.Instance.ActiveProviderChanged -= OnActiveProviderChanged;
             UsageCoordinator.Instance.ActiveToolPresenceChanged -= OnActiveToolPresenceChanged;
+            UsageCoordinator.Instance.ProviderWindowObserved -= OnProviderWindowObserved;
             AgentActivityService.Instance.Changed -= OnActivityChanged;
             UsageCoordinator.Instance.ProviderForegroundChanged -= OnProviderForegroundChanged;
             UsageCoordinator.Instance.IsOwnUiEngaged = null;
@@ -819,6 +1030,14 @@ namespace TaskbarQuota.Taskbar
             _initialized = false;
             _widgetHealthTimer?.Stop();
             _widgetHealthTimer = null;
+            _topologyRecoveryTimer?.Stop();
+            _topologyRecoveryTimer = null;
+            _topologyRecoveryPending = false;
+            _topologyForceReset = false;
+            _topologyRecoveryAttempts = 0;
+            _topologyRecoveryReason = string.Empty;
+            TopologyStability.Reset();
+            MissingTaskbarObservations.Clear();
             _activityTimer?.Stop();
             _activityTimer = null;
             _activityCts?.Cancel();
@@ -827,8 +1046,15 @@ namespace TaskbarQuota.Taskbar
             if (_foregroundWatcher is { } watcher)
             {
                 watcher.ForegroundChanged -= OnForegroundChanged;
+                watcher.WindowMoveSizeEnded -= OnWindowMoveSizeEnded;
                 watcher.Dispose();
                 _foregroundWatcher = null;
+            }
+            if (_sessionTopologyWatcher is { } topologyWatcher)
+            {
+                topologyWatcher.Changed -= OnTopologyChanged;
+                topologyWatcher.Dispose();
+                _sessionTopologyWatcher = null;
             }
             if (_trayIcon != null) { _trayIcon.TryRemove(); _trayIcon.Dispose(); _trayIcon = null; }
             try { _flyout?.Close(); } catch { }

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -700,13 +700,14 @@ namespace TaskbarQuota.Taskbar
 
             var coordinator = UsageCoordinator.Instance;
             var providers = ProvidersForWidget(widget, coordinator.WidgetDisplayProviders);
-            var activity = ActivityForWidget(widget, AgentActivityService.Instance.Snapshot);
+            var sourceActivity = AgentActivityService.Instance.Snapshot;
+            var activity = ActivityForWidget(widget, sourceActivity);
 
-            widget.SetActivitySnapshot(activity);
-            // window over the notification area (#10). The tiles are deliberately left bound while it
-            // hides: unbinding collapses them in the same frame, which wiped out the fade and made the
-            // widget look like it had blinked out of existence. SetVisible re-binds nothing on the way
-            // back in either — the set below runs first on show.
+            // A non-empty source filtered to empty by the selected-screen policy is intentional and must
+            // hide immediately. Reserve the empty grace period for genuinely empty scanner snapshots.
+            widget.SetActivitySnapshot(activity, allowEmptyGrace: sourceActivity.Primary is null);
+            // Keep outgoing tiles bound until the host fade completes. Clearing them first makes the
+            // animation run over an empty window and turns a cross-screen handoff into a visible blink.
             if (providers.Count == 0)
             {
                 widget.SetDisplayProviders(Array.Empty<ProviderId>(), ActiveProviderForWidget(widget, coordinator.ActiveProvider));
@@ -924,9 +925,9 @@ namespace TaskbarQuota.Taskbar
 
                 // Reconcile the tile set first, so a provider that just became active already owns a slot
                 // before its result is routed. SetDisplayProviders is a cheap no-op when nothing changed.
-                widget.SetActivitySnapshot(routedActivity);
-                // As in SyncWidgetState, clear the quota slots before hiding the quota host so a later
-                // provider return cannot reveal stale tiles.
+                widget.SetActivitySnapshot(routedActivity, allowEmptyGrace: activity.Primary is null);
+                // Keep the outgoing slots bound until their fade completes; the widget clears them in the
+                // completion callback, guarded so an interrupted hide cannot erase a returning provider.
                 if (providers.Count == 0)
                 {
                     widget.SetDisplayProviders(Array.Empty<ProviderId>(), ActiveProviderForWidget(widget, coordinator.ActiveProvider));

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -151,13 +151,14 @@ namespace TaskbarQuota.Taskbar
         private Microsoft.UI.Xaml.FrameworkElement? activityHostContent;
         // Show/hide cross-fade state. Short on purpose: the widget lives on the taskbar, so anything
         // slower reads as lag rather than as a transition.
-        private const int HostFadeMilliseconds = 100;
+        private const int HostFadeMilliseconds = 160;
         private Anim.Storyboard? hostFadeStoryboard;
         private Anim.Storyboard? activityFadeStoryboard;
         private Anim.Storyboard? quotaLayoutStoryboard;
         private Anim.Storyboard? activityLayoutStoryboard;
         private int hostFadeGeneration;
         private int activityFadeGeneration;
+        private bool quotaHideInProgress;
         private int WidgetHostWidth;
         private int ActivityHostWidth;
         private int currentOffsetX = int.MinValue;
@@ -567,6 +568,7 @@ namespace TaskbarQuota.Taskbar
 
             if (visible)
             {
+                quotaHideInProgress = false;
                 QueuePositionUpdate(TaskbarChangeReason.None);
                 if (hostContent is not null)
                     hostContent.Opacity = 0;
@@ -688,6 +690,53 @@ namespace TaskbarQuota.Taskbar
                 classicTaskbarReservation.Restore();
                 appWindow.Hide();
             }
+        }
+
+        /// <summary>
+        /// Fades the outgoing quota content before clearing its slots. Keeping the old pixels alive for
+        /// the fade lets another display reveal the incoming provider in the same frame, producing a
+        /// cross-screen handoff instead of an empty-window blink.
+        /// </summary>
+        public void HideDisplayProviders(ProviderId? activeProvider, bool keepActivityVisible)
+        {
+            if (appWindow is null)
+                return;
+
+            // A hide already in flight owns the eventual clear. Re-entering on every activity/usage
+            // publish would restart the storyboard indefinitely.
+            if (quotaHideInProgress || !isVisible && !appWindow.IsVisible)
+                return;
+
+            isVisible = false;
+            quotaHideInProgress = true;
+            hostFadeGeneration++;
+            int generation = hostFadeGeneration;
+
+            if (isDragging)
+                EndDragging(revert: true);
+
+            void CompleteHide()
+            {
+                if (generation != hostFadeGeneration || destroyed || appWindow is null)
+                    return;
+
+                quotaHideInProgress = false;
+                SetDisplayProviders(Array.Empty<ProviderId>(), activeProvider);
+                classicTaskbarReservation.Restore();
+                appWindow.Hide();
+                if (!keepActivityVisible)
+                    activityAppWindow?.Hide();
+                if (hostContent is { } content)
+                    content.Opacity = 1;
+            }
+
+            if (hostContent is null)
+            {
+                CompleteHide();
+                return;
+            }
+
+            AnimateHostOpacity(0, CompleteHide);
         }
 
         private Microsoft.UI.Xaml.Controls.StackPanel BuildSummaryPanel()

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -753,9 +753,9 @@ namespace TaskbarQuota.Taskbar
 
         private void WidgetSummary_DesiredHostWidthChanged(int logicalWidth) => RecomputeLayout();
 
-        public void SetActivitySnapshot(AgentActivitySnapshot snapshot)
+        public void SetActivitySnapshot(AgentActivitySnapshot snapshot, bool allowEmptyGrace = true)
         {
-            if (snapshot.Primary is null && activitySnapshot.Primary is not null)
+            if (ShouldDeferEmptyActivitySnapshot(activitySnapshot, snapshot, allowEmptyGrace))
             {
                 // Discovery can publish an empty intermediate snapshot while transcript sources are being
                 // rescanned. Keep the visible activity island for a short grace period instead of hiding
@@ -770,6 +770,12 @@ namespace TaskbarQuota.Taskbar
             pendingEmptyActivitySnapshot = null;
             ApplyActivitySnapshot(snapshot);
         }
+
+        internal static bool ShouldDeferEmptyActivitySnapshot(
+            AgentActivitySnapshot current,
+            AgentActivitySnapshot next,
+            bool allowEmptyGrace)
+            => allowEmptyGrace && next.Primary is null && current.Primary is not null;
 
         private void ActivityEmptySnapshotTimer_Tick(object? sender, object e)
         {

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Input;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
@@ -67,6 +68,7 @@ namespace TaskbarQuota.Taskbar
 
         private static readonly bool IsRtlUI = System.Globalization.CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft;
         private static readonly object WindowClassLock = new();
+        private static readonly ConcurrentDictionary<IntPtr, WeakReference<TaskBarWidget>> HostOwners = new();
         private static readonly WndProc SharedWndProc = SharedWindowProc;
         private static bool windowClassRegistered;
         private static int windowClassUsers;
@@ -76,8 +78,8 @@ namespace TaskbarQuota.Taskbar
         private int RepositionDeadbandPx => (int)Math.Ceiling(2 * dpiScale);
         private int TrayClearancePx => (int)Math.Ceiling(TrayClearanceLogicalPx * dpiScale);
 
-        private readonly double dpiScale;
-        private readonly uint taskbarDpi;
+        private double dpiScale;
+        private uint taskbarDpi;
         private readonly IntPtr hwndShell;
         private readonly IntPtr hwndTrayNotify;
         private readonly IntPtr hwndReBar;
@@ -94,6 +96,9 @@ namespace TaskbarQuota.Taskbar
         private readonly CancellationTokenSource positionUpdateCancellation = new();
         private readonly SemaphoreSlim positionUpdateGate = new(1, 1);
         private readonly object positionRequestLock = new();
+        private readonly DpiChangeDebouncer dpiChangeDebouncer = new();
+        private string? pendingDisplayKey;
+        private int pendingDisplayKeySamples;
 
         private IntPtr hwnd;
         private AppWindow? appWindow;
@@ -226,18 +231,10 @@ namespace TaskbarQuota.Taskbar
         /// <summary>True once <see cref="Initialize"/> has built the tile panel. A live window without it can
         /// render nothing at all, so the manager treats that pairing as a dead widget and recreates it.</summary>
         public bool IsHostContentReady => summaryPanel is not null;
-        public bool IsDpiCurrent
-        {
-            get
-            {
-                if (!User32.IsWindow(hwndShell))
-                    return false;
-                uint currentDpi = User32.GetDpiForWindow(hwndShell);
-                return (currentDpi == 0 ? 96u : currentDpi) == taskbarDpi;
-            }
-        }
+        public uint CurrentDpi => taskbarDpi;
         public IntPtr TaskbarHandle => hwndShell;
         public bool IsPrimaryTaskbar => isPrimaryTaskbar;
+        public string DisplayKey => displayKey;
         /// <summary>
         /// Supplies the best available snapshot for a provider when a slot is (re)assigned to it, so a
         /// re-ordered tile paints its new provider immediately instead of holding the previous one's rows
@@ -439,6 +436,113 @@ namespace TaskbarQuota.Taskbar
             => target.Handle == hwndShell
                 && target.IsPrimary == isPrimaryTaskbar
                 && string.Equals(target.DisplayKey, displayKey, StringComparison.Ordinal);
+
+        /// <summary>
+        /// Display identity can be temporarily unavailable while Explorer rebuilds its monitor topology.
+        /// Require the same changed key twice before replacing a healthy XAML island.
+        /// </summary>
+        public bool IsConfirmedTargetMismatch(TaskbarWindowTarget target)
+        {
+            if (target.Handle != hwndShell || target.IsPrimary != isPrimaryTaskbar)
+                return true;
+            if (string.Equals(target.DisplayKey, displayKey, StringComparison.OrdinalIgnoreCase))
+            {
+                pendingDisplayKey = null;
+                pendingDisplayKeySamples = 0;
+                return false;
+            }
+
+            if (!string.Equals(pendingDisplayKey, target.DisplayKey, StringComparison.OrdinalIgnoreCase))
+            {
+                pendingDisplayKey = target.DisplayKey;
+                pendingDisplayKeySamples = 1;
+                return false;
+            }
+
+            return ++pendingDisplayKeySamples >= 2;
+        }
+
+        /// <summary>Health-check fallback for DPI notifications lost during an Explorer topology rebuild.</summary>
+        public void RefreshDpiFromWindows()
+        {
+            // The Explorer taskbar is the canonical scale owner. The injected host can briefly retain its
+            // previous DPI while parent-change messages are still traversing the child window tree.
+            IntPtr source = hwndShell;
+            if (source == IntPtr.Zero || !User32.IsWindow(source))
+                return;
+
+            uint observed = User32.GetDpiForWindow(source);
+            observed = observed == 0 ? 96u : observed;
+            if (dpiChangeDebouncer.Observe(taskbarDpi, observed))
+                ApplyDpi(observed, "health-check");
+        }
+
+        private void HandleHostDpiNotification(IntPtr changedHwnd, bool authoritative)
+        {
+            if (disposedValue || changedHwnd == IntPtr.Zero || !User32.IsWindow(changedHwnd))
+                return;
+
+            uint observed = User32.GetDpiForWindow(changedHwnd);
+            observed = observed == 0 ? 96u : observed;
+            if (authoritative || dpiChangeDebouncer.Observe(taskbarDpi, observed))
+                ApplyDpi(observed, authoritative ? "window-message" : "display-change");
+        }
+
+        private void ApplyDpi(uint newDpi, string source)
+        {
+            if (newDpi == 0)
+                newDpi = 96;
+            if (newDpi == taskbarDpi)
+            {
+                dpiChangeDebouncer.Reset();
+                return;
+            }
+
+            uint previousDpi = taskbarDpi;
+            int nextActivityWidth = RescalePhysicalWidth(
+                ActivityHostWidth,
+                previousDpi,
+                newDpi,
+                AgentActivitySummary.MinimumLogicalWidth);
+            taskbarDpi = newDpi;
+            dpiScale = newDpi / 96d;
+            dpiChangeDebouncer.Reset();
+
+            ActivityHostWidth = nextActivityWidth;
+            int taskbarHeight = appWindow?.Size.Height ?? 0;
+            if (User32.GetWindowRect(hwndShell, out RECT taskbarRect)
+                && taskbarRect.bottom > taskbarRect.top)
+            {
+                taskbarHeight = taskbarRect.bottom - taskbarRect.top;
+            }
+
+            if (taskbarHeight > 0)
+            {
+                appWindow?.ResizeClient(new SizeInt32(WidgetHostWidth, taskbarHeight));
+                activityAppWindow?.ResizeClient(new SizeInt32(ActivityHostWidth, taskbarHeight));
+            }
+
+            lastWidgetsButtonClientRect = null;
+            lastTaskButtonClientRects.Clear();
+            availableLogicalWidth = DefaultAvailableLogicalWidth;
+            Log.Information(
+                $"Taskbar widget DPI updated in place: taskbar=0x{hwndShell.ToInt64():X}, {previousDpi}->{newDpi}, source={source}");
+            RecomputeLayout(forceReposition: true);
+        }
+
+        internal static int RescalePhysicalWidth(
+            int physicalWidth,
+            uint previousDpi,
+            uint newDpi,
+            int minimumLogicalWidth = 0)
+        {
+            double oldScale = (previousDpi == 0 ? 96u : previousDpi) / 96d;
+            double nextScale = (newDpi == 0 ? 96u : newDpi) / 96d;
+            int logicalWidth = Math.Max(
+                minimumLogicalWidth,
+                (int)Math.Round(physicalWidth / oldScale));
+            return (int)Math.Ceiling(logicalWidth * nextScale);
+        }
 
         /// <summary>
         /// Shows or hides the widget with a short cross-fade. A native window can't be animated, so the
@@ -3001,10 +3105,39 @@ namespace TaskbarQuota.Taskbar
 
         private IntPtr CreateHostWindow(IntPtr parent)
         {
-            RegisterWindowClass();
-            return User32.CreateWindowEx(
-                WindowStylesExtended.WS_EX_LAYERED, WidgetClassName, "WidgetHost",
-                WindowStyles.WS_POPUP, 0, 0, 0, 0, parent, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+            IntPtr previousContext = IntPtr.Zero;
+            IntPtr targetContext = User32.GetWindowDpiAwarenessContext(parent);
+            if (targetContext != IntPtr.Zero)
+                previousContext = User32.SetThreadDpiAwarenessContext(targetContext);
+
+            try
+            {
+                RegisterWindowClass();
+                // A layered popup is retained for compatibility with the existing XAML-island injection,
+                // but create it on the target monitor rather than at virtual-screen (0,0). This gives the
+                // host the correct initial per-monitor scale before it is reparented into Explorer.
+                int x = 0;
+                int y = 0;
+                if (User32.GetWindowRect(parent, out RECT parentRect))
+                {
+                    x = parentRect.left;
+                    y = parentRect.top;
+                }
+
+                IntPtr created = User32.CreateWindowEx(
+                    WindowStylesExtended.WS_EX_LAYERED, WidgetClassName, "WidgetHost",
+                    WindowStyles.WS_POPUP, x, y, 0, 0, parent, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+                if (created == IntPtr.Zero)
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), "Could not create the taskbar widget host window.");
+
+                HostOwners[created] = new WeakReference<TaskBarWidget>(this);
+                return created;
+            }
+            finally
+            {
+                if (previousContext != IntPtr.Zero)
+                    User32.SetThreadDpiAwarenessContext(previousContext);
+            }
         }
 
         private void RegisterWindowClass()
@@ -3040,7 +3173,29 @@ namespace TaskbarQuota.Taskbar
         }
 
         private static IntPtr SharedWindowProc(IntPtr hWnd, uint uMsg, IntPtr wParam, IntPtr lParam)
-            => User32.DefWindowProc(hWnd, uMsg, wParam, lParam);
+        {
+            if (uMsg == User32.WM_NCDESTROY)
+            {
+                HostOwners.TryRemove(hWnd, out _);
+            }
+            else if (uMsg is User32.WM_DPICHANGED
+                or User32.WM_DPICHANGED_BEFOREPARENT
+                or User32.WM_DPICHANGED_AFTERPARENT
+                or User32.WM_DISPLAYCHANGE)
+            {
+                bool authoritative = uMsg is User32.WM_DPICHANGED
+                    or User32.WM_DPICHANGED_BEFOREPARENT
+                    or User32.WM_DPICHANGED_AFTERPARENT;
+                if (HostOwners.TryGetValue(hWnd, out var weak)
+                    && weak.TryGetTarget(out var owner))
+                {
+                    App.Dispatcher?.TryEnqueue(
+                        () => owner.HandleHostDpiNotification(hWnd, authoritative));
+                }
+            }
+
+            return User32.DefWindowProc(hWnd, uMsg, wParam, lParam);
+        }
 
         private void ReleaseWindowClass()
         {
@@ -3190,6 +3345,10 @@ namespace TaskbarQuota.Taskbar
 
         private void DisposeWindowResources()
         {
+            if (hwnd != IntPtr.Zero)
+                HostOwners.TryRemove(hwnd, out _);
+            if (activityHwnd != IntPtr.Zero)
+                HostOwners.TryRemove(activityHwnd, out _);
             try
             {
                 if (!destroyed)

--- a/src/TaskbarQuota.App/Taskbar/TaskbarContentRouter.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskbarContentRouter.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TaskbarQuota.AgentActivity;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.Taskbar;
+
+/// <summary>Pure routing rules for distributing quota and activity content between taskbars.</summary>
+internal static class TaskbarContentRouter
+{
+    public static IReadOnlyList<ProviderId> ProvidersForDisplay(
+        IReadOnlyList<ProviderId> providers,
+        TaskbarPlacementMode mode,
+        string selectedDisplayKey,
+        string targetDisplayKey,
+        string primaryDisplayKey,
+        IReadOnlySet<string> availableDisplayKeys,
+        Func<ProviderId, string?> adaptiveDisplayForProvider)
+        => providers
+            .Where(provider => IsRoutedToDisplay(
+                provider,
+                mode,
+                selectedDisplayKey,
+                targetDisplayKey,
+                primaryDisplayKey,
+                availableDisplayKeys,
+                adaptiveDisplayForProvider))
+            .ToArray();
+
+    public static AgentActivitySnapshot ActivityForDisplay(
+        AgentActivitySnapshot snapshot,
+        TaskbarPlacementMode mode,
+        string selectedDisplayKey,
+        string targetDisplayKey,
+        string primaryDisplayKey,
+        IReadOnlySet<string> availableDisplayKeys,
+        Func<ProviderId, string?> adaptiveDisplayForProvider)
+    {
+        if (mode == TaskbarPlacementMode.AllDisplays)
+            return snapshot;
+
+        var items = snapshot.Items
+            .Where(item => IsRoutedToDisplay(
+                item.Provider,
+                mode,
+                selectedDisplayKey,
+                targetDisplayKey,
+                primaryDisplayKey,
+                availableDisplayKeys,
+                adaptiveDisplayForProvider))
+            .ToArray();
+        var runItems = snapshot.RunItems?
+            .Where(item => IsRoutedToDisplay(
+                item.Provider,
+                mode,
+                selectedDisplayKey,
+                targetDisplayKey,
+                primaryDisplayKey,
+                availableDisplayKeys,
+                adaptiveDisplayForProvider))
+            .ToArray();
+        return new AgentActivitySnapshot(items, runItems);
+    }
+
+    internal static bool IsRoutedToDisplay(
+        ProviderId provider,
+        TaskbarPlacementMode mode,
+        string selectedDisplayKey,
+        string targetDisplayKey,
+        string primaryDisplayKey,
+        IReadOnlySet<string> availableDisplayKeys,
+        Func<ProviderId, string?> adaptiveDisplayForProvider)
+    {
+        if (mode == TaskbarPlacementMode.AllDisplays)
+            return true;
+
+        string destination = mode == TaskbarPlacementMode.SelectedDisplay
+            ? selectedDisplayKey
+            : adaptiveDisplayForProvider(provider) ?? string.Empty;
+
+        // A disconnected/unknown selection must not make content disappear. It temporarily falls back
+        // to the primary taskbar while retaining the persisted destination for when that display returns.
+        if (destination.Length == 0 || !availableDisplayKeys.Contains(destination))
+            destination = primaryDisplayKey;
+
+        return string.Equals(destination, targetDisplayKey, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/TaskbarQuota.App/Taskbar/TaskbarContentRouter.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskbarContentRouter.cs
@@ -9,6 +9,25 @@ namespace TaskbarQuota.Taskbar;
 /// <summary>Pure routing rules for distributing quota and activity content between taskbars.</summary>
 internal static class TaskbarContentRouter
 {
+    public static IReadOnlyList<ProviderId> AdaptiveCandidatesForDisplay(
+        IReadOnlyList<ProviderId> providers,
+        ProviderId? currentProvider,
+        Func<ProviderId, bool> isVisible,
+        Func<ProviderId, bool> isPinned)
+    {
+        var result = new List<ProviderId>();
+        if (currentProvider is { } current && isVisible(current))
+            result.Add(current);
+
+        foreach (var provider in providers)
+        {
+            if (isPinned(provider) && !result.Contains(provider))
+                result.Add(provider);
+        }
+
+        return result;
+    }
+
     public static IReadOnlyList<ProviderId> ProvidersForDisplay(
         IReadOnlyList<ProviderId> providers,
         TaskbarPlacementMode mode,

--- a/src/TaskbarQuota.App/Taskbar/TaskbarContentRouter.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskbarContentRouter.cs
@@ -16,7 +16,9 @@ internal static class TaskbarContentRouter
         string targetDisplayKey,
         string primaryDisplayKey,
         IReadOnlySet<string> availableDisplayKeys,
-        Func<ProviderId, string?> adaptiveDisplayForProvider)
+        Func<ProviderId, string?> adaptiveDisplayForProvider,
+        Func<ProviderId, bool> isPinned,
+        Func<ProviderId, string?> pinnedDisplayForProvider)
         => providers
             .Where(provider => IsRoutedToDisplay(
                 provider,
@@ -25,7 +27,9 @@ internal static class TaskbarContentRouter
                 targetDisplayKey,
                 primaryDisplayKey,
                 availableDisplayKeys,
-                adaptiveDisplayForProvider))
+                adaptiveDisplayForProvider,
+                isPinned,
+                pinnedDisplayForProvider))
             .ToArray();
 
     public static AgentActivitySnapshot ActivityForDisplay(
@@ -70,14 +74,32 @@ internal static class TaskbarContentRouter
         string targetDisplayKey,
         string primaryDisplayKey,
         IReadOnlySet<string> availableDisplayKeys,
-        Func<ProviderId, string?> adaptiveDisplayForProvider)
+        Func<ProviderId, string?> adaptiveDisplayForProvider,
+        Func<ProviderId, bool>? isPinned = null,
+        Func<ProviderId, string?>? pinnedDisplayForProvider = null)
     {
         if (mode == TaskbarPlacementMode.AllDisplays)
             return true;
 
-        string destination = mode == TaskbarPlacementMode.SelectedDisplay
-            ? selectedDisplayKey
-            : adaptiveDisplayForProvider(provider) ?? string.Empty;
+        string destination;
+        if (mode == TaskbarPlacementMode.SelectedDisplay)
+        {
+            destination = selectedDisplayKey;
+        }
+        else
+        {
+            string? pinnedDestination = isPinned?.Invoke(provider) == true
+                ? pinnedDisplayForProvider?.Invoke(provider)
+                : null;
+            if (string.Equals(
+                pinnedDestination,
+                WidgetSettingsService.AllDisplaysPinDestination,
+                StringComparison.Ordinal))
+            {
+                return true;
+            }
+            destination = pinnedDestination ?? adaptiveDisplayForProvider(provider) ?? string.Empty;
+        }
 
         // A disconnected/unknown selection must not make content disappear. It temporarily falls back
         // to the primary taskbar while retaining the persisted destination for when that display returns.

--- a/src/TaskbarQuota.App/Taskbar/TaskbarStructureWatcher.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskbarStructureWatcher.cs
@@ -51,10 +51,21 @@ namespace TaskbarQuota.Taskbar
                 bool isCentered = SystemInfos.IsTaskBarCentered();
                 bool isHidden = IsTaskbarHidden();
 
-                var reason = TaskbarChangeReason.Other;
-                if (isWidgets != widgetsButtonEnabled) { reason = TaskbarChangeReason.WidgetsButton; widgetsButtonEnabled = isWidgets; }
-                else if (isCentered != taskbarCentered) { reason = TaskbarChangeReason.Alignment; taskbarCentered = isCentered; }
-                else if (isHidden != taskbarHidden) { reason = TaskbarChangeReason.Visibility; taskbarHidden = isHidden; }
+                var reason = DetectChangeReason(
+                    widgetsButtonEnabled,
+                    taskbarCentered,
+                    taskbarHidden,
+                    isWidgets,
+                    isCentered,
+                    isHidden);
+                if (reason == TaskbarChangeReason.None)
+                    return;
+
+                // Commit one coherent snapshot. If several shell properties changed together, the priority
+                // reason still describes the refresh while the next poll sees the complete new baseline.
+                widgetsButtonEnabled = isWidgets;
+                taskbarCentered = isCentered;
+                taskbarHidden = isHidden;
 
                 TaskbarChangedNotificationCompleted?.Invoke(this, new TaskbarChangedEventArgs
                 {
@@ -65,6 +76,23 @@ namespace TaskbarQuota.Taskbar
                 });
             }
             catch { /* best-effort */ }
+        }
+
+        internal static TaskbarChangeReason DetectChangeReason(
+            bool previousWidgets,
+            bool previousCentered,
+            bool previousHidden,
+            bool currentWidgets,
+            bool currentCentered,
+            bool currentHidden)
+        {
+            if (currentWidgets != previousWidgets)
+                return TaskbarChangeReason.WidgetsButton;
+            if (currentCentered != previousCentered)
+                return TaskbarChangeReason.Alignment;
+            if (currentHidden != previousHidden)
+                return TaskbarChangeReason.Visibility;
+            return TaskbarChangeReason.None;
         }
 
         /// <summary>
@@ -206,8 +234,11 @@ namespace TaskbarQuota.Taskbar
             WindowId id = Win32Interop.GetWindowIdFromWindow(hwndTaskbar);
             var area = DisplayArea.GetFromWindowId(id, DisplayAreaFallback.Primary);
             User32.GetWindowRect(hwndTaskbar, out var rect);
-            return rect.bottom > area.OuterBounds.Height;
+            return IsAutoHideTaskbarOffscreen(rect.bottom, area.OuterBounds.Y, area.OuterBounds.Height);
         }
+
+        internal static bool IsAutoHideTaskbarOffscreen(int taskbarBottom, int displayTop, int displayHeight)
+            => taskbarBottom > displayTop + displayHeight;
 
         public void Dispose()
         {

--- a/src/TaskbarQuota.App/Taskbar/TaskbarWindowTarget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskbarWindowTarget.cs
@@ -14,6 +14,8 @@ namespace TaskbarQuota.Taskbar
         internal const string PrimaryClassName = "Shell_TrayWnd";
         internal const string SecondaryClassName = "Shell_SecondaryTrayWnd";
 
+        public int DisplayNumber => TryGetDisplayNumber(DisplayKey);
+
         public static bool TryFindAll(out IReadOnlyList<TaskbarWindowTarget> result)
         {
             var targets = new List<TaskbarWindowTarget>();
@@ -74,6 +76,39 @@ namespace TaskbarQuota.Taskbar
         internal static string BuildPositionFileName(string displayKey)
             => $"taskbar-widget-position-{displayKey}.txt";
 
+        internal static int TryGetDisplayNumber(string? displayKey)
+        {
+            const string prefix = "DISPLAY";
+            if (string.IsNullOrWhiteSpace(displayKey)
+                || !displayKey.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return 0;
+            }
+
+            return int.TryParse(
+                displayKey.AsSpan(prefix.Length),
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out int number)
+                    ? number
+                    : 0;
+        }
+
+        internal static string GetDisplayKeyForWindow(IntPtr hwnd)
+        {
+            if (hwnd == IntPtr.Zero || !User32.IsWindow(hwnd))
+                return string.Empty;
+
+            var monitor = User32.MonitorFromWindow(hwnd, MonitorFromFlags.MONITOR_DEFAULTTONULL);
+            if (monitor == IntPtr.Zero)
+                return string.Empty;
+
+            var info = MONITORINFOEX.Create();
+            return User32.GetMonitorInfo(monitor, ref info)
+                ? BuildDisplayKey(info.szDevice, info.rcMonitor)
+                : string.Empty;
+        }
+
         private static bool EnumTaskbarWindow(IntPtr hwnd, IntPtr lParam)
         {
             var builder = new StringBuilder(64);
@@ -83,6 +118,8 @@ namespace TaskbarQuota.Taskbar
                 && GCHandle.FromIntPtr(lParam).Target is List<TaskbarWindowTarget> targets)
             {
                 var bounds = GetBounds(hwnd);
+                if (bounds.right <= bounds.left || bounds.bottom <= bounds.top)
+                    return true;
                 targets.Add(new TaskbarWindowTarget(
                     hwnd,
                     isPrimary,

--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using TaskbarQuota.ActiveApp;
+using TaskbarQuota.Interop;
 using TaskbarQuota.Usage;
 
 namespace TaskbarQuota
@@ -345,6 +346,8 @@ namespace TaskbarQuota
         public event Action<UsageResult>? StateChanged;
         public event Action<bool>? ActiveToolPresenceChanged;
         public event Action<ProviderId?>? ActiveProviderChanged;
+        /// <summary>Raised whenever foreground detection confidently associates a provider with a window.</summary>
+        public event Action<ProviderId, IntPtr>? ProviderWindowObserved;
 
         public void Start()
         {
@@ -1074,6 +1077,9 @@ namespace TaskbarQuota
                     _lastActive = p;
                     _activeProviderSource = detectedSource;
                     PromoteRecentProvider(p);
+                    var foregroundWindow = User32.GetForegroundWindow();
+                    if (foregroundWindow != IntPtr.Zero)
+                        ProviderWindowObserved?.Invoke(p, foregroundWindow);
                     if (previousActive != p)
                     {
                         ActiveProviderChanged?.Invoke(p);

--- a/src/TaskbarQuota.App/Views/DashboardPage.xaml
+++ b/src/TaskbarQuota.App/Views/DashboardPage.xaml
@@ -553,7 +553,8 @@
                                           Click="ProviderPinToggle_Click">
                                 <StackPanel Orientation="Horizontal" Spacing="6">
                                     <FontIcon Glyph="&#xE718;" FontSize="14"/>
-                                    <TextBlock Text="{x:Bind ViewModel.SelectedCard.ProviderPinToggleText, Mode=OneWay}"/>
+                                    <TextBlock x:Name="ProviderPinText"
+                                               Text="{x:Bind ViewModel.SelectedCard.ProviderPinToggleText, Mode=OneWay}"/>
                                 </StackPanel>
                             </ToggleButton>
                             <ToggleButton x:Name="ProviderWidgetToggle"

--- a/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
@@ -11,6 +11,7 @@ using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Xaml.Navigation;
 using TaskbarQuota.Usage;
 using TaskbarQuota.Services;
+using TaskbarQuota.Taskbar;
 using TaskbarQuota.ViewModels;
 using Windows.System;
 
@@ -25,6 +26,7 @@ namespace TaskbarQuota.Views
         private Storyboard? _selectionStoryboard;
         private TranslateTransform? _dashboardTranslate;
         private ProviderId? _lastAnimatedProvider;
+        private string _pinHereDisplayKey = string.Empty;
 
         public DashboardViewModel ViewModel { get; }
         public static DashboardViewModel? SharedViewModel { get; set; }
@@ -34,6 +36,16 @@ namespace TaskbarQuota.Views
 
         public static void SetSuppressWidgetEvents(bool suppress)
             => _suppressWidgetEvents = suppress;
+
+        /// <summary>
+        /// Gives the compact taskbar flyout a contextual pin target. The main dashboard leaves this empty,
+        /// so its pin action preserves the provider's configured destination.
+        /// </summary>
+        public void SetPinHereDisplay(string? displayKey)
+        {
+            _pinHereDisplayKey = displayKey?.Trim() ?? string.Empty;
+            UpdatePinPresentation(ViewModel.SelectedCard);
+        }
 
         public DashboardPage()
         {
@@ -46,10 +58,12 @@ namespace TaskbarQuota.Views
             ViewModel.SelectedCardChanged += OnSelectedCardChanged;
             ViewModel.DetailContentWidthChanged += OnDetailContentWidthChanged;
             DashboardContent.SizeChanged += DashboardContent_SizeChanged;
+            WidgetSettingsService.Changed += OnWidgetSettingsChanged;
             Loaded += (_, _) =>
             {
                 _lastAnimatedProvider = ViewModel.SelectedCard?.ProviderId;
                 ApplyLayoutState();
+                UpdatePinPresentation(ViewModel.SelectedCard);
                 QueueMeasuredHeightReport();
                 DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () => _ = ViewModel.LoadAsync());
             };
@@ -59,6 +73,7 @@ namespace TaskbarQuota.Views
                 ViewModel.SelectedCardChanged -= OnSelectedCardChanged;
                 ViewModel.DetailContentWidthChanged -= OnDetailContentWidthChanged;
                 DashboardContent.SizeChanged -= DashboardContent_SizeChanged;
+                WidgetSettingsService.Changed -= OnWidgetSettingsChanged;
                 if (_ownsViewModel)
                     ViewModel.Dispose();
             };
@@ -99,9 +114,13 @@ namespace TaskbarQuota.Views
         private void DashboardContent_SizeChanged(object sender, SizeChangedEventArgs e)
             => QueueMeasuredHeightReport();
 
+        private void OnWidgetSettingsChanged(object? sender, EventArgs e)
+            => DispatcherQueue.TryEnqueue(() => UpdatePinPresentation(ViewModel.SelectedCard));
+
         private void OnSelectedCardChanged(ProviderCardViewModel? card)
         {
             QueueMeasuredHeightReport();
+            UpdatePinPresentation(card);
             if (card is null)
                 return;
 
@@ -451,6 +470,7 @@ namespace TaskbarQuota.Views
             card.IsProviderPinned = WidgetSettingsService.IsProviderPinned(card.ProviderId);
             ProviderPinToggle.IsChecked = card.IsProviderPinned;
             ProviderPinToggle.IsEnabled = card.IsProviderPinToggleEnabled;
+            UpdatePinPresentation(card);
         }
 
         private void ProviderPinToggle_Click(object sender, RoutedEventArgs e)
@@ -475,14 +495,50 @@ namespace TaskbarQuota.Views
 
             PinBlockedTip.IsOpen = false;
 
+            if (wantPinned
+                && _pinHereDisplayKey.Length > 0
+                && WidgetSettingsService.CurrentSurface == WidgetSurfaceMode.Taskbar
+                && WidgetSettingsService.CurrentTaskbarPlacement == TaskbarPlacementMode.Adaptive)
+            {
+                WidgetSettingsService.SetPinnedProviderDisplay(card.ProviderId, _pinHereDisplayKey);
+            }
             WidgetSettingsService.SetProviderPinned(card.ProviderId, wantPinned);
             card.IsProviderPinned = WidgetSettingsService.IsProviderPinned(card.ProviderId);
             card.IsProviderWidgetVisible = WidgetSettingsService.IsProviderVisible(card.ProviderId);
-            ToolTipService.SetToolTip(toggle, DefaultPinTooltip);
+            UpdatePinPresentation(card);
         }
 
         private const string DefaultPinTooltip =
             "Keep this provider on the taskbar even when another tool is active";
+
+        private void UpdatePinPresentation(ProviderCardViewModel? card)
+        {
+            if (card is null || ProviderPinText is null || ProviderPinToggle is null)
+                return;
+
+            bool canPinHere = !card.IsProviderPinned
+                && _pinHereDisplayKey.Length > 0
+                && WidgetSettingsService.CurrentSurface == WidgetSurfaceMode.Taskbar
+                && WidgetSettingsService.CurrentTaskbarPlacement == TaskbarPlacementMode.Adaptive;
+            ProviderPinText.Text = canPinHere ? "Pin here" : card.ProviderPinToggleText;
+
+            string? fixedDisplay = WidgetSettingsService.GetPinnedProviderDisplay(card.ProviderId);
+            string tooltip = card.IsProviderPinned && fixedDisplay is not null
+                ? $"Pinned to {DisplayLabel(fixedDisplay)}"
+                : canPinHere
+                    ? $"Pin {card.DisplayName} to {DisplayLabel(_pinHereDisplayKey)}"
+                    : DefaultPinTooltip;
+            ToolTipService.SetToolTip(ProviderPinToggle, tooltip);
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(ProviderPinToggle, tooltip);
+        }
+
+        private static string DisplayLabel(string displayKey)
+        {
+            if (displayKey == WidgetSettingsService.AllDisplaysPinDestination)
+                return "all screens";
+            int number = TaskbarWindowTarget.TryGetDisplayNumber(displayKey);
+            return number > 0 ? $"Screen {number}" : "this screen";
+        }
 
         private void OpenSetupUrl_Click(object sender, RoutedEventArgs e)
         {

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml
@@ -88,6 +88,19 @@
                 </ComboBox>
             </tk:SettingsCard>
 
+            <tk:SettingsCard x:Name="TaskbarPlacementCard"
+                             Header="Taskbar screens"
+                             Description="Show the same usage on every taskbar, choose one screen, or place each provider on the screen where its window was last used.">
+                <tk:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE7F4;"/>
+                </tk:SettingsCard.HeaderIcon>
+                <ComboBox x:Name="TaskbarPlacementCombo"
+                          SelectionChanged="OnTaskbarPlacementChanged"
+                          MinWidth="200"
+                          AutomationProperties.Name="Taskbar screens"
+                          AutomationProperties.AutomationId="TaskbarPlacementCombo"/>
+            </tk:SettingsCard>
+
             <tk:SettingsCard x:Name="FloatingOpacityCard"
                              Header="Floating acrylic strength"
                              Description="How opaque the native Acrylic tint is (lower values reveal more of the blurred desktop behind it).">

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml
@@ -21,7 +21,7 @@
             <TextBlock Text="Settings" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,8"/>
 
             <!-- Explains a refused pin, matching DashboardPage. A tooltip is no use here: the user has just
-                 flicked the switch and watched it spring back, so the reason has to appear unprompted. -->
+                 selected a destination and watched it revert, so the reason has to appear unprompted. -->
             <muxc:InfoBar x:Name="PinBlockedBar"
                           Severity="Warning"
                           Title="Can't pin this provider"
@@ -90,7 +90,7 @@
 
             <tk:SettingsCard x:Name="TaskbarPlacementCard"
                              Header="Taskbar screens"
-                             Description="Show the same usage on every taskbar, choose one screen, or place each provider on the screen where its window was last used.">
+                             Description="Show the same usage on every taskbar, choose one screen, or keep one active provider per screen. With two or more screens, Adaptive mode also lets each pinned provider target a fixed screen.">
                 <tk:SettingsCard.HeaderIcon>
                     <FontIcon Glyph="&#xE7F4;"/>
                 </tk:SettingsCard.HeaderIcon>

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
@@ -7,6 +8,7 @@ using Microsoft.UI.Xaml.Media;
 using TaskbarQuota.Diagnostics;
 using TaskbarQuota.Helpers;
 using TaskbarQuota.Services;
+using TaskbarQuota.Taskbar;
 using TaskbarQuota.Usage;
 using TaskbarQuota.ViewModels;
 
@@ -18,9 +20,15 @@ namespace TaskbarQuota.Views
         private bool _isInitializing;
         // Suppresses the Toggled handlers while a row's toggles are synced programmatically.
         private bool _suppressProviderToggleEvents;
+        private bool _suppressTaskbarPlacementEvents;
         private Slider? _floatingOpacitySlider;
         // Per-provider toggles, so changing one updates only its own row instead of rebuilding the list.
         private readonly Dictionary<ProviderId, ProviderToggleRow> _providerRows = new();
+
+        private sealed record TaskbarPlacementOption(
+            string Label,
+            TaskbarPlacementMode Mode,
+            string DisplayKey = "");
 
         private sealed class ProviderToggleRow
         {
@@ -41,11 +49,13 @@ namespace TaskbarQuota.Views
                 _ => 0,
             };
             WidgetSurfaceCombo.SelectedIndex = WidgetSettingsService.CurrentSurface == WidgetSurfaceMode.Floating ? 1 : 0;
+            BuildTaskbarPlacementOptions();
             int opacityPercent = (int)System.Math.Round(WidgetSettingsService.FloatingOpacity * 100);
             if (_floatingOpacitySlider is { } slider)
                 slider.Value = opacityPercent;
             FloatingOpacityLabel.Text = $"{opacityPercent}%";
             FloatingOpacityCard.IsEnabled = WidgetSettingsService.CurrentSurface == WidgetSurfaceMode.Floating;
+            TaskbarPlacementCard.IsEnabled = WidgetSettingsService.CurrentSurface == WidgetSurfaceMode.Taskbar;
             WidgetModeCombo.SelectedIndex = WidgetSettingsService.Current switch
             {
                 WidgetDisplayMode.PercentagesOnly => 1,
@@ -66,6 +76,7 @@ namespace TaskbarQuota.Views
                     $"Settings page loaded (surface={WidgetSettingsService.CurrentSurface}, layout={WidgetSettingsService.Current})");
                 ViewModel.ReloadProviders();
                 RebuildProviderSettings();
+                BuildTaskbarPlacementOptions();
             };
             _isInitializing = false;
         }
@@ -265,7 +276,93 @@ namespace TaskbarQuota.Views
                     : WidgetSurfaceMode.Taskbar;
                 WidgetSettingsService.ApplySurface(mode);
                 FloatingOpacityCard.IsEnabled = mode == WidgetSurfaceMode.Floating;
+                TaskbarPlacementCard.IsEnabled = mode == WidgetSurfaceMode.Taskbar;
             }
+        }
+
+        private void BuildTaskbarPlacementOptions()
+        {
+            _suppressTaskbarPlacementEvents = true;
+            try
+            {
+                TaskbarPlacementCombo.Items.Clear();
+                AddTaskbarPlacementOption(new("All screens", TaskbarPlacementMode.AllDisplays));
+
+                var seen = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+                if (TaskbarWindowTarget.TryFindAll(out var targets))
+                {
+                    foreach (var target in targets
+                        .OrderBy(target => target.DisplayNumber == 0 ? int.MaxValue : target.DisplayNumber)
+                        .ThenByDescending(target => target.IsPrimary))
+                    {
+                        if (!seen.Add(target.DisplayKey))
+                            continue;
+
+                        string screenName = target.DisplayNumber > 0
+                            ? $"Screen {target.DisplayNumber}"
+                            : "Detected screen";
+                        if (target.IsPrimary)
+                            screenName += " (primary)";
+                        AddTaskbarPlacementOption(new(
+                            screenName,
+                            TaskbarPlacementMode.SelectedDisplay,
+                            target.DisplayKey));
+                    }
+                }
+
+                string selectedKey = WidgetSettingsService.SelectedTaskbarDisplayKey;
+                if (WidgetSettingsService.CurrentTaskbarPlacement == TaskbarPlacementMode.SelectedDisplay
+                    && selectedKey.Length > 0
+                    && seen.Add(selectedKey))
+                {
+                    AddTaskbarPlacementOption(new(
+                        $"{selectedKey} (disconnected)",
+                        TaskbarPlacementMode.SelectedDisplay,
+                        selectedKey));
+                }
+
+                AddTaskbarPlacementOption(new("Adaptive (follow each agent)", TaskbarPlacementMode.Adaptive));
+
+                for (int i = 0; i < TaskbarPlacementCombo.Items.Count; i++)
+                {
+                    if (TaskbarPlacementCombo.Items[i] is not ComboBoxItem { Tag: TaskbarPlacementOption option })
+                        continue;
+                    if (option.Mode != WidgetSettingsService.CurrentTaskbarPlacement)
+                        continue;
+                    if (option.Mode == TaskbarPlacementMode.SelectedDisplay
+                        && !string.Equals(
+                            option.DisplayKey,
+                            selectedKey,
+                            System.StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    TaskbarPlacementCombo.SelectedIndex = i;
+                    break;
+                }
+            }
+            finally
+            {
+                _suppressTaskbarPlacementEvents = false;
+            }
+        }
+
+        private void AddTaskbarPlacementOption(TaskbarPlacementOption option)
+            => TaskbarPlacementCombo.Items.Add(new ComboBoxItem
+            {
+                Content = option.Label,
+                Tag = option,
+            });
+
+        private void OnTaskbarPlacementChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isInitializing || _suppressTaskbarPlacementEvents)
+                return;
+            if (TaskbarPlacementCombo.SelectedItem is not ComboBoxItem { Tag: TaskbarPlacementOption option })
+                return;
+
+            WidgetSettingsService.ApplyTaskbarPlacement(option.Mode, option.DisplayKey);
         }
 
         /// <summary>

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
@@ -332,6 +332,36 @@ namespace TaskbarQuota.Views
             }
         }
 
+        private void RefreshProviderPinOptions()
+        {
+            _suppressProviderToggleEvents = true;
+            try
+            {
+                foreach (var item in ViewModel.Providers)
+                {
+                    if (!_providerRows.TryGetValue(item.Id, out var row) || row.Pin is not { } pin)
+                        continue;
+
+                    pin.Items.Clear();
+                    pin.SelectedIndex = -1;
+                    foreach (var option in _pinOptions)
+                    {
+                        pin.Items.Add(new ComboBoxItem { Content = option.Label, Tag = option });
+                        if (PinOptionMatches(item.Id, option))
+                            pin.SelectedIndex = pin.Items.Count - 1;
+                    }
+
+                    if (pin.SelectedIndex < 0)
+                        pin.SelectedIndex = 0;
+                    pin.IsEnabled = item.IsWidgetVisible;
+                }
+            }
+            finally
+            {
+                _suppressProviderToggleEvents = false;
+            }
+        }
+
         private void BuildTaskbarPlacementOptions()
         {
             _suppressTaskbarPlacementEvents = true;
@@ -486,7 +516,7 @@ namespace TaskbarQuota.Views
 
             WidgetSettingsService.ApplyTaskbarPlacement(option.Mode, option.DisplayKey);
             BuildPinOptions();
-            RebuildProviderSettings();
+            RefreshProviderPinOptions();
         }
 
         /// <summary>

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
@@ -22,19 +22,26 @@ namespace TaskbarQuota.Views
         private bool _suppressProviderToggleEvents;
         private bool _suppressTaskbarPlacementEvents;
         private Slider? _floatingOpacitySlider;
-        // Per-provider toggles, so changing one updates only its own row instead of rebuilding the list.
+        // Per-provider controls, so changing one updates only its own row instead of rebuilding the list.
         private readonly Dictionary<ProviderId, ProviderToggleRow> _providerRows = new();
+        private readonly List<PinOption> _pinOptions = new();
 
         private sealed record TaskbarPlacementOption(
             string Label,
             TaskbarPlacementMode Mode,
             string DisplayKey = "");
 
+        private sealed record PinOption(
+            string Label,
+            bool IsPinned,
+            string DisplayKey = "",
+            bool MatchesAnyDestination = false);
+
         private sealed class ProviderToggleRow
         {
             public ToggleSwitch? Dashboard;
             public ToggleSwitch? Widget;
-            public ToggleSwitch? Pinned;
+            public ComboBox? Pin;
         }
 
         public SettingsPage()
@@ -50,6 +57,7 @@ namespace TaskbarQuota.Views
             };
             WidgetSurfaceCombo.SelectedIndex = WidgetSettingsService.CurrentSurface == WidgetSurfaceMode.Floating ? 1 : 0;
             BuildTaskbarPlacementOptions();
+            BuildPinOptions();
             int opacityPercent = (int)System.Math.Round(WidgetSettingsService.FloatingOpacity * 100);
             if (_floatingOpacitySlider is { } slider)
                 slider.Value = opacityPercent;
@@ -75,8 +83,9 @@ namespace TaskbarQuota.Views
                 Log.Information(
                     $"Settings page loaded (surface={WidgetSettingsService.CurrentSurface}, layout={WidgetSettingsService.Current})");
                 ViewModel.ReloadProviders();
-                RebuildProviderSettings();
                 BuildTaskbarPlacementOptions();
+                BuildPinOptions();
+                RebuildProviderSettings();
             };
             _isInitializing = false;
         }
@@ -112,14 +121,14 @@ namespace TaskbarQuota.Views
                 var content = new StackPanel { Spacing = 8, MinWidth = 180 };
                 content.Children.Add(CreateProviderToggleRow("Dashboard", item, ProviderToggleKind.Dashboard, toggles));
                 content.Children.Add(CreateProviderToggleRow("Widget", item, ProviderToggleKind.Widget, toggles));
-                content.Children.Add(CreateProviderToggleRow("Pinned", item, ProviderToggleKind.Pinned, toggles));
+                content.Children.Add(CreateProviderPinRow(item, toggles));
                 card.Content = content;
 
                 ProviderSettingsPanel.Children.Add(card);
             }
         }
 
-        private enum ProviderToggleKind { Dashboard, Widget, Pinned }
+        private enum ProviderToggleKind { Dashboard, Widget }
 
         private FrameworkElement CreateProviderToggleRow(
             string label,
@@ -141,31 +150,60 @@ namespace TaskbarQuota.Views
                 IsOn = kind switch
                 {
                     ProviderToggleKind.Dashboard => item.IsDashboardVisible,
-                    ProviderToggleKind.Pinned => item.IsPinned,
                     _ => item.IsWidgetVisible,
                 },
-                // A provider can only be pinned to the taskbar when the widget may draw it at all.
-                IsEnabled = kind != ProviderToggleKind.Pinned || item.IsWidgetVisible,
                 Tag = item,
             };
             switch (kind)
             {
                 case ProviderToggleKind.Dashboard: toggles.Dashboard = toggle; break;
-                case ProviderToggleKind.Pinned: toggles.Pinned = toggle; break;
                 default: toggles.Widget = toggle; break;
             }
             toggle.Toggled += kind switch
             {
                 ProviderToggleKind.Dashboard => OnProviderDashboardToggled,
-                ProviderToggleKind.Pinned => OnProviderPinnedToggled,
                 _ => OnProviderWidgetToggled,
             };
             row.Children.Add(toggle);
             return row;
         }
 
-        // Syncs one provider's toggles to its current state in place. Enabling/disabling a provider and
-        // pinning both flip sibling toggles, and a whole-list rebuild would flash the page.
+        private FrameworkElement CreateProviderPinRow(
+            ProviderSettingItemViewModel item,
+            ProviderToggleRow toggles)
+        {
+            var row = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+            row.Children.Add(new TextBlock
+            {
+                Text = "Pin",
+                Width = 72,
+                VerticalAlignment = VerticalAlignment.Center,
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            });
+
+            var combo = new ComboBox
+            {
+                MinWidth = 150,
+                Tag = item,
+                IsEnabled = item.IsWidgetVisible,
+            };
+            foreach (var option in _pinOptions)
+            {
+                combo.Items.Add(new ComboBoxItem { Content = option.Label, Tag = option });
+                if (PinOptionMatches(item.Id, option))
+                    combo.SelectedIndex = combo.Items.Count - 1;
+            }
+            if (combo.SelectedIndex < 0)
+                combo.SelectedIndex = 0;
+
+            combo.SelectionChanged += OnProviderPinChanged;
+            toggles.Pin = combo;
+            row.Children.Add(combo);
+            return row;
+        }
+
+        // Syncs one provider's controls to its current state in place. Enabling/disabling a provider and
+        // pinning both affect sibling controls, and a whole-list rebuild would flash the page.
         private void RefreshProviderRow(ProviderSettingItemViewModel item)
         {
             if (!_providerRows.TryGetValue(item.Id, out var row))
@@ -176,10 +214,18 @@ namespace TaskbarQuota.Views
             {
                 if (row.Dashboard is { } dashboard) dashboard.IsOn = item.IsDashboardVisible;
                 if (row.Widget is { } widget) widget.IsOn = item.IsWidgetVisible;
-                if (row.Pinned is { } pinned)
+                if (row.Pin is { } pin)
                 {
-                    pinned.IsOn = item.IsPinned;
-                    pinned.IsEnabled = item.IsWidgetVisible;
+                    pin.IsEnabled = item.IsWidgetVisible;
+                    for (int i = 0; i < pin.Items.Count; i++)
+                    {
+                        if (pin.Items[i] is ComboBoxItem { Tag: PinOption option }
+                            && PinOptionMatches(item.Id, option))
+                        {
+                            pin.SelectedIndex = i;
+                            break;
+                        }
+                    }
                 }
             }
             finally
@@ -228,25 +274,31 @@ namespace TaskbarQuota.Views
             RefreshProviderRow(item);
         }
 
-        private void OnProviderPinnedToggled(object sender, RoutedEventArgs e)
+        private void OnProviderPinChanged(object sender, SelectionChangedEventArgs e)
         {
             if (_isInitializing || _suppressProviderToggleEvents)
                 return;
-            if (sender is not ToggleSwitch toggle || toggle.Tag is not ProviderSettingItemViewModel item)
-                return;
-
-            if (toggle.IsOn && !PinBudgetService.CanPin(item.Id, out var reason))
+            if (sender is not ComboBox
+                {
+                    Tag: ProviderSettingItemViewModel item,
+                    SelectedItem: ComboBoxItem { Tag: PinOption option },
+                })
             {
-                _suppressProviderToggleEvents = true;
-                try { toggle.IsOn = false; }
-                finally { _suppressProviderToggleEvents = false; }
+                return;
+            }
+
+            if (option.IsPinned && !item.IsPinned && !PinBudgetService.CanPin(item.Id, out var reason))
+            {
                 PinBlockedBar.Message = reason;
                 PinBlockedBar.IsOpen = true;
+                RefreshProviderRow(item);
                 return;
             }
 
             PinBlockedBar.IsOpen = false;
-            ViewModel.ApplyPinned(item, toggle.IsOn);
+            ViewModel.ApplyPinned(item, option.IsPinned);
+            if (option.IsPinned)
+                WidgetSettingsService.SetPinnedProviderDisplay(item.Id, option.DisplayKey);
             RefreshProviderRow(item);
         }
 
@@ -348,6 +400,76 @@ namespace TaskbarQuota.Views
             }
         }
 
+        private void BuildPinOptions()
+        {
+            _pinOptions.Clear();
+            _pinOptions.Add(new("Not pinned", false));
+
+            if (WidgetSettingsService.CurrentTaskbarPlacement != TaskbarPlacementMode.Adaptive)
+            {
+                _pinOptions.Add(new("Pinned", true, MatchesAnyDestination: true));
+                return;
+            }
+
+            if (!TaskbarWindowTarget.TryFindAll(out var targets))
+            {
+                _pinOptions.Add(new("Pinned", true, MatchesAnyDestination: true));
+                return;
+            }
+
+            var displays = targets
+                .GroupBy(target => target.DisplayKey, System.StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First())
+                .OrderBy(target => target.DisplayNumber == 0 ? int.MaxValue : target.DisplayNumber)
+                .ThenByDescending(target => target.IsPrimary)
+                .ToList();
+            if (displays.Count < 2)
+            {
+                _pinOptions.Add(new("Pinned", true, MatchesAnyDestination: true));
+                return;
+
+            }
+
+            _pinOptions.Add(new("Pinned — follow app", true));
+            _pinOptions.Add(new(
+                "Pinned — all screens",
+                true,
+                WidgetSettingsService.AllDisplaysPinDestination));
+
+            foreach (var target in displays)
+            {
+                string screenName = target.DisplayNumber > 0
+                    ? $"Screen {target.DisplayNumber}"
+                    : "Detected screen";
+                if (target.IsPrimary)
+                    screenName += " (primary)";
+                _pinOptions.Add(new($"Pinned — {screenName}", true, target.DisplayKey));
+            }
+
+            var known = displays.Select(target => target.DisplayKey)
+                .ToHashSet(System.StringComparer.OrdinalIgnoreCase);
+            foreach (ProviderId provider in System.Enum.GetValues<ProviderId>())
+            {
+                string? saved = WidgetSettingsService.GetPinnedProviderDisplay(provider);
+                if (saved is not null && known.Add(saved))
+                    _pinOptions.Add(new($"Pinned — {saved} (disconnected)", true, saved));
+            }
+        }
+
+        private static bool PinOptionMatches(ProviderId provider, PinOption option)
+        {
+            bool pinned = WidgetSettingsService.IsProviderPinned(provider);
+            if (pinned != option.IsPinned)
+                return false;
+            if (!pinned)
+                return true;
+            if (option.MatchesAnyDestination)
+                return true;
+
+            string selected = WidgetSettingsService.GetPinnedProviderDisplay(provider) ?? string.Empty;
+            return string.Equals(selected, option.DisplayKey, System.StringComparison.OrdinalIgnoreCase);
+        }
+
         private void AddTaskbarPlacementOption(TaskbarPlacementOption option)
             => TaskbarPlacementCombo.Items.Add(new ComboBoxItem
             {
@@ -363,6 +485,8 @@ namespace TaskbarQuota.Views
                 return;
 
             WidgetSettingsService.ApplyTaskbarPlacement(option.Mode, option.DisplayKey);
+            BuildPinOptions();
+            RebuildProviderSettings();
         }
 
         /// <summary>

--- a/tests/TaskbarQuota.Tests/AdaptiveDisplayProviderStateTests.cs
+++ b/tests/TaskbarQuota.Tests/AdaptiveDisplayProviderStateTests.cs
@@ -1,0 +1,55 @@
+using TaskbarQuota.Taskbar;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.Tests;
+
+public class AdaptiveDisplayProviderStateTests
+{
+    [Fact]
+    public void FocusingProviderOnAnotherDisplayKeepsTheFirstDisplaysProvider()
+    {
+        var state = new AdaptiveDisplayProviderState();
+
+        state.Observe(ProviderId.Codex, "DISPLAY2", new IntPtr(2));
+        state.Observe(ProviderId.OpenCode, "DISPLAY1", new IntPtr(1));
+
+        Assert.Equal(ProviderId.OpenCode, state.GetProvider("DISPLAY1"));
+        Assert.Equal(ProviderId.Codex, state.GetProvider("DISPLAY2"));
+    }
+
+    [Fact]
+    public void MovingAProviderTransfersItInsteadOfDuplicatingIt()
+    {
+        var state = new AdaptiveDisplayProviderState();
+        state.Observe(ProviderId.Codex, "DISPLAY1", new IntPtr(1));
+
+        state.Observe(ProviderId.Codex, "DISPLAY2", new IntPtr(2));
+
+        Assert.Null(state.GetProvider("DISPLAY1"));
+        Assert.Equal(ProviderId.Codex, state.GetProvider("DISPLAY2"));
+    }
+
+    [Fact]
+    public void ADisplayTracksItsMostRecentlyFocusedProvider()
+    {
+        var state = new AdaptiveDisplayProviderState();
+        state.Observe(ProviderId.Codex, "DISPLAY1", new IntPtr(1));
+
+        state.Observe(ProviderId.OpenCode, "display1", new IntPtr(2));
+
+        Assert.Equal(ProviderId.OpenCode, state.GetProvider("DISPLAY1"));
+        Assert.DoesNotContain(ProviderId.Codex, state.Providers);
+    }
+
+    [Fact]
+    public void ClosedOrMovedWindowNoLongerCountsAsActiveOnThatDisplay()
+    {
+        var state = new AdaptiveDisplayProviderState();
+        state.Observe(ProviderId.Codex, "DISPLAY1", new IntPtr(10));
+
+        var provider = state.GetProvider("DISPLAY1", window => window != new IntPtr(10));
+
+        Assert.Null(provider);
+        Assert.Empty(state.Providers);
+    }
+}

--- a/tests/TaskbarQuota.Tests/AdaptiveDisplayProviderStateTests.cs
+++ b/tests/TaskbarQuota.Tests/AdaptiveDisplayProviderStateTests.cs
@@ -30,7 +30,7 @@ public class AdaptiveDisplayProviderStateTests
     }
 
     [Fact]
-    public void ADisplayTracksItsMostRecentlyFocusedProvider()
+    public void ADisplayRestoresItsPreviousValidProvider()
     {
         var state = new AdaptiveDisplayProviderState();
         state.Observe(ProviderId.Codex, "DISPLAY1", new IntPtr(1));
@@ -38,7 +38,39 @@ public class AdaptiveDisplayProviderStateTests
         state.Observe(ProviderId.OpenCode, "display1", new IntPtr(2));
 
         Assert.Equal(ProviderId.OpenCode, state.GetProvider("DISPLAY1"));
-        Assert.DoesNotContain(ProviderId.Codex, state.Providers);
+        Assert.Equal(
+            ProviderId.Codex,
+            state.GetProvider("DISPLAY1", window => window != new IntPtr(2)));
+    }
+
+    [Fact]
+    public void MovingProviderAwayRevealsTheProviderItDisplaced()
+    {
+        var state = new AdaptiveDisplayProviderState();
+        state.Observe(ProviderId.OpenCode, "DISPLAY2", new IntPtr(20));
+        state.Observe(ProviderId.Antigravity, "DISPLAY1", new IntPtr(10));
+
+        state.Observe(ProviderId.Antigravity, "DISPLAY2", new IntPtr(10));
+        Assert.Equal(ProviderId.Antigravity, state.GetProvider("DISPLAY2"));
+
+        state.Observe(ProviderId.Antigravity, "DISPLAY1", new IntPtr(10));
+
+        Assert.Equal(ProviderId.Antigravity, state.GetProvider("DISPLAY1"));
+        Assert.Equal(ProviderId.OpenCode, state.GetProvider("DISPLAY2"));
+    }
+
+    [Fact]
+    public void ReclassifyingTheSameWindowDoesNotRetainItsOldProvider()
+    {
+        var state = new AdaptiveDisplayProviderState();
+        var terminal = new IntPtr(10);
+        state.Observe(ProviderId.Codex, "DISPLAY1", terminal);
+
+        state.Observe(ProviderId.OpenCode, "DISPLAY1", terminal);
+        state.Observe(ProviderId.OpenCode, "DISPLAY2", terminal);
+
+        Assert.Null(state.GetProvider("DISPLAY1"));
+        Assert.Equal(ProviderId.OpenCode, state.GetProvider("DISPLAY2"));
     }
 
     [Fact]

--- a/tests/TaskbarQuota.Tests/MixedDpiLifecycleTests.cs
+++ b/tests/TaskbarQuota.Tests/MixedDpiLifecycleTests.cs
@@ -1,0 +1,67 @@
+using TaskbarQuota.Taskbar;
+
+namespace TaskbarQuota.Tests;
+
+public class MixedDpiLifecycleTests
+{
+    [Fact]
+    public void Unchanged_taskbar_poll_does_not_request_position_work()
+    {
+        Assert.Equal(
+            TaskbarChangeReason.None,
+            TaskbarStructureWatcher.DetectChangeReason(
+                previousWidgets: true,
+                previousCentered: true,
+                previousHidden: false,
+                currentWidgets: true,
+                currentCentered: true,
+                currentHidden: false));
+    }
+
+    [Theory]
+    [InlineData(true, true, false, false, true, false, TaskbarChangeReason.WidgetsButton)]
+    [InlineData(true, true, false, true, false, false, TaskbarChangeReason.Alignment)]
+    [InlineData(true, true, false, true, true, true, TaskbarChangeReason.Visibility)]
+    public void Changed_taskbar_poll_reports_the_responsible_reason(
+        bool oldWidgets,
+        bool oldCentered,
+        bool oldHidden,
+        bool newWidgets,
+        bool newCentered,
+        bool newHidden,
+        TaskbarChangeReason expected)
+    {
+        Assert.Equal(
+            expected,
+            TaskbarStructureWatcher.DetectChangeReason(
+                oldWidgets, oldCentered, oldHidden, newWidgets, newCentered, newHidden));
+    }
+
+    [Fact]
+    public void Dpi_change_requires_two_matching_observations()
+    {
+        var debounce = new DpiChangeDebouncer();
+
+        Assert.False(debounce.Observe(120, 168));
+        Assert.True(debounce.Observe(120, 168));
+    }
+
+    [Fact]
+    public void Dpi_change_rejects_flapping_and_resets_at_applied_value()
+    {
+        var debounce = new DpiChangeDebouncer();
+
+        Assert.False(debounce.Observe(120, 168));
+        Assert.False(debounce.Observe(120, 96));
+        Assert.False(debounce.Observe(120, 120));
+        Assert.False(debounce.Observe(120, 168));
+        Assert.True(debounce.Observe(120, 168));
+    }
+
+    [Fact]
+    public void Physical_width_preserves_logical_size_across_dpi_change()
+    {
+        // 300 physical px at 150% is 200 DIP; at 125% it should occupy 250 physical px.
+        Assert.Equal(250, TaskBarWidget.RescalePhysicalWidth(300, 144, 120));
+    }
+}

--- a/tests/TaskbarQuota.Tests/SessionTopologyRecoveryTests.cs
+++ b/tests/TaskbarQuota.Tests/SessionTopologyRecoveryTests.cs
@@ -1,0 +1,79 @@
+using TaskbarQuota.Taskbar;
+
+namespace TaskbarQuota.Tests;
+
+public class SessionTopologyRecoveryTests
+{
+    [Theory]
+    [InlineData(SessionTopologyWatcher.WtsRemoteConnect, (int)TopologyChangeKind.SessionConnect)]
+    [InlineData(SessionTopologyWatcher.WtsRemoteDisconnect, (int)TopologyChangeKind.SessionDisconnect)]
+    [InlineData(SessionTopologyWatcher.WtsConsoleConnect, (int)TopologyChangeKind.SessionConnect)]
+    [InlineData(SessionTopologyWatcher.WtsConsoleDisconnect, (int)TopologyChangeKind.SessionDisconnect)]
+    [InlineData(SessionTopologyWatcher.WtsSessionLogon, (int)TopologyChangeKind.SessionConnect)]
+    [InlineData(SessionTopologyWatcher.WtsSessionUnlock, (int)TopologyChangeKind.SessionUnlock)]
+    public void Session_changes_that_replace_desktop_hosts_request_recovery(
+        int code,
+        int expectedKind)
+    {
+        Assert.True(SessionTopologyWatcher.TryMapSessionChange(code, out var change));
+        Assert.Equal((TopologyChangeKind)expectedKind, change.Kind);
+        Assert.True(change.RequiresHostReset);
+    }
+
+    [Fact]
+    public void Unrelated_session_change_is_ignored()
+        => Assert.False(SessionTopologyWatcher.TryMapSessionChange(0x7fff, out _));
+
+    [Theory]
+    [InlineData(0, 250)]
+    [InlineData(1, 500)]
+    [InlineData(2, 1000)]
+    [InlineData(3, 2000)]
+    [InlineData(4, 4000)]
+    [InlineData(20, 4000)]
+    public void Recovery_retry_uses_bounded_backoff(int attempts, int expectedMilliseconds)
+        => Assert.Equal(expectedMilliseconds, SessionTopologyWatcher.RetryDelay(attempts).TotalMilliseconds);
+
+    [Fact]
+    public void Recovery_waits_for_two_identical_non_empty_topologies()
+    {
+        var tracker = new TopologyStabilityTracker();
+
+        Assert.False(tracker.Observe("primary"));
+        Assert.False(tracker.Observe("primary|secondary"));
+        Assert.True(tracker.Observe("primary|secondary"));
+    }
+
+    [Fact]
+    public void Empty_topology_resets_stability_candidate()
+    {
+        var tracker = new TopologyStabilityTracker();
+
+        Assert.False(tracker.Observe("primary|secondary"));
+        Assert.False(tracker.Observe(string.Empty));
+        Assert.False(tracker.Observe("primary|secondary"));
+        Assert.True(tracker.Observe("primary|secondary"));
+    }
+
+    [Fact]
+    public void One_missing_secondary_scan_does_not_destroy_a_live_host()
+    {
+        Assert.False(TaskBarManager.ShouldRemoveMissingTaskbar(1, hostAlive: true));
+        Assert.True(TaskBarManager.ShouldRemoveMissingTaskbar(2, hostAlive: true));
+        Assert.True(TaskBarManager.ShouldRemoveMissingTaskbar(1, hostAlive: false));
+    }
+
+    [Theory]
+    [InlineData(2160, 1080, 1080, false)]
+    [InlineData(2161, 1080, 1080, true)]
+    [InlineData(0, -1080, 1080, false)]
+    [InlineData(1, -1080, 1080, true)]
+    public void Auto_hide_detection_uses_the_monitor_origin(
+        int taskbarBottom,
+        int displayTop,
+        int displayHeight,
+        bool expected)
+        => Assert.Equal(
+            expected,
+            TaskbarStructureWatcher.IsAutoHideTaskbarOffscreen(taskbarBottom, displayTop, displayHeight));
+}

--- a/tests/TaskbarQuota.Tests/TaskBarWidgetActivitySnapshotTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskBarWidgetActivitySnapshotTests.cs
@@ -1,0 +1,47 @@
+using TaskbarQuota.AgentActivity;
+using TaskbarQuota.Taskbar;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.Tests;
+
+public class TaskBarWidgetActivitySnapshotTests
+{
+    [Fact]
+    public void ScreenPolicyEmptyDoesNotUseScannerGracePeriod()
+    {
+        var visible = Snapshot("visible");
+        var routedEmpty = new AgentActivitySnapshot([]);
+
+        Assert.False(TaskBarWidget.ShouldDeferEmptyActivitySnapshot(
+            visible,
+            routedEmpty,
+            allowEmptyGrace: false));
+    }
+
+    [Fact]
+    public void TransientScannerEmptyKeepsExistingGracePeriod()
+    {
+        var visible = Snapshot("visible");
+        var scannerEmpty = new AgentActivitySnapshot([]);
+
+        Assert.True(TaskBarWidget.ShouldDeferEmptyActivitySnapshot(
+            visible,
+            scannerEmpty,
+            allowEmptyGrace: true));
+    }
+
+    private static AgentActivitySnapshot Snapshot(string id)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new AgentActivitySnapshot([
+            new AgentActivityItem(
+                id,
+                ProviderId.Codex,
+                "Codex",
+                "Working",
+                AgentActivityStatus.Working,
+                now,
+                now),
+        ]);
+    }
+}

--- a/tests/TaskbarQuota.Tests/TaskbarContentRouterTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskbarContentRouterTests.cs
@@ -1,0 +1,101 @@
+using TaskbarQuota.AgentActivity;
+using TaskbarQuota.Taskbar;
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.Tests;
+
+public class TaskbarContentRouterTests
+{
+    private static readonly HashSet<string> Displays = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "DISPLAY1",
+        "DISPLAY2",
+    };
+
+    [Fact]
+    public void AllDisplays_routes_every_provider_to_every_taskbar()
+    {
+        ProviderId[] providers = [ProviderId.Codex, ProviderId.Antigravity];
+
+        var routed = Route(providers, TaskbarPlacementMode.AllDisplays, "DISPLAY2", "DISPLAY1", _ => null);
+
+        Assert.Equal(providers, routed);
+    }
+
+    [Fact]
+    public void SelectedDisplay_routes_all_content_only_to_selection()
+    {
+        ProviderId[] providers = [ProviderId.Codex, ProviderId.Antigravity];
+
+        Assert.Empty(Route(providers, TaskbarPlacementMode.SelectedDisplay, "DISPLAY2", "DISPLAY1", _ => null));
+        Assert.Equal(
+            providers,
+            Route(providers, TaskbarPlacementMode.SelectedDisplay, "DISPLAY2", "DISPLAY2", _ => null));
+    }
+
+    [Fact]
+    public void Missing_selected_display_falls_back_to_primary()
+    {
+        ProviderId[] providers = [ProviderId.Codex];
+
+        Assert.Equal(
+            providers,
+            Route(providers, TaskbarPlacementMode.SelectedDisplay, "DISPLAY9", "DISPLAY1", _ => null));
+    }
+
+    [Fact]
+    public void Adaptive_routes_each_provider_to_its_observed_display()
+    {
+        ProviderId[] providers = [ProviderId.Codex, ProviderId.Antigravity, ProviderId.Claude];
+        string? Assignment(ProviderId provider) => provider switch
+        {
+            ProviderId.Codex => "DISPLAY1",
+            ProviderId.Antigravity => "DISPLAY2",
+            _ => null,
+        };
+
+        Assert.Equal(
+            [ProviderId.Codex, ProviderId.Claude],
+            Route(providers, TaskbarPlacementMode.Adaptive, string.Empty, "DISPLAY1", Assignment));
+        Assert.Equal(
+            [ProviderId.Antigravity],
+            Route(providers, TaskbarPlacementMode.Adaptive, string.Empty, "DISPLAY2", Assignment));
+    }
+
+    [Fact]
+    public void Adaptive_filters_agent_activity_by_provider_display()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var codex = new AgentActivityItem(
+            "codex", ProviderId.Codex, "Codex", "Working", AgentActivityStatus.Working, now, now);
+        var antigravity = new AgentActivityItem(
+            "antigravity", ProviderId.Antigravity, "Antigravity", "Working", AgentActivityStatus.Working, now, now);
+        var snapshot = new AgentActivitySnapshot([codex, antigravity]);
+
+        var routed = TaskbarContentRouter.ActivityForDisplay(
+            snapshot,
+            TaskbarPlacementMode.Adaptive,
+            string.Empty,
+            "DISPLAY2",
+            "DISPLAY1",
+            Displays,
+            provider => provider == ProviderId.Antigravity ? "DISPLAY2" : "DISPLAY1");
+
+        Assert.Equal([antigravity], routed.Items);
+    }
+
+    private static IReadOnlyList<ProviderId> Route(
+        IReadOnlyList<ProviderId> providers,
+        TaskbarPlacementMode mode,
+        string selected,
+        string target,
+        Func<ProviderId, string?> assignment)
+        => TaskbarContentRouter.ProvidersForDisplay(
+            providers,
+            mode,
+            selected,
+            target,
+            "DISPLAY1",
+            Displays,
+            assignment);
+}

--- a/tests/TaskbarQuota.Tests/TaskbarContentRouterTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskbarContentRouterTests.cs
@@ -84,12 +84,100 @@ public class TaskbarContentRouterTests
         Assert.Equal([antigravity], routed.Items);
     }
 
+    [Fact]
+    public void Adaptive_fixed_pin_destination_overrides_the_apps_display()
+    {
+        ProviderId[] providers = [ProviderId.Codex];
+
+        var appDisplay = Route(
+            providers,
+            TaskbarPlacementMode.Adaptive,
+            string.Empty,
+            "DISPLAY1",
+            _ => "DISPLAY1",
+            _ => true,
+            _ => "DISPLAY2");
+        var pinDisplay = Route(
+            providers,
+            TaskbarPlacementMode.Adaptive,
+            string.Empty,
+            "DISPLAY2",
+            _ => "DISPLAY1",
+            _ => true,
+            _ => "DISPLAY2");
+
+        Assert.Empty(appDisplay);
+        Assert.Equal(providers, pinDisplay);
+    }
+
+    [Fact]
+    public void Adaptive_unpinned_provider_ignores_a_saved_pin_destination()
+    {
+        ProviderId[] providers = [ProviderId.Codex];
+
+        var routed = Route(
+            providers,
+            TaskbarPlacementMode.Adaptive,
+            string.Empty,
+            "DISPLAY1",
+            _ => "DISPLAY1",
+            _ => false,
+            _ => "DISPLAY2");
+
+        Assert.Equal(providers, routed);
+    }
+
+    [Fact]
+    public void Adaptive_disconnected_pin_destination_temporarily_falls_back_to_primary()
+    {
+        ProviderId[] providers = [ProviderId.Codex];
+
+        var routed = Route(
+            providers,
+            TaskbarPlacementMode.Adaptive,
+            string.Empty,
+            "DISPLAY1",
+            _ => "DISPLAY2",
+            _ => true,
+            _ => "DISPLAY9");
+
+        Assert.Equal(providers, routed);
+    }
+
+    [Fact]
+    public void Adaptive_all_screens_pin_routes_to_every_display()
+    {
+        ProviderId[] providers = [ProviderId.Codex];
+
+        var primary = Route(
+            providers,
+            TaskbarPlacementMode.Adaptive,
+            string.Empty,
+            "DISPLAY1",
+            _ => "DISPLAY1",
+            _ => true,
+            _ => WidgetSettingsService.AllDisplaysPinDestination);
+        var secondary = Route(
+            providers,
+            TaskbarPlacementMode.Adaptive,
+            string.Empty,
+            "DISPLAY2",
+            _ => "DISPLAY1",
+            _ => true,
+            _ => WidgetSettingsService.AllDisplaysPinDestination);
+
+        Assert.Equal(providers, primary);
+        Assert.Equal(providers, secondary);
+    }
+
     private static IReadOnlyList<ProviderId> Route(
         IReadOnlyList<ProviderId> providers,
         TaskbarPlacementMode mode,
         string selected,
         string target,
-        Func<ProviderId, string?> assignment)
+        Func<ProviderId, string?> assignment,
+        Func<ProviderId, bool>? isPinned = null,
+        Func<ProviderId, string?>? pinAssignment = null)
         => TaskbarContentRouter.ProvidersForDisplay(
             providers,
             mode,
@@ -97,5 +185,7 @@ public class TaskbarContentRouterTests
             target,
             "DISPLAY1",
             Displays,
-            assignment);
+            assignment,
+            isPinned ?? (_ => false),
+            pinAssignment ?? (_ => null));
 }

--- a/tests/TaskbarQuota.Tests/TaskbarContentRouterTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskbarContentRouterTests.cs
@@ -63,6 +63,34 @@ public class TaskbarContentRouterTests
     }
 
     [Fact]
+    public void Adaptive_candidates_exclude_stale_unpinned_provider_during_move()
+    {
+        ProviderId[] providers = [ProviderId.OpenCode, ProviderId.Codex];
+
+        var candidates = TaskbarContentRouter.AdaptiveCandidatesForDisplay(
+            providers,
+            ProviderId.OpenCode,
+            _ => true,
+            _ => false);
+
+        Assert.Equal([ProviderId.OpenCode], candidates);
+    }
+
+    [Fact]
+    public void Adaptive_candidates_preserve_explicit_pins_beside_current_provider()
+    {
+        ProviderId[] providers = [ProviderId.OpenCode, ProviderId.Codex];
+
+        var candidates = TaskbarContentRouter.AdaptiveCandidatesForDisplay(
+            providers,
+            ProviderId.OpenCode,
+            _ => true,
+            provider => provider == ProviderId.Codex);
+
+        Assert.Equal([ProviderId.OpenCode, ProviderId.Codex], candidates);
+    }
+
+    [Fact]
     public void Adaptive_filters_agent_activity_by_provider_display()
     {
         var now = DateTimeOffset.UtcNow;

--- a/tests/TaskbarQuota.Tests/TaskbarPlacementSettingsTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskbarPlacementSettingsTests.cs
@@ -1,0 +1,43 @@
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.Tests;
+
+[Collection(WidgetRowSettingsCollection.Name)]
+public class TaskbarPlacementSettingsTests
+{
+    [Fact]
+    public void Placement_and_adaptive_assignments_round_trip()
+    {
+        var previousMode = WidgetSettingsService.CurrentTaskbarPlacement;
+        var previousSelection = WidgetSettingsService.SelectedTaskbarDisplayKey;
+        var previousAssignments = Enum.GetValues<ProviderId>()
+            .Select(provider => (Provider: provider.ToString(), Display: WidgetSettingsService.GetAdaptiveProviderDisplay(provider)))
+            .Where(pair => pair.Display is not null)
+            .ToDictionary(pair => pair.Provider, pair => pair.Display!);
+        string directory = Path.Combine(Path.GetTempPath(), "taskbarquota-placement-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            using var storageOverride = AppStorage.OverrideAppDataDirectoryForTesting(directory);
+            WidgetSettingsService.ReloadTaskbarPlacementForTesting();
+            Assert.Equal(TaskbarPlacementMode.AllDisplays, WidgetSettingsService.CurrentTaskbarPlacement);
+
+            WidgetSettingsService.ApplyTaskbarPlacement(TaskbarPlacementMode.SelectedDisplay, "DISPLAY2");
+            Assert.True(WidgetSettingsService.SetAdaptiveProviderDisplay(ProviderId.Codex, "DISPLAY1"));
+            Assert.Equal("1", File.ReadAllText(Path.Combine(directory, "taskbar-placement-mode.txt")));
+
+            WidgetSettingsService.ReloadTaskbarPlacementForTesting();
+            Assert.Equal(TaskbarPlacementMode.SelectedDisplay, WidgetSettingsService.CurrentTaskbarPlacement);
+            Assert.Equal("DISPLAY2", WidgetSettingsService.SelectedTaskbarDisplayKey);
+            Assert.Equal("DISPLAY1", WidgetSettingsService.GetAdaptiveProviderDisplay(ProviderId.Codex));
+        }
+        finally
+        {
+            WidgetSettingsService.RestoreTaskbarPlacementForTesting(
+                previousMode,
+                previousSelection,
+                previousAssignments);
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/tests/TaskbarQuota.Tests/TaskbarPlacementSettingsTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskbarPlacementSettingsTests.cs
@@ -14,6 +14,10 @@ public class TaskbarPlacementSettingsTests
             .Select(provider => (Provider: provider.ToString(), Display: WidgetSettingsService.GetAdaptiveProviderDisplay(provider)))
             .Where(pair => pair.Display is not null)
             .ToDictionary(pair => pair.Provider, pair => pair.Display!);
+        var previousPinAssignments = Enum.GetValues<ProviderId>()
+            .Select(provider => (Provider: provider.ToString(), Display: WidgetSettingsService.GetPinnedProviderDisplay(provider)))
+            .Where(pair => pair.Display is not null)
+            .ToDictionary(pair => pair.Provider, pair => pair.Display!);
         string directory = Path.Combine(Path.GetTempPath(), "taskbarquota-placement-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
         try
@@ -24,19 +28,22 @@ public class TaskbarPlacementSettingsTests
 
             WidgetSettingsService.ApplyTaskbarPlacement(TaskbarPlacementMode.SelectedDisplay, "DISPLAY2");
             Assert.True(WidgetSettingsService.SetAdaptiveProviderDisplay(ProviderId.Codex, "DISPLAY1"));
+            WidgetSettingsService.SetPinnedProviderDisplay(ProviderId.Codex, "DISPLAY2");
             Assert.Equal("1", File.ReadAllText(Path.Combine(directory, "taskbar-placement-mode.txt")));
 
             WidgetSettingsService.ReloadTaskbarPlacementForTesting();
             Assert.Equal(TaskbarPlacementMode.SelectedDisplay, WidgetSettingsService.CurrentTaskbarPlacement);
             Assert.Equal("DISPLAY2", WidgetSettingsService.SelectedTaskbarDisplayKey);
             Assert.Equal("DISPLAY1", WidgetSettingsService.GetAdaptiveProviderDisplay(ProviderId.Codex));
+            Assert.Equal("DISPLAY2", WidgetSettingsService.GetPinnedProviderDisplay(ProviderId.Codex));
         }
         finally
         {
             WidgetSettingsService.RestoreTaskbarPlacementForTesting(
                 previousMode,
                 previousSelection,
-                previousAssignments);
+                previousAssignments,
+                previousPinAssignments);
             Directory.Delete(directory, recursive: true);
         }
     }

--- a/tests/TaskbarQuota.Tests/TaskbarWindowTargetTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskbarWindowTargetTests.cs
@@ -42,4 +42,12 @@ public class TaskbarWindowTargetTests
         Assert.Equal("-1920_0_0_1080", displayKey);
         Assert.Equal("taskbar-widget-position--1920_0_0_1080.txt", TaskbarWindowTarget.BuildPositionFileName(displayKey));
     }
+
+    [Theory]
+    [InlineData("DISPLAY1", 1)]
+    [InlineData("display12", 12)]
+    [InlineData("-1920_0_0_1080", 0)]
+    [InlineData("", 0)]
+    public void TryGetDisplayNumber_reads_gdi_display_key(string displayKey, int expected)
+        => Assert.Equal(expected, TaskbarWindowTarget.TryGetDisplayNumber(displayKey));
 }


### PR DESCRIPTION
## Summary

Adds full multi-monitor taskbar placement control and hardens TaskbarQuota across mixed-DPI, Remote Desktop, Explorer, and display-topology transitions.

Closes #71.

## Placement modes

- **All screens** — shows the same TaskbarQuota content on every detected taskbar and remains the backward-compatible default.
- **Screen 1 / Screen 2 / detected displays** — limits taskbar content to the selected monitor and persists the selection across restarts.
- **Adaptive (follow each agent)** — routes each provider and its agent activity to the taskbar on the monitor containing that provider's window. Moving a provider window between monitors updates its taskbar placement.

## Reliability fixes

- Creates each taskbar host under the target monitor's DPI-awareness context.
- Applies stable DPI changes in place instead of repeatedly destroying and recreating XAML hosts.
- Debounces DPI and display-identity changes to prevent secondary-monitor flicker during Explorer topology rebuilds.
- Ignores temporary zero-sized taskbar windows and tolerates a single transient secondary-taskbar enumeration miss.
- Listens for Remote Desktop session changes, unlocks, display changes, Explorer taskbar recreation, and resume events.
- Waits for a stable non-empty topology before rebuilding stale taskbar hosts after those transitions.
- Fixes auto-hide geometry on monitors with non-zero or negative desktop coordinates.
- Keeps the existing periodic health check as a fallback if event-driven recovery cannot complete immediately.

## Validation

- `dotnet test tests/TaskbarQuota.Tests/TaskbarQuota.Tests.csproj --no-restore`
  - 795 passed, 0 failed
- `dotnet build src/TaskbarQuota.App/TaskbarQuota.App.csproj -c Release -p:Platform=x64 --no-restore`
  - Build succeeded with 0 errors
  - One pre-existing CS0649 test-hook warning remains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose whether taskbar widgets appear on all screens, a selected screen, or adapt based on provider activity.
  * Assign pinned providers to a specific screen, all screens, or the screen hosting the active app.
  * Added persistent taskbar screen placement settings with disconnected-display handling.
  * Improved support for mixed-DPI displays, display changes, session transitions, Explorer restarts, and system resume.
  * Added automatic taskbar topology recovery and adaptive content routing.

* **Bug Fixes**
  * Improved widget recreation, visibility synchronization, auto-hide detection, and missing-taskbar handling.
  * Reduced unnecessary updates and stabilized DPI and topology change detection.

* **Tests**
  * Added coverage for placement, routing, pinning, DPI, lifecycle, recovery, and display detection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->