### PR TITLE
fix(taskbar): harden per-screen routing

### DIFF
--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -839,16 +839,8 @@ namespace TaskbarQuota
             string? fixedDisplay = WidgetSettingsService.GetPinnedProviderDisplay(id);
             string pinDescription = fixedDisplay is null
                 ? "pinned — follows app screen"
-                : $"pinned to {DisplayLabel(fixedDisplay)}";
+                : $"pinned to {TaskbarWindowTarget.GetDisplayLabel(fixedDisplay)}";
             ToolTipService.SetToolTip(button, pinned ? $"{displayName} — {pinDescription}" : displayName);
-        }
-
-        private static string DisplayLabel(string displayKey)
-        {
-            if (displayKey == WidgetSettingsService.AllDisplaysPinDestination)
-                return "all screens";
-            int number = TaskbarWindowTarget.TryGetDisplayNumber(displayKey);
-            return number > 0 ? $"Screen {number}" : displayKey;
         }
 
         /// <summary>

--- a/src/TaskbarQuota.App/Taskbar/AdaptiveDisplayProviderState.cs
+++ b/src/TaskbarQuota.App/Taskbar/AdaptiveDisplayProviderState.cs
@@ -46,6 +46,20 @@ internal sealed class AdaptiveDisplayProviderState
         }
     }
 
+    public ProviderId? GetProviderForWindow(IntPtr window)
+    {
+        foreach (var entries in _providers.Values)
+        {
+            foreach (var entry in entries)
+            {
+                if (entry.Window == window)
+                    return entry.Provider;
+            }
+        }
+
+        return null;
+    }
+
     public bool Observe(ProviderId provider, string displayKey, IntPtr window)
     {
         displayKey = displayKey.Trim();

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -384,7 +384,15 @@ namespace TaskbarQuota.Taskbar
                     return;
                 }
 
-                EnsureWidgets();
+                if (_topologyRecoveryPending)
+                {
+                    if (TryRecoverTaskbarTopology())
+                        CompleteTopologyRecovery();
+                }
+                else
+                {
+                    EnsureWidgets();
+                }
                 RefreshPinnedTiles();
                 // The free span is only known once a widget has measured it, so a set pinned before that
                 // (or pinned when the bar was emptier) is reconciled here rather than rendering badly.
@@ -556,10 +564,17 @@ namespace TaskbarQuota.Taskbar
                 WidgetSettingsService.GetPinnedProviderDisplay);
         }
 
-        private static ProviderId? ActiveProviderForWidget(TaskBarWidget widget, ProviderId? globalActive)
-            => WidgetSettingsService.CurrentTaskbarPlacement == TaskbarPlacementMode.Adaptive
-                ? AdaptiveProviderForDisplay(widget.DisplayKey)
-                : globalActive;
+        private static ProviderId? ActiveProviderForWidget(
+            TaskBarWidget widget,
+            IReadOnlyList<ProviderId> providers,
+            ProviderId? globalActive)
+        {
+            if (WidgetSettingsService.CurrentTaskbarPlacement != TaskbarPlacementMode.Adaptive)
+                return globalActive;
+
+            return AdaptiveProviderForDisplay(widget.DisplayKey)
+                ?? (globalActive is { } active && providers.Contains(active) ? active : null);
+        }
 
         private static ProviderId? AdaptiveProviderForDisplay(string displayKey)
             => AdaptiveDisplayProviders.GetProvider(
@@ -685,7 +700,9 @@ namespace TaskbarQuota.Taskbar
                 widget.DisplayKey,
                 primary,
                 available,
-                WidgetSettingsService.GetAdaptiveProviderDisplay);
+                WidgetSettingsService.GetAdaptiveProviderDisplay,
+                WidgetSettingsService.IsProviderPinned,
+                WidgetSettingsService.GetPinnedProviderDisplay);
         }
 
         private static void SyncWidgetState()
@@ -718,12 +735,14 @@ namespace TaskbarQuota.Taskbar
             if (providers.Count == 0)
             {
                 widget.HideDisplayProviders(
-                    ActiveProviderForWidget(widget, coordinator.ActiveProvider),
+                    ActiveProviderForWidget(widget, providers, coordinator.ActiveProvider),
                     keepActivityVisible: widget.HasVisibleActivity);
                 return;
             }
 
-            widget.SetDisplayProviders(providers, ActiveProviderForWidget(widget, coordinator.ActiveProvider));
+            widget.SetDisplayProviders(
+                providers,
+                ActiveProviderForWidget(widget, providers, coordinator.ActiveProvider));
             widget.SetVisible(true);
 
             bool needsFetch = false;
@@ -933,12 +952,14 @@ namespace TaskbarQuota.Taskbar
                 if (providers.Count == 0)
                 {
                     widget.HideDisplayProviders(
-                        ActiveProviderForWidget(widget, coordinator.ActiveProvider),
+                        ActiveProviderForWidget(widget, providers, coordinator.ActiveProvider),
                         keepActivityVisible: widget.HasVisibleActivity);
                     continue;
                 }
 
-                widget.SetDisplayProviders(providers, ActiveProviderForWidget(widget, coordinator.ActiveProvider));
+                widget.SetDisplayProviders(
+                    providers,
+                    ActiveProviderForWidget(widget, providers, coordinator.ActiveProvider));
                 widget.SetVisible(true);
                 if (!isDisplayedOnWidget)
                     continue;
@@ -996,7 +1017,7 @@ namespace TaskbarQuota.Taskbar
         {
             if (hwnd == IntPtr.Zero || User32.GetForegroundWindow() != hwnd)
                 return;
-            if (UsageCoordinator.Instance.ActiveProvider is not { } provider)
+            if (AdaptiveDisplayProviders.GetProviderForWindow(hwnd) is not { } provider)
                 return;
 
             string displayKey = TaskbarWindowTarget.GetDisplayKeyForWindow(hwnd);

--- a/src/TaskbarQuota.App/Taskbar/TaskbarContentRouter.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskbarContentRouter.cs
@@ -58,7 +58,9 @@ internal static class TaskbarContentRouter
         string targetDisplayKey,
         string primaryDisplayKey,
         IReadOnlySet<string> availableDisplayKeys,
-        Func<ProviderId, string?> adaptiveDisplayForProvider)
+        Func<ProviderId, string?> adaptiveDisplayForProvider,
+        Func<ProviderId, bool> isPinned,
+        Func<ProviderId, string?> pinnedDisplayForProvider)
     {
         if (mode == TaskbarPlacementMode.AllDisplays)
             return snapshot;
@@ -71,7 +73,9 @@ internal static class TaskbarContentRouter
                 targetDisplayKey,
                 primaryDisplayKey,
                 availableDisplayKeys,
-                adaptiveDisplayForProvider))
+                adaptiveDisplayForProvider,
+                isPinned,
+                pinnedDisplayForProvider))
             .ToArray();
         var runItems = snapshot.RunItems?
             .Where(item => IsRoutedToDisplay(
@@ -81,7 +85,9 @@ internal static class TaskbarContentRouter
                 targetDisplayKey,
                 primaryDisplayKey,
                 availableDisplayKeys,
-                adaptiveDisplayForProvider))
+                adaptiveDisplayForProvider,
+                isPinned,
+                pinnedDisplayForProvider))
             .ToArray();
         return new AgentActivitySnapshot(items, runItems);
     }

--- a/src/TaskbarQuota.App/Taskbar/TaskbarWindowTarget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskbarWindowTarget.cs
@@ -94,6 +94,15 @@ namespace TaskbarQuota.Taskbar
                     : 0;
         }
 
+        internal static string GetDisplayLabel(string displayKey)
+        {
+            if (displayKey == WidgetSettingsService.AllDisplaysPinDestination)
+                return "all screens";
+
+            int number = TryGetDisplayNumber(displayKey);
+            return number > 0 ? $"Screen {number}" : "this screen";
+        }
+
         internal static string GetDisplayKeyForWindow(IntPtr hwnd)
         {
             if (hwnd == IntPtr.Zero || !User32.IsWindow(hwnd))

--- a/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
@@ -524,20 +524,12 @@ namespace TaskbarQuota.Views
 
             string? fixedDisplay = WidgetSettingsService.GetPinnedProviderDisplay(card.ProviderId);
             string tooltip = card.IsProviderPinned && fixedDisplay is not null
-                ? $"Pinned to {DisplayLabel(fixedDisplay)}"
+                ? $"Pinned to {TaskbarWindowTarget.GetDisplayLabel(fixedDisplay)}"
                 : canPinHere
-                    ? $"Pin {card.DisplayName} to {DisplayLabel(_pinHereDisplayKey)}"
+                    ? $"Pin {card.DisplayName} to {TaskbarWindowTarget.GetDisplayLabel(_pinHereDisplayKey)}"
                     : DefaultPinTooltip;
             ToolTipService.SetToolTip(ProviderPinToggle, tooltip);
             Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(ProviderPinToggle, tooltip);
-        }
-
-        private static string DisplayLabel(string displayKey)
-        {
-            if (displayKey == WidgetSettingsService.AllDisplaysPinDestination)
-                return "all screens";
-            int number = TaskbarWindowTarget.TryGetDisplayNumber(displayKey);
-            return number > 0 ? $"Screen {number}" : "this screen";
         }
 
         private void OpenSetupUrl_Click(object sender, RoutedEventArgs e)

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
@@ -297,7 +297,9 @@ namespace TaskbarQuota.Views
 
             PinBlockedBar.IsOpen = false;
             ViewModel.ApplyPinned(item, option.IsPinned);
-            if (option.IsPinned)
+            // The normal-mode "Pinned" option has no destination semantics and must preserve the saved
+            // adaptive destination. In adaptive mode, an empty destination deliberately means follow app.
+            if (option.IsPinned && !option.MatchesAnyDestination)
                 WidgetSettingsService.SetPinnedProviderDisplay(item.Id, option.DisplayKey);
             RefreshProviderRow(item);
         }
@@ -481,7 +483,9 @@ namespace TaskbarQuota.Views
             foreach (ProviderId provider in System.Enum.GetValues<ProviderId>())
             {
                 string? saved = WidgetSettingsService.GetPinnedProviderDisplay(provider);
-                if (saved is not null && known.Add(saved))
+                if (saved is not null
+                    && saved != WidgetSettingsService.AllDisplaysPinDestination
+                    && known.Add(saved))
                     _pinOptions.Add(new($"Pinned — {saved} (disconnected)", true, saved));
             }
         }

--- a/tests/TaskbarQuota.Tests/AdaptiveDisplayProviderStateTests.cs
+++ b/tests/TaskbarQuota.Tests/AdaptiveDisplayProviderStateTests.cs
@@ -84,4 +84,14 @@ public class AdaptiveDisplayProviderStateTests
         Assert.Null(provider);
         Assert.Empty(state.Providers);
     }
+
+    [Fact]
+    public void WindowLookupDoesNotBorrowTheLastActiveProviderForAnUnknownWindow()
+    {
+        var state = new AdaptiveDisplayProviderState();
+        state.Observe(ProviderId.Codex, "DISPLAY1", new IntPtr(10));
+
+        Assert.Equal(ProviderId.Codex, state.GetProviderForWindow(new IntPtr(10)));
+        Assert.Null(state.GetProviderForWindow(new IntPtr(20)));
+    }
 }

--- a/tests/TaskbarQuota.Tests/TaskbarContentRouterTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskbarContentRouterTests.cs
@@ -107,9 +107,33 @@ public class TaskbarContentRouterTests
             "DISPLAY2",
             "DISPLAY1",
             Displays,
-            provider => provider == ProviderId.Antigravity ? "DISPLAY2" : "DISPLAY1");
+            provider => provider == ProviderId.Antigravity ? "DISPLAY2" : "DISPLAY1",
+            _ => false,
+            _ => null);
 
         Assert.Equal([antigravity], routed.Items);
+    }
+
+    [Fact]
+    public void Adaptive_activity_honors_a_fixed_pin_destination()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var codex = new AgentActivityItem(
+            "codex", ProviderId.Codex, "Codex", "Working", AgentActivityStatus.Working, now, now);
+        var snapshot = new AgentActivitySnapshot([codex]);
+
+        var routed = TaskbarContentRouter.ActivityForDisplay(
+            snapshot,
+            TaskbarPlacementMode.Adaptive,
+            string.Empty,
+            "DISPLAY2",
+            "DISPLAY1",
+            Displays,
+            _ => "DISPLAY1",
+            _ => true,
+            _ => "DISPLAY2");
+
+        Assert.Equal([codex], routed.Items);
     }
 
     [Fact]

--- a/tests/TaskbarQuota.Tests/TaskbarWindowTargetTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskbarWindowTargetTests.cs
@@ -50,4 +50,11 @@ public class TaskbarWindowTargetTests
     [InlineData("", 0)]
     public void TryGetDisplayNumber_reads_gdi_display_key(string displayKey, int expected)
         => Assert.Equal(expected, TaskbarWindowTarget.TryGetDisplayNumber(displayKey));
+
+    [Theory]
+    [InlineData("DISPLAY2", "Screen 2")]
+    [InlineData("legacy-monitor-key", "this screen")]
+    [InlineData(WidgetSettingsService.AllDisplaysPinDestination, "all screens")]
+    public void GetDisplayLabel_never_exposes_internal_display_keys(string displayKey, string expected)
+        => Assert.Equal(expected, TaskbarWindowTarget.GetDisplayLabel(displayKey));
 }


### PR DESCRIPTION
Follow-up to #72. Fixes per-screen activity pin routing, active-provider fallback, window/provider move association, topology recovery, pin destination handling, and shared display labels. Adds regression coverage. Test: dotnet test --no-restore (824 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved adaptive activity placement so items follow their configured pinned display.
  - Added clearer pin descriptions, including “this screen,” numbered screens, and “all screens.”
  - Improved handling of window moves and resizing across displays.

- **Bug Fixes**
  - Prevented unknown windows from incorrectly inheriting the last active provider.
  - Preserved existing adaptive destinations when selecting generic pin options.
  - Improved recovery when taskbar display topology changes.

- **Tests**
  - Added coverage for fixed pin destinations, display labels, and window-specific provider detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->