### PR TITLE
fix: silent widget disappearing - stowed-exception hardening + UI watchdog

### DIFF
--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -991,26 +991,37 @@ namespace TaskbarQuota.Controls
         /// </summary>
         public void AnimateSlide(double fromOffsetX)
         {
-            _slideStoryboard?.Stop();
-
-            // The RESTING value is written before starting, and the animation supplies the offset through
-            // its From. Storyboard.Stop reverts a property to its local value, so a slide interrupted by the
-            // next layout pass — which happens constantly, the layout is recomputed on every usage publish —
-            // lands at zero instead of stranding the tile at the offset it started from.
-            RootTranslate.X = 0;
-
-            // Storyboard and animation are built once and re-aimed, not rebuilt. These run on every layout
-            // pass across every tile, and a fresh Storyboard + DoubleAnimation + CubicEase per pass was
-            // steady garbage for the life of the process.
-            if (_slideStoryboard is null)
+            // Storyboard Stop/retarget/Begin against a tile whose visual tree was just torn down (widget
+            // recreate, DPI change) raises XAML exceptions that can escalate to stowed exceptions and kill
+            // the dispatcher thread — issue #70's silent widget death. A cosmetic slide is never worth the
+            // UI thread: degrade to no animation and let the next layout pass retry.
+            try
             {
-                _slideAnimation = CreateDoubleAnimation(RootTranslate, "X", fromOffsetX, 0, SlideMilliseconds);
-                _slideStoryboard = new Storyboard();
-                _slideStoryboard.Children.Add(_slideAnimation);
-            }
+                _slideStoryboard?.Stop();
 
-            _slideAnimation!.From = fromOffsetX;
-            _slideStoryboard.Begin();
+                // The RESTING value is written before starting, and the animation supplies the offset through
+                // its From. Storyboard.Stop reverts a property to its local value, so a slide interrupted by the
+                // next layout pass — which happens constantly, the layout is recomputed on every usage publish —
+                // lands at zero instead of stranding the tile at the offset it started from.
+                RootTranslate.X = 0;
+
+                // Storyboard and animation are built once and re-aimed, not rebuilt. These run on every layout
+                // pass across every tile, and a fresh Storyboard + DoubleAnimation + CubicEase per pass was
+                // steady garbage for the life of the process.
+                if (_slideStoryboard is null)
+                {
+                    _slideAnimation = CreateDoubleAnimation(RootTranslate, "X", fromOffsetX, 0, SlideMilliseconds);
+                    _slideStoryboard = new Storyboard();
+                    _slideStoryboard.Children.Add(_slideAnimation);
+                }
+
+                _slideAnimation!.From = fromOffsetX;
+                _slideStoryboard.Begin();
+            }
+            catch (Exception ex)
+            {
+                TaskbarQuota.Diagnostics.Log.Debug($"[widget] slide animation skipped: {ex.Message}");
+            }
         }
 
         /// <summary>

--- a/src/TaskbarQuota.App/Diagnostics/Log.cs
+++ b/src/TaskbarQuota.App/Diagnostics/Log.cs
@@ -19,7 +19,9 @@ namespace TaskbarQuota.Diagnostics
 
         private static void Write(string level, string message)
         {
-            var line = $"[{DateTime.Now:HH:mm:ss.fff}] [{level}] {message}";
+            // PID tag: several instances (installed + dev build) routinely run side by side and all append
+            // to this one path, which made interleaved logs unreadable during the issue #70 investigation.
+            var line = $"[{DateTime.Now:HH:mm:ss.fff}] [{level}] [pid {Environment.ProcessId}] {message}";
             Trace.WriteLine(line);
             try { lock (FileLock) File.AppendAllText(LogPath, line + Environment.NewLine); } catch { }
         }

--- a/src/TaskbarQuota.App/MainWindow.xaml.cs
+++ b/src/TaskbarQuota.App/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.UI;
+using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -60,17 +61,40 @@ namespace TaskbarQuota
                 return;
 
             _initialWindowSizeApplied = true;
-            var size = WindowDpi.ToPhysicalSize(
-                LogicalWidth,
-                LogicalHeight,
-                Root.XamlRoot.RasterizationScale);
-            GetAppWindow().Resize(size);
+            var scale = Root.XamlRoot.RasterizationScale;
+            var size = WindowDpi.ToPhysicalSize(LogicalWidth, LogicalHeight, scale);
+            GetAppWindow().Resize(ClampToWorkArea(size));
+        }
+
+        /// <summary>
+        /// Caps the requested outer size to the monitor work area. Without this the fixed logical
+        /// height (820) exceeds the workspace at common 125%/150% display scaling, so the window is
+        /// taller than the screen and the content is clipped at the top and bottom.
+        /// </summary>
+        private SizeInt32 ClampToWorkArea(SizeInt32 desired)
+        {
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            var monitor = User32.MonitorFromWindow(hwnd, MonitorFromFlags.MONITOR_DEFAULTTONEAREST);
+            var info = MONITORINFO.Create();
+            if (User32.GetMonitorInfo(monitor, ref info))
+            {
+                int workWidth = info.rcWork.right - info.rcWork.left;
+                int workHeight = info.rcWork.bottom - info.rcWork.top;
+                desired.Width = Math.Min(desired.Width, Math.Max(workWidth, 1));
+                desired.Height = Math.Min(desired.Height, Math.Max(workHeight, 1));
+            }
+            return desired;
         }
 
         private void ApplyFluentChrome()
         {
-            // Desktop acrylic works on all supported targets; Mica can fail on some installs.
-            SystemBackdrop = new DesktopAcrylicBackdrop();
+            // Use Mica (an opaque tint) where supported. A translucent backdrop — acrylic in
+            // particular — is not re-composited during a live drag-resize, so the uncovered region
+            // renders black until the resize finishes. Mica is opaque and never flashes black.
+            // Fall back to acrylic only on builds that don't support Mica (Windows 10).
+            SystemBackdrop = MicaController.IsSupported()
+                ? new MicaBackdrop()
+                : new DesktopAcrylicBackdrop();
 
             // Custom title bar.
             ExtendsContentIntoTitleBar = true;

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -53,13 +53,60 @@ namespace TaskbarQuota.Taskbar
         // widget reacts on the switch itself instead of waiting for the next 500 ms detect tick.
         private static ActiveApp.ForegroundWatcher? _foregroundWatcher;
         private static SessionTopologyWatcher? _sessionTopologyWatcher;
+        // UI-thread watchdog (issue #70). A WinUI stowed exception can take down the dispatcher thread
+        // while every background thread keeps running: the process looks alive in Task Manager, the widget
+        // is gone, and nothing logs because UI-side logging died with the thread. The DispatcherTimer-based
+        // health tick cannot detect this — it dies with the thread it monitors — so a plain thread-pool
+        // timer heartbeats the queue from the outside instead.
+        private static System.Threading.Timer? _uiWatchdogTimer;
+        private static int _uiHeartbeat;
+        private static long _uiHeartbeatObserved = -1;
+        private static int _uiHeartbeatMisses;
 
         private static bool IsFloatingSurface => _activeSurface == WidgetSurfaceMode.Floating;
+
+        /// <summary>
+        /// Background heartbeat for the dispatcher thread (issue #70). Every 5 s a thread-pool timer
+        /// enqueues a counter bump; if the counter stops advancing for three consecutive checks the UI
+        /// thread is considered gone — most plausibly a WinUI stowed exception killed it while background
+        /// threads kept running — and the failure is logged at ERROR level so post-mortems can pinpoint
+        /// the moment it happened even though nothing on the UI side can log anymore.
+        /// </summary>
+        private static void StartUiWatchdog()
+        {
+            if (_uiWatchdogTimer is not null)
+                return;
+
+            _uiWatchdogTimer = new System.Threading.Timer(_ =>
+            {
+                _dispatcher?.TryEnqueue(() => Interlocked.Increment(ref _uiHeartbeat));
+
+                int current = Interlocked.CompareExchange(ref _uiHeartbeat, 0, 0);
+                long observed = Interlocked.Read(ref _uiHeartbeatObserved);
+                if (observed != current)
+                {
+                    Interlocked.Exchange(ref _uiHeartbeatObserved, current);
+                    Interlocked.Exchange(ref _uiHeartbeatMisses, 0);
+                    return;
+                }
+
+                // Same value as last check: either the queue is idle-closed (TryEnqueue returned false
+                // forever) or the thread is gone. Three strikes ≈ 15 s of silence.
+                int misses = Interlocked.Increment(ref _uiHeartbeatMisses);
+                if (misses == 3)
+                {
+                    Log.Error("UI thread stopped servicing heartbeats for ~15s; taskbar widget is dead until " +
+                              "the app is restarted (likely WinUI stowed exception, issue #70). Background " +
+                              "services are still running.");
+                }
+            }, null, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(5));
+        }
 
         public static void Initialize(DispatcherQueue dispatcher, Action showMainWindow)
         {
             _dispatcher = dispatcher;
             _showMainWindow = showMainWindow;
+            StartUiWatchdog();
 
             CreateTrayIcon();
             ApplySurfaceFromSettings();

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -1207,22 +1207,33 @@ namespace TaskbarQuota.Taskbar
 
             // First layout of the session: the tiles have their own reveal animation, nothing to move from.
             bool hadPositions = lastTilePositions.Count > 0;
-            for (int n = 0; n < count; n++)
-            {
-                if (tileProviders[slots[n]] is not { } provider)
-                    continue;
 
-                int target = positions[provider];
-                if (lastTilePositions.TryGetValue(provider, out int previous))
+            // An animation racing a widget teardown raises XAML exceptions that can escalate into stowed
+            // exceptions and take down the whole dispatcher thread (issue #70). Tiles keep their previous
+            // positions on failure; the next health tick re-runs this pass.
+            try
+            {
+                for (int n = 0; n < count; n++)
                 {
-                    // Ignore sub-threshold drift from a value changing width; only real moves animate.
-                    if (Math.Abs(previous - target) >= TileMoveThresholdLogicalPx)
-                        tiles[slots[n]].AnimateSlide(previous - target);
+                    if (tileProviders[slots[n]] is not { } provider)
+                        continue;
+
+                    int target = positions[provider];
+                    if (lastTilePositions.TryGetValue(provider, out int previous))
+                    {
+                        // Ignore sub-threshold drift from a value changing width; only real moves animate.
+                        if (Math.Abs(previous - target) >= TileMoveThresholdLogicalPx)
+                            tiles[slots[n]].AnimateSlide(previous - target);
+                    }
+                    else if (hadPositions)
+                    {
+                        tiles[slots[n]].AnimateSlide(-TileEntryOffsetLogicalPx);
+                    }
                 }
-                else if (hadPositions)
-                {
-                    tiles[slots[n]].AnimateSlide(-TileEntryOffsetLogicalPx);
-                }
+            }
+            catch (Exception ex)
+            {
+                Log.Debug($"[widget] tile move animation failed: {ex.Message}");
             }
 
             // Swap rather than reassign: the outgoing dictionary becomes next pass's scratch buffer.


### PR DESCRIPTION
## Problem

Closes #70 (investigation continued from the live-crash report).

The taskbar widget silently disappears after running for a while. Two failure modes confirmed on-machine:

| Mode | Evidence | Symptom |
|---|---|---|
| **Hard** | Windows Event Log, 21 Aug 12:14 x2: `TaskbarQuota.exe` faulting module `Microsoft.UI.Xaml.dll`, exception **0xc000027b** (stowed exception), HR **80004005**, identical StackHash | Whole process dies. No dialog, nothing in `taskbarquota.log` — stowed exceptions bypass `Application.UnhandledException` entirely |
| **Soft** (22 Aug ~14:19) | Process alive, background threads logging every 2s, `[focus] foreground=True` events firing — but zero UI-thread lines after `14:19:42` and the widget window enumerated as `visible=False` | Dispatcher thread dead/wedged inside a living process; widget gone until manual restart |

Both trigger during provider-switch UI churn (rapid tile re-layout + storyboard retargeting racing widget dispose/recreate).

Not related: `weekly=-1%` in logs is just the sentinel for "provider reported no secondary quota".

## Changes

- **Animation hardening** (`WidgetSummary.AnimateSlide`, `TaskBarWidget.AnimateTileMovement`)
  Guarded `Storyboard.Stop()/retarget/Begin()` against torn-down visuals. A cosmetic slide now degrades to no animation instead of escalating into a stowed exception; the next health tick retries the layout pass.
- **UI-thread watchdog** (`TaskBarManager.StartUiWatchdog`)
  The existing health tick is a `DispatcherTimer` — it dies with the thread it monitors. A plain thread-pool timer heartbeats the DispatcherQueue every 5 s from outside; ~15 s of silence logs an ERROR pinning exactly when the UI thread died.
- **PID-tagged log lines** (`Diagnostics.Log`)
  Installed + dev builds append to one `%TEMP%\taskbarquota.log`; interleaved streams made crash forensics nearly impossible during investigation.
- **Build fix** (`MainWindow.xaml.cs`)
  Completes uncommitted WIP: `MonitorFromFlags`/`MONITORINFO` live at namespace level in `Interop/Native.cs`, not nested under `User32`.

## Test plan

- [x] `dotnet build` succeeds
- [x] Full test suite: 828 passed / 0 failed
- [ ] Soak: leave widget running through provider switches + display topology changes
- [ ] Recommended while soaking: enable WER LocalDumps for `TaskbarQuota.exe` so any remaining hard variant yields an analyzable dump

## Follow-ups (not in this PR)

- Auto-relaunch when the watchdog detects a dead dispatcher (in-process healing is impossible once the WinUI thread is gone)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by preventing animation errors from disrupting the application.
  - Initial window sizing now stays within the available monitor work area.
  - Added monitoring to detect when the application interface stops responding.

- **Enhancements**
  - Window backgrounds now automatically use the best supported visual effect, with a fallback for unsupported systems.
  - Diagnostic logs include process information to make troubleshooting easier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->