### PR TITLE
fix: preserve provider settings across updates

### DIFF
--- a/src/TaskbarQuota.App/Services/ProviderDiscoveryService.cs
+++ b/src/TaskbarQuota.App/Services/ProviderDiscoveryService.cs
@@ -21,6 +21,7 @@ public static class ProviderDiscoveryService
     private static readonly HashSet<ProviderId> Configured = new();
     private static readonly HashSet<ProviderId> ExplicitlyEnabled = new();
     private static readonly HashSet<ProviderId> ExplicitlyDisabled = new();
+    private static readonly HashSet<ProviderId> ExplicitlyWidgetDisabled = new();
 
     static ProviderDiscoveryService() => Load();
 
@@ -70,7 +71,9 @@ public static class ProviderDiscoveryService
 
             // First successful fetch after install/login — restore widget visibility
             // (auto-hide turns it off for NotInstalled, but usage should return once set up).
-                if (newlyConfigured && !WidgetSettingsService.IsProviderVisible(result.Id))
+                if (newlyConfigured
+                    && !ExplicitlyWidgetDisabled.Contains(result.Id)
+                    && !WidgetSettingsService.IsProviderVisible(result.Id))
                     WidgetSettingsService.SetProviderVisible(result.Id, true);
             }
 
@@ -79,7 +82,8 @@ public static class ProviderDiscoveryService
             {
                 if (!WidgetSettingsService.IsProviderDashboardVisible(result.Id))
                     WidgetSettingsService.SetProviderDashboardVisible(result.Id, true);
-                if (!WidgetSettingsService.IsProviderVisible(result.Id))
+                if (!ExplicitlyWidgetDisabled.Contains(result.Id)
+                    && !WidgetSettingsService.IsProviderVisible(result.Id))
                     WidgetSettingsService.SetProviderVisible(result.Id, true);
             }
 
@@ -127,6 +131,24 @@ public static class ProviderDiscoveryService
             ExplicitlyEnabled.Add(id);
             ExplicitlyDisabled.Remove(id);
             EnsureProviderEnabled(id);
+            Save();
+        }
+    }
+
+    /// <summary>
+    /// Records a user widget-visibility choice separately from automatic provider discovery, so an
+    /// installed provider that the user hid is not silently restored on the next launch.
+    /// </summary>
+    public static void SetWidgetVisibilityPreference(ProviderId id, bool visible)
+    {
+        lock (SyncRoot)
+        {
+            if (visible)
+                ExplicitlyWidgetDisabled.Remove(id);
+            else
+                ExplicitlyWidgetDisabled.Add(id);
+
+            WidgetSettingsService.SetProviderVisible(id, visible);
             Save();
         }
     }
@@ -204,6 +226,7 @@ public static class ProviderDiscoveryService
             Configured.Clear();
             ExplicitlyEnabled.Clear();
             ExplicitlyDisabled.Clear();
+            ExplicitlyWidgetDisabled.Clear();
         }
     }
 
@@ -223,6 +246,12 @@ public static class ProviderDiscoveryService
     {
         lock (SyncRoot)
             ExplicitlyDisabled.Add(id);
+    }
+
+    internal static void MarkExplicitlyWidgetDisabledForTesting(ProviderId id)
+    {
+        lock (SyncRoot)
+            ExplicitlyWidgetDisabled.Add(id);
     }
 
     private static void EnsureProviderEnabled(ProviderId id)
@@ -245,7 +274,8 @@ public static class ProviderDiscoveryService
             dashboardChanged = true;
         }
 
-        if (!WidgetSettingsService.IsProviderVisible(id))
+        if (!ExplicitlyWidgetDisabled.Contains(id)
+            && !WidgetSettingsService.IsProviderVisible(id))
         {
             WidgetSettingsService.SetProviderVisibleSilent(id, true);
             widgetChanged = true;
@@ -256,35 +286,62 @@ public static class ProviderDiscoveryService
 
     private static void Load()
     {
+        bool hasExplicitWidgetState = false;
         try
         {
-            if (!File.Exists(StatePath))
-                return;
+            if (File.Exists(StatePath))
+            {
+                var state = JsonSerializer.Deserialize<DiscoveryState>(File.ReadAllText(StatePath));
+                if (state is not null)
+                {
+                    foreach (var id in state.Probed ?? [])
+                        if (Enum.TryParse<ProviderId>(id, out var parsed))
+                            Probed.Add(parsed);
 
-            var state = JsonSerializer.Deserialize<DiscoveryState>(File.ReadAllText(StatePath));
-            if (state is null)
-                return;
+                    foreach (var id in state.Configured ?? [])
+                        if (Enum.TryParse<ProviderId>(id, out var parsed))
+                            Configured.Add(parsed);
 
-            foreach (var id in state.Probed ?? [])
-                if (Enum.TryParse<ProviderId>(id, out var parsed))
-                    Probed.Add(parsed);
+                    foreach (var id in state.ExplicitlyEnabled ?? [])
+                        if (Enum.TryParse<ProviderId>(id, out var parsed))
+                            ExplicitlyEnabled.Add(parsed);
 
-            foreach (var id in state.Configured ?? [])
-                if (Enum.TryParse<ProviderId>(id, out var parsed))
-                    Configured.Add(parsed);
+                    foreach (var id in state.ExplicitlyDisabled ?? [])
+                        if (Enum.TryParse<ProviderId>(id, out var parsed))
+                            ExplicitlyDisabled.Add(parsed);
 
-            foreach (var id in state.ExplicitlyEnabled ?? [])
-                if (Enum.TryParse<ProviderId>(id, out var parsed))
-                    ExplicitlyEnabled.Add(parsed);
+                    foreach (var id in state.ExplicitlyWidgetDisabled ?? [])
+                        if (Enum.TryParse<ProviderId>(id, out var parsed))
+                            ExplicitlyWidgetDisabled.Add(parsed);
 
-            foreach (var id in state.ExplicitlyDisabled ?? [])
-                if (Enum.TryParse<ProviderId>(id, out var parsed))
-                    ExplicitlyDisabled.Add(parsed);
+                    hasExplicitWidgetState = state.ExplicitlyWidgetDisabled is not null;
+                }
+            }
         }
         catch
         {
             // Best effort — rediscover on next fetch.
         }
+
+        if (hasExplicitWidgetState)
+            return;
+
+        // v1.2/v1.3 stored widget visibility but did not record that a false value came from the
+        // user. Migrate only widget-only hides. Automatic discovery hides both dashboard and
+        // widget, so those remain eligible to reappear if the provider is installed later.
+        bool migrated = false;
+        foreach (ProviderId id in Enum.GetValues<ProviderId>())
+        {
+            bool widgetHidden = WidgetSettingsService.TryGetProviderVisibilityOverride(id, out bool widgetVisible)
+                && !widgetVisible;
+            bool dashboardHidden = WidgetSettingsService.TryGetDashboardProviderVisibilityOverride(id, out bool dashboardVisible)
+                && !dashboardVisible;
+            if (widgetHidden && !dashboardHidden)
+                migrated |= ExplicitlyWidgetDisabled.Add(id);
+        }
+
+        if (migrated)
+            Save();
     }
 
     private static void Save()
@@ -298,6 +355,7 @@ public static class ProviderDiscoveryService
                 Configured = Configured.Select(id => id.ToString()).OrderBy(s => s).ToArray(),
                 ExplicitlyEnabled = ExplicitlyEnabled.Select(id => id.ToString()).OrderBy(s => s).ToArray(),
                 ExplicitlyDisabled = ExplicitlyDisabled.Select(id => id.ToString()).OrderBy(s => s).ToArray(),
+                ExplicitlyWidgetDisabled = ExplicitlyWidgetDisabled.Select(id => id.ToString()).OrderBy(s => s).ToArray(),
             };
             File.WriteAllText(StatePath, JsonSerializer.Serialize(state, new JsonSerializerOptions { WriteIndented = true }));
         }
@@ -313,5 +371,6 @@ public static class ProviderDiscoveryService
         public string[]? Configured { get; set; }
         public string[]? ExplicitlyEnabled { get; set; }
         public string[]? ExplicitlyDisabled { get; set; }
+        public string[]? ExplicitlyWidgetDisabled { get; set; }
     }
 }

--- a/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
+++ b/src/TaskbarQuota.App/Services/WidgetSettingsService.cs
@@ -203,11 +203,17 @@ public static class WidgetSettingsService
         return ProviderVisibility.TryGetValue(key, out bool visible) ? visible : true;
     }
 
+    internal static bool TryGetProviderVisibilityOverride(ProviderId provider, out bool visible)
+        => ProviderVisibility.TryGetValue(provider.ToString(), out visible);
+
     public static bool IsProviderDashboardVisible(ProviderId provider)
     {
         var key = provider.ToString();
         return DashboardProviderVisibility.TryGetValue(key, out bool visible) ? visible : true;
     }
+
+    internal static bool TryGetDashboardProviderVisibilityOverride(ProviderId provider, out bool visible)
+        => DashboardProviderVisibility.TryGetValue(provider.ToString(), out visible);
 
     public static void SetProviderVisible(ProviderId provider, bool visible)
     {

--- a/src/TaskbarQuota.App/Usage/CredentialStore.cs
+++ b/src/TaskbarQuota.App/Usage/CredentialStore.cs
@@ -16,8 +16,9 @@ namespace TaskbarQuota.Usage
     {
         public static CredentialStore Instance { get; } = new();
 
-        private static readonly string Dir = AppStorage.AppDataDirectory;
-        private static readonly string Path_ = Path.Combine(Dir, "credentials.json");
+        private readonly string _directory;
+        private readonly string _path;
+        private readonly string _backupPath;
 
         private Dictionary<string, Entry> _entries = new(StringComparer.OrdinalIgnoreCase);
 
@@ -29,7 +30,15 @@ namespace TaskbarQuota.Usage
             public string? Extra { get; set; } // provider-specific (e.g. MiniMax group id)
         }
 
-        private CredentialStore() => Load();
+        private CredentialStore() : this(AppStorage.AppDataDirectory) { }
+
+        internal CredentialStore(string directory)
+        {
+            _directory = directory;
+            _path = Path.Combine(directory, "credentials.json");
+            _backupPath = _path + ".bak";
+            Load();
+        }
 
         public Entry For(ProviderId id)
         {
@@ -77,25 +86,52 @@ namespace TaskbarQuota.Usage
 
         public void Save()
         {
+            string tempPath = _path + ".tmp";
             try
             {
-                Directory.CreateDirectory(Dir);
-                File.WriteAllText(Path_, JsonSerializer.Serialize(_entries, new JsonSerializerOptions { WriteIndented = true }));
+                Directory.CreateDirectory(_directory);
+                File.WriteAllText(tempPath, JsonSerializer.Serialize(_entries, new JsonSerializerOptions { WriteIndented = true }));
+
+                if (File.Exists(_path))
+                    File.Replace(tempPath, _path, _backupPath, ignoreMetadataErrors: true);
+                else
+                    File.Move(tempPath, _path);
             }
-            catch (Exception ex) { Diagnostics.Log.Warning(ex, "Failed to save credentials"); }
+            catch (Exception ex)
+            {
+                Diagnostics.Log.Warning(ex, "Failed to save credentials");
+                try { if (File.Exists(tempPath)) File.Delete(tempPath); } catch { }
+            }
         }
 
         private void Load()
         {
+            if (TryLoad(_path))
+                return;
+
+            if (TryLoad(_backupPath))
+                Diagnostics.Log.Warning("Recovered credentials from backup after the primary store could not be loaded.");
+        }
+
+        private bool TryLoad(string path)
+        {
             try
             {
-                if (File.Exists(Path_))
-                {
-                    var d = JsonSerializer.Deserialize<Dictionary<string, Entry>>(File.ReadAllText(Path_));
-                    if (d != null) _entries = new Dictionary<string, Entry>(d, StringComparer.OrdinalIgnoreCase);
-                }
+                if (!File.Exists(path))
+                    return false;
+
+                var loaded = JsonSerializer.Deserialize<Dictionary<string, Entry>>(File.ReadAllText(path));
+                if (loaded is null)
+                    return false;
+
+                _entries = new Dictionary<string, Entry>(loaded, StringComparer.OrdinalIgnoreCase);
+                return true;
             }
-            catch (Exception ex) { Diagnostics.Log.Warning(ex, "Failed to load credentials"); }
+            catch (Exception ex)
+            {
+                Diagnostics.Log.Warning(ex, $"Failed to load credential store '{Path.GetFileName(path)}'");
+                return false;
+            }
         }
     }
 }

--- a/src/TaskbarQuota.App/ViewModels/SettingsViewModel.cs
+++ b/src/TaskbarQuota.App/ViewModels/SettingsViewModel.cs
@@ -143,7 +143,7 @@ namespace TaskbarQuota.ViewModels
 
         public void ApplyWidgetVisibility(ProviderSettingItemViewModel item, bool visible)
         {
-            WidgetSettingsService.SetProviderVisible(item.Id, visible);
+            ProviderDiscoveryService.SetWidgetVisibilityPreference(item.Id, visible);
             item.IsWidgetVisible = WidgetSettingsService.IsProviderVisible(item.Id);
             // Hiding a provider from the widget drops its pin.
             item.IsPinned = WidgetSettingsService.IsProviderPinned(item.Id);
@@ -151,6 +151,8 @@ namespace TaskbarQuota.ViewModels
 
         public void ApplyPinned(ProviderSettingItemViewModel item, bool pinned)
         {
+            if (pinned)
+                ProviderDiscoveryService.SetWidgetVisibilityPreference(item.Id, true);
             WidgetSettingsService.SetProviderPinned(item.Id, pinned);
             item.IsPinned = WidgetSettingsService.IsProviderPinned(item.Id);
             // Pinning implies widget-visible, so reflect the possibly-flipped widget toggle.

--- a/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
@@ -445,7 +445,7 @@ namespace TaskbarQuota.Views
             if (sender is not ToggleButton toggle || toggle.Tag is not ProviderCardViewModel card)
                 return;
 
-            WidgetSettingsService.SetProviderVisible(card.ProviderId, toggle.IsChecked == true);
+            ProviderDiscoveryService.SetWidgetVisibilityPreference(card.ProviderId, toggle.IsChecked == true);
             card.IsProviderWidgetVisible = WidgetSettingsService.IsProviderVisible(card.ProviderId);
             // Hiding a provider from the widget also drops its pin, so keep the pin button in step.
             card.IsProviderPinned = WidgetSettingsService.IsProviderPinned(card.ProviderId);
@@ -475,6 +475,8 @@ namespace TaskbarQuota.Views
 
             PinBlockedTip.IsOpen = false;
 
+            if (wantPinned)
+                ProviderDiscoveryService.SetWidgetVisibilityPreference(card.ProviderId, true);
             WidgetSettingsService.SetProviderPinned(card.ProviderId, wantPinned);
             card.IsProviderPinned = WidgetSettingsService.IsProviderPinned(card.ProviderId);
             card.IsProviderWidgetVisible = WidgetSettingsService.IsProviderVisible(card.ProviderId);

--- a/tests/TaskbarQuota.Tests/CredentialStorePersistenceTests.cs
+++ b/tests/TaskbarQuota.Tests/CredentialStorePersistenceTests.cs
@@ -1,0 +1,63 @@
+using TaskbarQuota.Usage;
+
+namespace TaskbarQuota.Tests;
+
+public sealed class CredentialStorePersistenceTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        $"TaskbarQuota-CredentialStoreTests-{Guid.NewGuid():N}");
+
+    [Fact]
+    public void Save_PersistsCredentialsAcrossInstances()
+    {
+        var first = new CredentialStore(_directory);
+        first.For(ProviderId.Copilot).ApiKey = "copilot-token";
+        first.For(ProviderId.Cursor).CookieHeader = "WorkosCursorSessionToken=cursor-cookie";
+
+        first.Save();
+        var reloaded = new CredentialStore(_directory);
+
+        Assert.Equal("copilot-token", reloaded.For(ProviderId.Copilot).ApiKey);
+        Assert.Equal("WorkosCursorSessionToken=cursor-cookie", reloaded.For(ProviderId.Cursor).CookieHeader);
+    }
+
+    [Fact]
+    public void Load_UsesBackupWhenPrimaryFileIsCorrupt()
+    {
+        var store = new CredentialStore(_directory);
+        store.For(ProviderId.Copilot).ApiKey = "preserved-token";
+        store.Save();
+
+        // A second atomic save creates credentials.json.bak from the last known-good file.
+        store.For(ProviderId.Copilot).ApiKey = "new-token";
+        store.Save();
+        File.WriteAllText(Path.Combine(_directory, "credentials.json"), "{broken json");
+
+        var recovered = new CredentialStore(_directory);
+
+        Assert.Equal("preserved-token", recovered.For(ProviderId.Copilot).ApiKey);
+    }
+
+    [Fact]
+    public void Save_ReplacesAnExistingBackupOnLaterSaves()
+    {
+        var store = new CredentialStore(_directory);
+        store.For(ProviderId.Copilot).ApiKey = "first";
+        store.Save();
+        store.For(ProviderId.Copilot).ApiKey = "second";
+        store.Save();
+        store.For(ProviderId.Copilot).ApiKey = "third";
+
+        store.Save();
+
+        var reloaded = new CredentialStore(_directory);
+        Assert.Equal("third", reloaded.For(ProviderId.Copilot).ApiKey);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory))
+            Directory.Delete(_directory, recursive: true);
+    }
+}

--- a/tests/TaskbarQuota.Tests/ProviderDiscoveryServiceTests.cs
+++ b/tests/TaskbarQuota.Tests/ProviderDiscoveryServiceTests.cs
@@ -116,6 +116,19 @@ public class ProviderDiscoveryServiceTests
     }
 
     [Fact]
+    public void SyncInstalledProviderVisibility_PreservesExplicitWidgetHide()
+    {
+        ProviderInstallDetector.IsInstalledOverrideForTesting = id => id == ProviderId.Grok;
+        WidgetSettingsService.SetProviderVisibleForTesting(ProviderId.Grok, false);
+        ProviderDiscoveryService.MarkExplicitlyWidgetDisabledForTesting(ProviderId.Grok);
+
+        ProviderDiscoveryService.SyncInstalledProviderVisibility();
+
+        Assert.True(WidgetSettingsService.IsProviderDashboardVisible(ProviderId.Grok));
+        Assert.False(WidgetSettingsService.IsProviderVisible(ProviderId.Grok));
+    }
+
+    [Fact]
     public void ShouldFetch_SkipsExplicitlyDisabledInstalledProvider()
     {
         ProviderDiscoveryService.MarkExplicitlyDisabledForTesting(ProviderId.Grok);


### PR DESCRIPTION
## Summary
- preserve explicit widget-provider visibility choices across restarts and upgrades
- migrate widget-only hidden preferences written by v1.2/v1.3
- save credentials atomically and recover from a last-known-good backup
- cover provider visibility and Copilot/Cursor credential persistence with regression tests

## Verification
- `dotnet test tests/TaskbarQuota.Tests/TaskbarQuota.Tests.csproj -c Release --no-restore` (762 passed)

Fixes #73