### PR TITLE
fix: silent widget disappearing - stowed-exception hardening + UI watchdog

### DIFF
--- a/src/TaskbarQuota.App/App.xaml.cs
+++ b/src/TaskbarQuota.App/App.xaml.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using TaskbarQuota.Diagnostics;
+using TaskbarQuota.Interop;
 using TaskbarQuota.Services;
 using TaskbarQuota.Taskbar;
 
@@ -43,6 +44,7 @@ namespace TaskbarQuota
         protected override void OnLaunched(LaunchActivatedEventArgs args)
         {
             Dispatcher = DispatcherQueue.GetForCurrentThread();
+            RegisterForWindowsRestart(IsWidgetStartup(args.Arguments, Environment.GetCommandLineArgs()));
             AppStorage.MigrateLegacyDataIfNeeded();
             StartupSettingsService.MigrateLegacyStartupEntryIfNeeded();
 
@@ -80,6 +82,21 @@ namespace TaskbarQuota
                 }
             }
 
+        }
+
+        private static void RegisterForWindowsRestart(bool widgetStartup)
+        {
+            try
+            {
+                var result = Kernel32.RegisterApplicationRestart(
+                    widgetStartup ? StartupSettingsService.StartupArgument : null,
+                    ApplicationRestart.None);
+                Log.Debug($"Registered Windows restart recovery: 0x{result.ToInt64():X}");
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Could not register Windows restart recovery");
+            }
         }
 
         public void ShowMainWindow()

--- a/src/TaskbarQuota.App/App.xaml.cs
+++ b/src/TaskbarQuota.App/App.xaml.cs
@@ -90,8 +90,8 @@ namespace TaskbarQuota
             {
                 var result = Kernel32.RegisterApplicationRestart(
                     widgetStartup ? StartupSettingsService.StartupArgument : null,
-                    ApplicationRestart.None);
-                Log.Debug($"Registered Windows restart recovery: 0x{result.ToInt64():X}");
+                    ApplicationRestart.NoReboot);
+                Log.Debug($"Registered Windows restart recovery: HRESULT 0x{result:X8}");
             }
             catch (Exception ex)
             {
@@ -219,6 +219,8 @@ namespace TaskbarQuota
         public static void Quit()
         {
             IsQuitting = true;
+            try { Kernel32.UnregisterApplicationRestart(); }
+            catch (Exception ex) { Log.Warning(ex, "Could not unregister Windows restart recovery"); }
             Quitting?.Invoke();
             Current.Exit();
         }

--- a/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/AgentActivitySummary.xaml.cs
@@ -59,6 +59,15 @@ public sealed partial class AgentActivitySummary : UserControl
         Loaded += (_, _) => ApplyForeground();
         ActualThemeChanged += (_, _) => ApplyForeground();
         PointerWheelChanged += AgentActivitySummary_PointerWheelChanged;
+        Unloaded += (_, _) => StopAnimations();
+    }
+
+    internal void StopAnimations()
+    {
+        try { _selectionStoryboard?.Stop(); } catch { }
+        try { _appearanceStoryboard?.Stop(); } catch { }
+        _selectionStoryboard = null;
+        _appearanceStoryboard = null;
     }
 
     private void OpenActivityButton_Click(object sender, RoutedEventArgs e)

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -181,6 +181,7 @@ namespace TaskbarQuota.Controls
             Unloaded += (_, _) =>
             {
                 WidgetSettingsService.Changed -= OnWidgetSettingsChanged;
+                StopAnimations();
             };
         }
 
@@ -1026,7 +1027,7 @@ namespace TaskbarQuota.Controls
                 _slideStoryboard = null;
                 _slideAnimation = null;
                 try { RootTranslate.X = 0; } catch { }
-                TaskbarQuota.Diagnostics.Log.Debug($"[widget] slide animation skipped: {ex.Message}");
+                TaskbarQuota.Diagnostics.Log.Warning(ex, "[widget] slide animation skipped");
             }
         }
 
@@ -1125,7 +1126,7 @@ namespace TaskbarQuota.Controls
                 _softRefreshStoryboard = null;
                 _softRefreshAnimation = null;
                 try { Panel.Opacity = to; } catch { }
-                TaskbarQuota.Diagnostics.Log.Debug($"[widget] panel animation skipped: {ex.Message}");
+                TaskbarQuota.Diagnostics.Log.Warning(ex, "[widget] panel animation skipped");
             }
         }
 
@@ -1175,8 +1176,30 @@ namespace TaskbarQuota.Controls
                 _visibilityOffset = null;
                 try { Root.Opacity = toOpacity; } catch { }
                 try { RootTranslate.Y = toOffset; } catch { }
-                TaskbarQuota.Diagnostics.Log.Debug($"[widget] visibility animation skipped: {ex.Message}");
+                TaskbarQuota.Diagnostics.Log.Warning(ex, "[widget] visibility animation skipped");
             }
+        }
+
+        /// <summary>
+        /// Stops in-flight storyboards before the visual tree is destroyed. A storyboard whose target is
+        /// already gone is a common source of stowed exception 0xc000027b (issue #70).
+        /// </summary>
+        internal void StopAnimations()
+        {
+            StopStoryboard(ref _slideStoryboard);
+            _slideAnimation = null;
+            StopStoryboard(ref _visibilityStoryboard);
+            _visibilityOpacity = null;
+            _visibilityOffset = null;
+            StopStoryboard(ref _softRefreshStoryboard);
+            _softRefreshAnimation = null;
+        }
+
+        private static void StopStoryboard(ref Storyboard? storyboard)
+        {
+            try { storyboard?.Stop(); }
+            catch { }
+            storyboard = null;
         }
 
         private static DoubleAnimation CreateDoubleAnimation(

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -1020,6 +1020,12 @@ namespace TaskbarQuota.Controls
             }
             catch (Exception ex)
             {
+                // A storyboard that failed against a torn-down visual must not be reused. Otherwise every
+                // later health/layout pass hits the same invalid target and the tile can remain stranded at
+                // its in-flight offset forever.
+                _slideStoryboard = null;
+                _slideAnimation = null;
+                try { RootTranslate.X = 0; } catch { }
                 TaskbarQuota.Diagnostics.Log.Debug($"[widget] slide animation skipped: {ex.Message}");
             }
         }
@@ -1099,18 +1105,28 @@ namespace TaskbarQuota.Controls
         /// </summary>
         private void AnimatePanelOpacity(double from, double to, int milliseconds)
         {
-            _softRefreshStoryboard?.Stop();
-            if (_softRefreshStoryboard is null)
+            try
             {
-                _softRefreshAnimation = CreateDoubleAnimation(Panel, "Opacity", from, to, milliseconds);
-                _softRefreshStoryboard = new Storyboard();
-                _softRefreshStoryboard.Children.Add(_softRefreshAnimation);
-            }
+                _softRefreshStoryboard?.Stop();
+                if (_softRefreshStoryboard is null)
+                {
+                    _softRefreshAnimation = CreateDoubleAnimation(Panel, "Opacity", from, to, milliseconds);
+                    _softRefreshStoryboard = new Storyboard();
+                    _softRefreshStoryboard.Children.Add(_softRefreshAnimation);
+                }
 
-            _softRefreshAnimation!.From = from;
-            _softRefreshAnimation.To = to;
-            _softRefreshAnimation.Duration = new Duration(TimeSpan.FromMilliseconds(milliseconds));
-            _softRefreshStoryboard.Begin();
+                _softRefreshAnimation!.From = from;
+                _softRefreshAnimation.To = to;
+                _softRefreshAnimation.Duration = new Duration(TimeSpan.FromMilliseconds(milliseconds));
+                _softRefreshStoryboard.Begin();
+            }
+            catch (Exception ex)
+            {
+                _softRefreshStoryboard = null;
+                _softRefreshAnimation = null;
+                try { Panel.Opacity = to; } catch { }
+                TaskbarQuota.Diagnostics.Log.Debug($"[widget] panel animation skipped: {ex.Message}");
+            }
         }
 
         /// <summary>
@@ -1122,33 +1138,45 @@ namespace TaskbarQuota.Controls
 
         private void AnimateVisibility(double toOpacity, double toOffset, int milliseconds)
         {
-            double fromOpacity = Root.Opacity;
-            double fromOffset = RootTranslate.Y;
-
-            _visibilityStoryboard?.Stop();
-            // Same rule as AnimateSlide: park the local values at the destination and let the animation
-            // supply the start through From, so an interrupted transition can never leave a tile stuck
-            // invisible or offset.
-            Root.Opacity = toOpacity;
-            RootTranslate.Y = toOffset;
-
-            if (_visibilityStoryboard is null)
+            try
             {
-                _visibilityOpacity = CreateDoubleAnimation(Root, "Opacity", fromOpacity, toOpacity, milliseconds);
-                _visibilityOffset = CreateDoubleAnimation(RootTranslate, "Y", fromOffset, toOffset, milliseconds);
-                _visibilityStoryboard = new Storyboard();
-                _visibilityStoryboard.Children.Add(_visibilityOpacity);
-                _visibilityStoryboard.Children.Add(_visibilityOffset);
-            }
+                double fromOpacity = Root.Opacity;
+                double fromOffset = RootTranslate.Y;
 
-            var duration = new Duration(TimeSpan.FromMilliseconds(milliseconds));
-            _visibilityOpacity!.From = fromOpacity;
-            _visibilityOpacity.To = toOpacity;
-            _visibilityOpacity.Duration = duration;
-            _visibilityOffset!.From = fromOffset;
-            _visibilityOffset.To = toOffset;
-            _visibilityOffset.Duration = duration;
-            _visibilityStoryboard.Begin();
+                _visibilityStoryboard?.Stop();
+                // Same rule as AnimateSlide: park the local values at the destination and let the animation
+                // supply the start through From, so an interrupted transition can never leave a tile stuck
+                // invisible or offset.
+                Root.Opacity = toOpacity;
+                RootTranslate.Y = toOffset;
+
+                if (_visibilityStoryboard is null)
+                {
+                    _visibilityOpacity = CreateDoubleAnimation(Root, "Opacity", fromOpacity, toOpacity, milliseconds);
+                    _visibilityOffset = CreateDoubleAnimation(RootTranslate, "Y", fromOffset, toOffset, milliseconds);
+                    _visibilityStoryboard = new Storyboard();
+                    _visibilityStoryboard.Children.Add(_visibilityOpacity);
+                    _visibilityStoryboard.Children.Add(_visibilityOffset);
+                }
+
+                var duration = new Duration(TimeSpan.FromMilliseconds(milliseconds));
+                _visibilityOpacity!.From = fromOpacity;
+                _visibilityOpacity.To = toOpacity;
+                _visibilityOpacity.Duration = duration;
+                _visibilityOffset!.From = fromOffset;
+                _visibilityOffset.To = toOffset;
+                _visibilityOffset.Duration = duration;
+                _visibilityStoryboard.Begin();
+            }
+            catch (Exception ex)
+            {
+                _visibilityStoryboard = null;
+                _visibilityOpacity = null;
+                _visibilityOffset = null;
+                try { Root.Opacity = toOpacity; } catch { }
+                try { RootTranslate.Y = toOffset; } catch { }
+                TaskbarQuota.Diagnostics.Log.Debug($"[widget] visibility animation skipped: {ex.Message}");
+            }
         }
 
         private static DoubleAnimation CreateDoubleAnimation(

--- a/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
+++ b/src/TaskbarQuota.App/Controls/WidgetSummary.xaml.cs
@@ -991,26 +991,37 @@ namespace TaskbarQuota.Controls
         /// </summary>
         public void AnimateSlide(double fromOffsetX)
         {
-            _slideStoryboard?.Stop();
-
-            // The RESTING value is written before starting, and the animation supplies the offset through
-            // its From. Storyboard.Stop reverts a property to its local value, so a slide interrupted by the
-            // next layout pass — which happens constantly, the layout is recomputed on every usage publish —
-            // lands at zero instead of stranding the tile at the offset it started from.
-            RootTranslate.X = 0;
-
-            // Storyboard and animation are built once and re-aimed, not rebuilt. These run on every layout
-            // pass across every tile, and a fresh Storyboard + DoubleAnimation + CubicEase per pass was
-            // steady garbage for the life of the process.
-            if (_slideStoryboard is null)
+            // Storyboard Stop/retarget/Begin against a tile whose visual tree was just torn down (widget
+            // recreate, DPI change) raises XAML exceptions that can escalate to stowed exceptions and kill
+            // the dispatcher thread — issue #70's silent widget death. A cosmetic slide is never worth the
+            // UI thread: degrade to no animation and let the next layout pass retry.
+            try
             {
-                _slideAnimation = CreateDoubleAnimation(RootTranslate, "X", fromOffsetX, 0, SlideMilliseconds);
-                _slideStoryboard = new Storyboard();
-                _slideStoryboard.Children.Add(_slideAnimation);
-            }
+                _slideStoryboard?.Stop();
 
-            _slideAnimation!.From = fromOffsetX;
-            _slideStoryboard.Begin();
+                // The RESTING value is written before starting, and the animation supplies the offset through
+                // its From. Storyboard.Stop reverts a property to its local value, so a slide interrupted by the
+                // next layout pass — which happens constantly, the layout is recomputed on every usage publish —
+                // lands at zero instead of stranding the tile at the offset it started from.
+                RootTranslate.X = 0;
+
+                // Storyboard and animation are built once and re-aimed, not rebuilt. These run on every layout
+                // pass across every tile, and a fresh Storyboard + DoubleAnimation + CubicEase per pass was
+                // steady garbage for the life of the process.
+                if (_slideStoryboard is null)
+                {
+                    _slideAnimation = CreateDoubleAnimation(RootTranslate, "X", fromOffsetX, 0, SlideMilliseconds);
+                    _slideStoryboard = new Storyboard();
+                    _slideStoryboard.Children.Add(_slideAnimation);
+                }
+
+                _slideAnimation!.From = fromOffsetX;
+                _slideStoryboard.Begin();
+            }
+            catch (Exception ex)
+            {
+                TaskbarQuota.Diagnostics.Log.Debug($"[widget] slide animation skipped: {ex.Message}");
+            }
         }
 
         /// <summary>

--- a/src/TaskbarQuota.App/Diagnostics/Log.cs
+++ b/src/TaskbarQuota.App/Diagnostics/Log.cs
@@ -19,7 +19,9 @@ namespace TaskbarQuota.Diagnostics
 
         private static void Write(string level, string message)
         {
-            var line = $"[{DateTime.Now:HH:mm:ss.fff}] [{level}] {message}";
+            // PID tag: several instances (installed + dev build) routinely run side by side and all append
+            // to this one path, which made interleaved logs unreadable during the issue #70 investigation.
+            var line = $"[{DateTime.Now:HH:mm:ss.fff}] [{level}] [pid {Environment.ProcessId}] {message}";
             Trace.WriteLine(line);
             try { lock (FileLock) File.AppendAllText(LogPath, line + Environment.NewLine); } catch { }
         }

--- a/src/TaskbarQuota.App/Interop/Native.cs
+++ b/src/TaskbarQuota.App/Interop/Native.cs
@@ -310,8 +310,13 @@ namespace TaskbarQuota.Interop
         [DllImport("kernel32.dll")]
         public static extern IntPtr GetModuleHandle(string? module);
 
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        public static extern int RegisterApplicationRestart(
+            [MarshalAs(UnmanagedType.LPWStr)] string? pwzCommandline,
+            ApplicationRestart dwFlags = ApplicationRestart.None);
+
         [DllImport("kernel32.dll")]
-        public static extern IntPtr RegisterApplicationRestart(string? pwzCommandline, ApplicationRestart dwFlags = ApplicationRestart.None);
+        public static extern int UnregisterApplicationRestart();
     }
 
     [Flags]
@@ -420,5 +425,9 @@ namespace TaskbarQuota.Interop
     public enum ApplicationRestart
     {
         None = 0,
+        NoCrash = 1,
+        NoHang = 2,
+        NoPatch = 4,
+        NoReboot = 8,
     }
 }

--- a/src/TaskbarQuota.App/MainWindow.xaml.cs
+++ b/src/TaskbarQuota.App/MainWindow.xaml.cs
@@ -1,6 +1,5 @@
 using System;
 using Microsoft.UI;
-using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -61,40 +60,17 @@ namespace TaskbarQuota
                 return;
 
             _initialWindowSizeApplied = true;
-            var scale = Root.XamlRoot.RasterizationScale;
-            var size = WindowDpi.ToPhysicalSize(LogicalWidth, LogicalHeight, scale);
-            GetAppWindow().Resize(ClampToWorkArea(size));
-        }
-
-        /// <summary>
-        /// Caps the requested outer size to the monitor work area. Without this the fixed logical
-        /// height (820) exceeds the workspace at common 125%/150% display scaling, so the window is
-        /// taller than the screen and the content is clipped at the top and bottom.
-        /// </summary>
-        private SizeInt32 ClampToWorkArea(SizeInt32 desired)
-        {
-            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            var monitor = User32.MonitorFromWindow(hwnd, MonitorFromFlags.MONITOR_DEFAULTTONEAREST);
-            var info = MONITORINFO.Create();
-            if (User32.GetMonitorInfo(monitor, ref info))
-            {
-                int workWidth = info.rcWork.right - info.rcWork.left;
-                int workHeight = info.rcWork.bottom - info.rcWork.top;
-                desired.Width = Math.Min(desired.Width, Math.Max(workWidth, 1));
-                desired.Height = Math.Min(desired.Height, Math.Max(workHeight, 1));
-            }
-            return desired;
+            var size = WindowDpi.ToPhysicalSize(
+                LogicalWidth,
+                LogicalHeight,
+                Root.XamlRoot.RasterizationScale);
+            GetAppWindow().Resize(size);
         }
 
         private void ApplyFluentChrome()
         {
-            // Use Mica (an opaque tint) where supported. A translucent backdrop — acrylic in
-            // particular — is not re-composited during a live drag-resize, so the uncovered region
-            // renders black until the resize finishes. Mica is opaque and never flashes black.
-            // Fall back to acrylic only on builds that don't support Mica (Windows 10).
-            SystemBackdrop = MicaController.IsSupported()
-                ? new MicaBackdrop()
-                : new DesktopAcrylicBackdrop();
+            // Desktop acrylic works on all supported targets; Mica can fail on some installs.
+            SystemBackdrop = new DesktopAcrylicBackdrop();
 
             // Custom title bar.
             ExtendsContentIntoTitleBar = true;

--- a/src/TaskbarQuota.App/MainWindow.xaml.cs
+++ b/src/TaskbarQuota.App/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.UI;
+using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -60,17 +61,40 @@ namespace TaskbarQuota
                 return;
 
             _initialWindowSizeApplied = true;
-            var size = WindowDpi.ToPhysicalSize(
-                LogicalWidth,
-                LogicalHeight,
-                Root.XamlRoot.RasterizationScale);
-            GetAppWindow().Resize(size);
+            var scale = Root.XamlRoot.RasterizationScale;
+            var size = WindowDpi.ToPhysicalSize(LogicalWidth, LogicalHeight, scale);
+            GetAppWindow().Resize(ClampToWorkArea(size));
+        }
+
+        /// <summary>
+        /// Caps the requested outer size to the monitor work area. Without this the fixed logical
+        /// height (820) exceeds the workspace at common 125%/150% display scaling, so the window is
+        /// taller than the screen and the content is clipped at the top and bottom.
+        /// </summary>
+        private SizeInt32 ClampToWorkArea(SizeInt32 desired)
+        {
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            var monitor = User32.MonitorFromWindow(hwnd, MonitorFromFlags.MONITOR_DEFAULTTONEAREST);
+            var info = MONITORINFO.Create();
+            if (User32.GetMonitorInfo(monitor, ref info))
+            {
+                int workWidth = info.rcWork.right - info.rcWork.left;
+                int workHeight = info.rcWork.bottom - info.rcWork.top;
+                desired.Width = Math.Min(desired.Width, Math.Max(workWidth, 1));
+                desired.Height = Math.Min(desired.Height, Math.Max(workHeight, 1));
+            }
+            return desired;
         }
 
         private void ApplyFluentChrome()
         {
-            // Desktop acrylic works on all supported targets; Mica can fail on some installs.
-            SystemBackdrop = new DesktopAcrylicBackdrop();
+            // Use Mica (an opaque tint) where supported. A translucent backdrop — acrylic in
+            // particular — is not re-composited during a live drag-resize, so the uncovered region
+            // renders black until the resize finishes. Mica is opaque and never flashes black.
+            // Fall back to acrylic only on builds that don't support Mica (Windows 10).
+            SystemBackdrop = MicaController.IsSupported()
+                ? new MicaBackdrop()
+                : new DesktopAcrylicBackdrop();
 
             // Custom title bar.
             ExtendsContentIntoTitleBar = true;

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -8,10 +8,12 @@ using H.NotifyIcon.Core;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.Windows.AppLifecycle;
 using TaskbarQuota.Diagnostics;
 using TaskbarQuota.Interop;
 using TaskbarQuota.Usage;
 using TaskbarQuota.AgentActivity;
+using TaskbarQuota.Services;
 
 namespace TaskbarQuota.Taskbar
 {
@@ -62,6 +64,9 @@ namespace TaskbarQuota.Taskbar
         private static int _uiHeartbeat;
         private static long _uiHeartbeatObserved = -1;
         private static int _uiHeartbeatMisses;
+        private static int _uiWatchdogStopping;
+        private static int _uiWatchdogRestartRequested;
+        private const int UiWatchdogMissLimit = 3;
 
         private static bool IsFloatingSurface => _activeSurface == WidgetSurfaceMode.Floating;
 
@@ -77,9 +82,34 @@ namespace TaskbarQuota.Taskbar
             if (_uiWatchdogTimer is not null)
                 return;
 
-            _uiWatchdogTimer = new System.Threading.Timer(_ =>
+            Interlocked.Exchange(ref _uiWatchdogStopping, 0);
+            Interlocked.Exchange(ref _uiWatchdogRestartRequested, 0);
+            Interlocked.Exchange(ref _uiHeartbeat, 0);
+            Interlocked.Exchange(ref _uiHeartbeatObserved, -1);
+            Interlocked.Exchange(ref _uiHeartbeatMisses, 0);
+            _uiWatchdogTimer = new System.Threading.Timer(_ => UiWatchdogTick(),
+                null,
+                TimeSpan.FromSeconds(10),
+                TimeSpan.FromSeconds(5));
+        }
+
+        private static void UiWatchdogTick()
+        {
+            if (Volatile.Read(ref _uiWatchdogStopping) != 0)
+                return;
+
+            try
             {
-                _dispatcher?.TryEnqueue(() => Interlocked.Increment(ref _uiHeartbeat));
+                try
+                {
+                    _dispatcher?.TryEnqueue(() => Interlocked.Increment(ref _uiHeartbeat));
+                }
+                catch (Exception ex)
+                {
+                    // Treat a queue/COM failure as a missed heartbeat and let the normal threshold logic
+                    // decide whether the dispatcher is unrecoverable.
+                    Log.Debug($"UI watchdog could not enqueue heartbeat: {ex.Message}");
+                }
 
                 int current = Interlocked.CompareExchange(ref _uiHeartbeat, 0, 0);
                 long observed = Interlocked.Read(ref _uiHeartbeatObserved);
@@ -93,13 +123,40 @@ namespace TaskbarQuota.Taskbar
                 // Same value as last check: either the queue is idle-closed (TryEnqueue returned false
                 // forever) or the thread is gone. Three strikes ≈ 15 s of silence.
                 int misses = Interlocked.Increment(ref _uiHeartbeatMisses);
-                if (misses == 3)
+                if (ShouldRestartUiWatchdog(
+                    misses,
+                    App.IsQuitting,
+                    Volatile.Read(ref _uiWatchdogRestartRequested) != 0)
+                    && Interlocked.CompareExchange(ref _uiWatchdogRestartRequested, 1, 0) == 0)
                 {
                     Log.Error("UI thread stopped servicing heartbeats for ~15s; taskbar widget is dead until " +
-                              "the app is restarted (likely WinUI stowed exception, issue #70). Background " +
-                              "services are still running.");
+                              "the app is restarted (likely WinUI stowed exception, issue #70). Requesting " +
+                              "an automatic restart; background services are still running.");
+                    RequestUiRestart();
                 }
-            }, null, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(5));
+            }
+            catch (Exception ex)
+            {
+                // A closed DispatcherQueue or a failed restart request must not let the watchdog itself
+                // become another unhandled thread-pool exception.
+                Log.Warning(ex, "UI watchdog tick failed");
+            }
+        }
+
+        internal static bool ShouldRestartUiWatchdog(int misses, bool isQuitting, bool restartRequested)
+            => misses >= UiWatchdogMissLimit && !isQuitting && !restartRequested;
+
+        private static void RequestUiRestart()
+        {
+            try
+            {
+                var reason = AppInstance.Restart(StartupSettingsService.StartupArgument);
+                Log.Error($"UI watchdog restart result: {reason}");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "UI watchdog could not request an app restart");
+            }
         }
 
         public static void Initialize(DispatcherQueue dispatcher, Action showMainWindow)
@@ -1129,6 +1186,9 @@ namespace TaskbarQuota.Taskbar
             UsageCoordinator.Instance.IsOwnUiEngaged = null;
             WidgetSettingsService.Changed -= OnWidgetSettingsChanged;
             _initialized = false;
+            Interlocked.Exchange(ref _uiWatchdogStopping, 1);
+            _uiWatchdogTimer?.Dispose();
+            _uiWatchdogTimer = null;
             _widgetHealthTimer?.Stop();
             _widgetHealthTimer = null;
             _topologyRecoveryTimer?.Stop();

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -108,7 +109,7 @@ namespace TaskbarQuota.Taskbar
                 {
                     // Treat a queue/COM failure as a missed heartbeat and let the normal threshold logic
                     // decide whether the dispatcher is unrecoverable.
-                    Log.Debug($"UI watchdog could not enqueue heartbeat: {ex.Message}");
+                    Log.Warning(ex, "UI watchdog could not enqueue heartbeat");
                 }
 
                 int current = Interlocked.CompareExchange(ref _uiHeartbeat, 0, 0);
@@ -132,7 +133,11 @@ namespace TaskbarQuota.Taskbar
                     Log.Error("UI thread stopped servicing heartbeats for ~15s; taskbar widget is dead until " +
                               "the app is restarted (likely WinUI stowed exception, issue #70). Requesting " +
                               "an automatic restart; background services are still running.");
-                    RequestUiRestart();
+                    if (!RequestUiRestart())
+                    {
+                        // Do not leave the one-shot latch set after a failed spawn — later ticks must retry.
+                        Interlocked.Exchange(ref _uiWatchdogRestartRequested, 0);
+                    }
                 }
             }
             catch (Exception ex)
@@ -146,16 +151,73 @@ namespace TaskbarQuota.Taskbar
         internal static bool ShouldRestartUiWatchdog(int misses, bool isQuitting, bool restartRequested)
             => misses >= UiWatchdogMissLimit && !isQuitting && !restartRequested;
 
-        private static void RequestUiRestart()
+        /// <summary>
+        /// Best-effort recovery for a dead dispatcher. <see cref="AppInstance.Restart"/> needs a foreground
+        /// window and will not return on success, so a tray-only widget with a wedged UI thread has to
+        /// unregister the single-instance key and start a replacement process itself.
+        /// Returns true when a new process was started (this process should then exit).
+        /// </summary>
+        private static bool RequestUiRestart()
         {
             try
             {
                 var reason = AppInstance.Restart(StartupSettingsService.StartupArgument);
-                Log.Error($"UI watchdog restart result: {reason}");
+                Log.Error($"UI watchdog AppInstance.Restart returned {reason}; falling back to a new process");
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "UI watchdog could not request an app restart");
+                Log.Error(ex, "UI watchdog AppInstance.Restart threw; falling back to a new process");
+            }
+
+            if (!TrySpawnReplacementProcess())
+            {
+                Log.Error("UI watchdog could not start a replacement process; will retry on the next miss streak");
+                return false;
+            }
+
+            Environment.Exit(1);
+            return true;
+        }
+
+        private static bool TrySpawnReplacementProcess()
+        {
+            var path = Environment.ProcessPath;
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            {
+                Log.Error("UI watchdog replacement path is missing");
+                return false;
+            }
+
+            try
+            {
+                AppInstance.GetCurrent().UnregisterKey();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "UI watchdog could not unregister the single-instance key");
+            }
+
+            try
+            {
+                var started = Process.Start(new ProcessStartInfo
+                {
+                    FileName = path,
+                    Arguments = StartupSettingsService.StartupArgument,
+                    UseShellExecute = false,
+                });
+                if (started is null)
+                {
+                    Log.Error("UI watchdog Process.Start returned null");
+                    return false;
+                }
+
+                Log.Error($"UI watchdog started replacement pid {started.Id}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "UI watchdog Process.Start failed");
+                return false;
             }
         }
 

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -53,13 +53,60 @@ namespace TaskbarQuota.Taskbar
         // widget reacts on the switch itself instead of waiting for the next 500 ms detect tick.
         private static ActiveApp.ForegroundWatcher? _foregroundWatcher;
         private static SessionTopologyWatcher? _sessionTopologyWatcher;
+        // UI-thread watchdog (issue #70). A WinUI stowed exception can take down the dispatcher thread
+        // while every background thread keeps running: the process looks alive in Task Manager, the widget
+        // is gone, and nothing logs because UI-side logging died with the thread. The DispatcherTimer-based
+        // health tick cannot detect this — it dies with the thread it monitors — so a plain thread-pool
+        // timer heartbeats the queue from the outside instead.
+        private static System.Threading.Timer? _uiWatchdogTimer;
+        private static int _uiHeartbeat;
+        private static long _uiHeartbeatObserved = -1;
+        private static int _uiHeartbeatMisses;
 
         private static bool IsFloatingSurface => _activeSurface == WidgetSurfaceMode.Floating;
+
+        /// <summary>
+        /// Background heartbeat for the dispatcher thread (issue #70). Every 5 s a thread-pool timer
+        /// enqueues a counter bump; if the counter stops advancing for three consecutive checks the UI
+        /// thread is considered gone — most plausibly a WinUI stowed exception killed it while background
+        /// threads kept running — and the failure is logged at ERROR level so post-mortems can pinpoint
+        /// the moment it happened even though nothing on the UI side can log anymore.
+        /// </summary>
+        private static void StartUiWatchdog()
+        {
+            if (_uiWatchdogTimer is not null)
+                return;
+
+            _uiWatchdogTimer = new System.Threading.Timer(_ =>
+            {
+                _dispatcher?.TryEnqueue(() => Interlocked.Increment(ref _uiHeartbeat));
+
+                int current = Interlocked.CompareExchange(ref _uiHeartbeat, 0, 0);
+                long observed = Interlocked.Read(ref _uiHeartbeatObserved);
+                if (observed != current)
+                {
+                    Interlocked.Exchange(ref _uiHeartbeatObserved, current);
+                    Interlocked.Exchange(ref _uiHeartbeatMisses, 0);
+                    return;
+                }
+
+                // Same value as last check: either the queue is idle-closed (TryEnqueue returned false
+                // forever) or the thread is gone. Three strikes ≈ 15 s of silence.
+                int misses = Interlocked.Increment(ref _uiHeartbeatMisses);
+                if (misses == 3)
+                {
+                    Log.Error("UI thread stopped servicing heartbeats for ~15s; taskbar widget is dead until " +
+                              "the app is restarted (likely WinUI stowed exception, issue #70). Background " +
+                              "services are still running.");
+                }
+            }, null, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(5));
+        }
 
         public static void Initialize(DispatcherQueue dispatcher, Action showMainWindow)
         {
             _dispatcher = dispatcher;
             _showMainWindow = showMainWindow;
+            StartUiWatchdog();
 
             CreateTrayIcon();
             ApplySurfaceFromSettings();

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -660,7 +660,7 @@ namespace TaskbarQuota.Taskbar
                 hostFadeStoryboard = null;
                 try { content.Opacity = to; } catch { }
                 InvokeAnimationCompletion(completed);
-                Log.Debug($"[widget] host fade skipped: {ex.Message}");
+                Log.Warning(ex, "[widget] host fade skipped");
             }
         }
 
@@ -673,7 +673,11 @@ namespace TaskbarQuota.Taskbar
             catch (Exception ex) { Log.Debug($"[widget] animation completion skipped: {ex.Message}"); }
         }
 
-        public void Destroy() => appWindow?.Destroy();
+        public void Destroy()
+        {
+            StopHostStoryboards();
+            appWindow?.Destroy();
+        }
 
         public void UpdatePosition(bool resetManualPosition = false)
         {
@@ -1252,7 +1256,8 @@ namespace TaskbarQuota.Taskbar
             }
             catch (Exception ex)
             {
-                Log.Debug($"[widget] tile move animation failed: {ex.Message}");
+                Log.Warning(ex, "[widget] tile move animation failed");
+                return;
             }
 
             // Swap rather than reassign: the outgoing dictionary becomes next pass's scratch buffer.
@@ -1385,7 +1390,7 @@ namespace TaskbarQuota.Taskbar
                     content.Opacity = 1;
                 }
                 catch { }
-                Log.Debug($"[widget] layout animation skipped: {ex.Message}");
+                Log.Warning(ex, "[widget] layout animation skipped");
             }
         }
 
@@ -1462,7 +1467,7 @@ namespace TaskbarQuota.Taskbar
                 activityFadeStoryboard = null;
                 try { content.Opacity = to; } catch { }
                 InvokeAnimationCompletion(completed);
-                Log.Debug($"[widget] activity fade skipped: {ex.Message}");
+                Log.Warning(ex, "[widget] activity fade skipped");
             }
         }
 
@@ -2346,7 +2351,7 @@ namespace TaskbarQuota.Taskbar
                     activityTransform.TranslateX = 0;
                 }
                 catch { }
-                Log.Debug($"[widget] pair-swap animation skipped: {ex.Message}");
+                Log.Warning(ex, "[widget] pair-swap animation skipped");
             }
         }
 
@@ -3467,8 +3472,28 @@ namespace TaskbarQuota.Taskbar
             try { positionUpdateGate.Dispose(); } catch { }
         }
 
+        private void StopHostStoryboards()
+        {
+            StopStoryboard(ref hostFadeStoryboard);
+            StopStoryboard(ref activityFadeStoryboard);
+            StopStoryboard(ref quotaLayoutStoryboard);
+            StopStoryboard(ref activityLayoutStoryboard);
+            StopStoryboard(ref swapVisualStoryboard);
+            foreach (var tile in tiles)
+                tile?.StopAnimations();
+            activitySummary?.StopAnimations();
+        }
+
+        private static void StopStoryboard(ref Anim.Storyboard? storyboard)
+        {
+            try { storyboard?.Stop(); }
+            catch { }
+            storyboard = null;
+        }
+
         private void DisposeWindowResources()
         {
+            StopHostStoryboards();
             if (hwnd != IntPtr.Zero)
                 HostOwners.TryRemove(hwnd, out _);
             if (activityHwnd != IntPtr.Zero)

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -1207,22 +1207,33 @@ namespace TaskbarQuota.Taskbar
 
             // First layout of the session: the tiles have their own reveal animation, nothing to move from.
             bool hadPositions = lastTilePositions.Count > 0;
-            for (int n = 0; n < count; n++)
-            {
-                if (tileProviders[slots[n]] is not { } provider)
-                    continue;
 
-                int target = positions[provider];
-                if (lastTilePositions.TryGetValue(provider, out int previous))
+            // An animation racing a widget teardown raises XAML exceptions that can escalate into stowed
+            // exceptions and take down the whole dispatcher thread (issue #70). Tiles keep their previous
+            // positions on failure; the next health tick re-runs this pass.
+            try
+            {
+                for (int n = 0; n < count; n++)
                 {
-                    // Ignore sub-threshold drift from a value changing width; only real moves animate.
-                    if (Math.Abs(previous - target) >= TileMoveThresholdLogicalPx)
-                        tiles[slots[n]].AnimateSlide(previous - target);
+                    if (tileProviders[slots[n]] is not { } provider)
+                        continue;
+
+                    int target = positions[provider];
+                    if (lastTilePositions.TryGetValue(provider, out int previous))
+                    {
+                        // Ignore sub-threshold drift from a value changing width; only real moves animate.
+                        if (Math.Abs(previous - target) >= TileMoveThresholdLogicalPx)
+                            tiles[slots[n]].AnimateSlide(previous - target);
+                    }
+                    else if (hadPositions)
+                    {
+                        tiles[slots[n]].AnimateSlide(-TileEntryOffsetLogicalPx);
+                    }
                 }
-                else if (hadPositions)
-                {
-                    tiles[slots[n]].AnimateSlide(-TileEntryOffsetLogicalPx);
-                }
+            }
+            catch (Exception ex)
+            {
+                Log.Debug($"[widget] tile move animation failed: {ex.Message}");
             }
 
             // Swap rather than reassign: the outgoing dictionary becomes next pass's scratch buffer.

--- a/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarWidget.cs
@@ -610,48 +610,67 @@ namespace TaskbarQuota.Taskbar
         {
             if (hostContent is not { } content)
             {
-                completed?.Invoke();
+                InvokeAnimationCompletion(completed);
                 return;
             }
 
-            hostFadeStoryboard?.Stop();
-
-            double from = content.Opacity;
-
-            // When hiding (to == 0) we always run the storyboard, even if the content is already
-            // near-transparent: skipping it would call the completion immediately, which hides the
-            // window without any animation and is the "instant disappear" the user saw.
-            // When showing (to == 1) skip is fine — nothing to animate if we're already opaque.
-            bool skip = Math.Abs(from - to) < 0.01 && to > 0.5;
-            if (skip)
+            try
             {
+                hostFadeStoryboard?.Stop();
+
+                double from = content.Opacity;
+
+                // When hiding (to == 0) we always run the storyboard, even if the content is already
+                // near-transparent: skipping it would call the completion immediately, which hides the
+                // window without any animation and is the "instant disappear" the user saw.
+                // When showing (to == 1) skip is fine — nothing to animate if we're already opaque.
+                bool skip = Math.Abs(from - to) < 0.01 && to > 0.5;
+                if (skip)
+                {
+                    content.Opacity = to;
+                    InvokeAnimationCompletion(completed);
+                    return;
+                }
+
+                // Park the local value at the destination and let the animation supply the start through From,
+                // the same rule the tile animations follow: an interrupted fade then settles visible rather
+                // than leaving the host stuck transparent.
                 content.Opacity = to;
-                completed?.Invoke();
-                return;
+
+                var animation = new Anim.DoubleAnimation
+                {
+                    From = from < 0.01 ? 0.15 : from, // guarantee at least a short visible flash so the fade is perceptible
+                    To = to,
+                    Duration = new Microsoft.UI.Xaml.Duration(TimeSpan.FromMilliseconds(HostFadeMilliseconds)),
+                    EasingFunction = new Anim.CubicEase { EasingMode = Anim.EasingMode.EaseOut },
+                };
+                Anim.Storyboard.SetTarget(animation, content);
+                Anim.Storyboard.SetTargetProperty(animation, "Opacity");
+
+                var storyboard = new Anim.Storyboard();
+                storyboard.Children.Add(animation);
+                if (completed is not null)
+                    storyboard.Completed += (_, _) => InvokeAnimationCompletion(completed);
+
+                hostFadeStoryboard = storyboard;
+                storyboard.Begin();
             }
-
-            // Park the local value at the destination and let the animation supply the start through From,
-            // the same rule the tile animations follow: an interrupted fade then settles visible rather
-            // than leaving the host stuck transparent.
-            content.Opacity = to;
-
-            var animation = new Anim.DoubleAnimation
+            catch (Exception ex)
             {
-                From = from < 0.01 ? 0.15 : from, // guarantee at least a short visible flash so the fade is perceptible
-                To = to,
-                Duration = new Microsoft.UI.Xaml.Duration(TimeSpan.FromMilliseconds(HostFadeMilliseconds)),
-                EasingFunction = new Anim.CubicEase { EasingMode = Anim.EasingMode.EaseOut },
-            };
-            Anim.Storyboard.SetTarget(animation, content);
-            Anim.Storyboard.SetTargetProperty(animation, "Opacity");
+                hostFadeStoryboard = null;
+                try { content.Opacity = to; } catch { }
+                InvokeAnimationCompletion(completed);
+                Log.Debug($"[widget] host fade skipped: {ex.Message}");
+            }
+        }
 
-            var storyboard = new Anim.Storyboard();
-            storyboard.Children.Add(animation);
-            if (completed is not null)
-                storyboard.Completed += (_, _) => completed();
+        private static void InvokeAnimationCompletion(Action? completed)
+        {
+            if (completed is null)
+                return;
 
-            hostFadeStoryboard = storyboard;
-            storyboard.Begin();
+            try { completed(); }
+            catch (Exception ex) { Log.Debug($"[widget] animation completion skipped: {ex.Message}"); }
         }
 
         public void Destroy() => appWindow?.Destroy();
@@ -1313,46 +1332,61 @@ namespace TaskbarQuota.Taskbar
             if (content?.RenderTransform is not Microsoft.UI.Xaml.Media.CompositeTransform transform)
                 return;
 
-            storyboard?.Stop();
-            transform.TranslateX = travel;
-            transform.ScaleX = 0.985;
-            content.Opacity = Math.Min(content.Opacity <= 0 ? 1 : content.Opacity, 0.94);
-
-            var easing = new Anim.CubicEase { EasingMode = Anim.EasingMode.EaseOut };
-            var slide = new Anim.DoubleAnimation
+            try
             {
-                To = 0,
-                Duration = new Microsoft.UI.Xaml.Duration(TimeSpan.FromMilliseconds(LayoutTransitionMilliseconds)),
-                EasingFunction = easing,
-                EnableDependentAnimation = true,
-            };
-            Anim.Storyboard.SetTarget(slide, transform);
-            Anim.Storyboard.SetTargetProperty(slide, "TranslateX");
+                storyboard?.Stop();
+                transform.TranslateX = travel;
+                transform.ScaleX = 0.985;
+                content.Opacity = Math.Min(content.Opacity <= 0 ? 1 : content.Opacity, 0.94);
 
-            var scale = new Anim.DoubleAnimation
+                var easing = new Anim.CubicEase { EasingMode = Anim.EasingMode.EaseOut };
+                var slide = new Anim.DoubleAnimation
+                {
+                    To = 0,
+                    Duration = new Microsoft.UI.Xaml.Duration(TimeSpan.FromMilliseconds(LayoutTransitionMilliseconds)),
+                    EasingFunction = easing,
+                    EnableDependentAnimation = true,
+                };
+                Anim.Storyboard.SetTarget(slide, transform);
+                Anim.Storyboard.SetTargetProperty(slide, "TranslateX");
+
+                var scale = new Anim.DoubleAnimation
+                {
+                    To = 1,
+                    Duration = new Microsoft.UI.Xaml.Duration(TimeSpan.FromMilliseconds(LayoutTransitionMilliseconds)),
+                    EasingFunction = easing,
+                };
+                Anim.Storyboard.SetTarget(scale, transform);
+                Anim.Storyboard.SetTargetProperty(scale, "ScaleX");
+
+                var fade = new Anim.DoubleAnimation
+                {
+                    To = 1,
+                    Duration = new Microsoft.UI.Xaml.Duration(TimeSpan.FromMilliseconds(LayoutTransitionMilliseconds)),
+                    EasingFunction = easing,
+                };
+                Anim.Storyboard.SetTarget(fade, content);
+                Anim.Storyboard.SetTargetProperty(fade, "Opacity");
+
+                var next = new Anim.Storyboard();
+                next.Children.Add(slide);
+                next.Children.Add(scale);
+                next.Children.Add(fade);
+                storyboard = next;
+                next.Begin();
+            }
+            catch (Exception ex)
             {
-                To = 1,
-                Duration = new Microsoft.UI.Xaml.Duration(TimeSpan.FromMilliseconds(LayoutTransitionMilliseconds)),
-                EasingFunction = easing,
-            };
-            Anim.Storyboard.SetTarget(scale, transform);
-            Anim.Storyboard.SetTargetProperty(scale, "ScaleX");
-
-            var fade = new Anim.DoubleAnimation
-            {
-                To = 1,
-                Duration = new Microsoft.UI.Xaml.Duration(TimeSpan.FromMilliseconds(LayoutTransitionMilliseconds)),
-                EasingFunction = easing,
-            };
-            Anim.Storyboard.SetTarget(fade, content);
-            Anim.Storyboard.SetTargetProperty(fade, "Opacity");
-
-            var next = new Anim.Storyboard();
-            next.Children.Add(slide);
-            next.Children.Add(scale);
-            next.Children.Add(fade);
-            storyboard = next;
-            next.Begin();
+                storyboard = null;
+                try
+                {
+                    transform.TranslateX = 0;
+                    transform.ScaleX = 1;
+                    content.Opacity = 1;
+                }
+                catch { }
+                Log.Debug($"[widget] layout animation skipped: {ex.Message}");
+            }
         }
 
         private bool SetActivityHostVisible(bool visible)
@@ -1389,37 +1423,47 @@ namespace TaskbarQuota.Taskbar
         {
             if (activityHostContent is not { } content)
             {
-                completed?.Invoke();
+                InvokeAnimationCompletion(completed);
                 return;
             }
 
-            activityFadeStoryboard?.Stop();
-            double from = content.Opacity;
-            bool skip = Math.Abs(from - to) < 0.01 && to > 0.5;
-            if (skip)
+            try
             {
+                activityFadeStoryboard?.Stop();
+                double from = content.Opacity;
+                bool skip = Math.Abs(from - to) < 0.01 && to > 0.5;
+                if (skip)
+                {
+                    content.Opacity = to;
+                    InvokeAnimationCompletion(completed);
+                    return;
+                }
+
                 content.Opacity = to;
-                completed?.Invoke();
-                return;
+                var animation = new Anim.DoubleAnimation
+                {
+                    From = from < 0.01 ? 0.15 : from,
+                    To = to,
+                    Duration = new Microsoft.UI.Xaml.Duration(TimeSpan.FromMilliseconds(HostFadeMilliseconds)),
+                    EasingFunction = new Anim.CubicEase { EasingMode = Anim.EasingMode.EaseOut },
+                };
+                Anim.Storyboard.SetTarget(animation, content);
+                Anim.Storyboard.SetTargetProperty(animation, "Opacity");
+
+                var storyboard = new Anim.Storyboard();
+                storyboard.Children.Add(animation);
+                if (completed is not null)
+                    storyboard.Completed += (_, _) => InvokeAnimationCompletion(completed);
+                activityFadeStoryboard = storyboard;
+                storyboard.Begin();
             }
-
-            content.Opacity = to;
-            var animation = new Anim.DoubleAnimation
+            catch (Exception ex)
             {
-                From = from < 0.01 ? 0.15 : from,
-                To = to,
-                Duration = new Microsoft.UI.Xaml.Duration(TimeSpan.FromMilliseconds(HostFadeMilliseconds)),
-                EasingFunction = new Anim.CubicEase { EasingMode = Anim.EasingMode.EaseOut },
-            };
-            Anim.Storyboard.SetTarget(animation, content);
-            Anim.Storyboard.SetTargetProperty(animation, "Opacity");
-
-            var storyboard = new Anim.Storyboard();
-            storyboard.Children.Add(animation);
-            if (completed is not null)
-                storyboard.Completed += (_, _) => completed();
-            activityFadeStoryboard = storyboard;
-            storyboard.Begin();
+                activityFadeStoryboard = null;
+                try { content.Opacity = to; } catch { }
+                InvokeAnimationCompletion(completed);
+                Log.Debug($"[widget] activity fade skipped: {ex.Message}");
+            }
         }
 
         private void SetActivityLogicalWidthOnUiThread(int logicalWidth, int physicalWidth)
@@ -2261,35 +2305,49 @@ namespace TaskbarQuota.Taskbar
             if (quotaTransform is null || activityTransform is null)
                 return;
 
-            swapVisualStoryboard?.Stop();
-            quotaTransform.TranslateX = quotaOldX - quotaNewX;
-            activityTransform.TranslateX = activityOldX - activityNewX;
-
-            var storyboard = new Anim.Storyboard();
-            var quotaSlide = new Anim.DoubleAnimation
+            try
             {
-                To = 0,
-                Duration = TimeSpan.FromMilliseconds(180),
-                EasingFunction = new Anim.CubicEase { EasingMode = Anim.EasingMode.EaseOut },
-                EnableDependentAnimation = true,
-            };
-            Anim.Storyboard.SetTarget(quotaSlide, quotaTransform);
-            Anim.Storyboard.SetTargetProperty(quotaSlide, "TranslateX");
+                swapVisualStoryboard?.Stop();
+                quotaTransform.TranslateX = quotaOldX - quotaNewX;
+                activityTransform.TranslateX = activityOldX - activityNewX;
 
-            var activitySlide = new Anim.DoubleAnimation
+                var storyboard = new Anim.Storyboard();
+                var quotaSlide = new Anim.DoubleAnimation
+                {
+                    To = 0,
+                    Duration = TimeSpan.FromMilliseconds(180),
+                    EasingFunction = new Anim.CubicEase { EasingMode = Anim.EasingMode.EaseOut },
+                    EnableDependentAnimation = true,
+                };
+                Anim.Storyboard.SetTarget(quotaSlide, quotaTransform);
+                Anim.Storyboard.SetTargetProperty(quotaSlide, "TranslateX");
+
+                var activitySlide = new Anim.DoubleAnimation
+                {
+                    To = 0,
+                    Duration = TimeSpan.FromMilliseconds(180),
+                    EasingFunction = new Anim.CubicEase { EasingMode = Anim.EasingMode.EaseOut },
+                    EnableDependentAnimation = true,
+                };
+                Anim.Storyboard.SetTarget(activitySlide, activityTransform);
+                Anim.Storyboard.SetTargetProperty(activitySlide, "TranslateX");
+
+                storyboard.Children.Add(quotaSlide);
+                storyboard.Children.Add(activitySlide);
+                swapVisualStoryboard = storyboard;
+                storyboard.Begin();
+            }
+            catch (Exception ex)
             {
-                To = 0,
-                Duration = TimeSpan.FromMilliseconds(180),
-                EasingFunction = new Anim.CubicEase { EasingMode = Anim.EasingMode.EaseOut },
-                EnableDependentAnimation = true,
-            };
-            Anim.Storyboard.SetTarget(activitySlide, activityTransform);
-            Anim.Storyboard.SetTargetProperty(activitySlide, "TranslateX");
-
-            storyboard.Children.Add(quotaSlide);
-            storyboard.Children.Add(activitySlide);
-            swapVisualStoryboard = storyboard;
-            storyboard.Begin();
+                swapVisualStoryboard = null;
+                try
+                {
+                    quotaTransform.TranslateX = 0;
+                    activityTransform.TranslateX = 0;
+                }
+                catch { }
+                Log.Debug($"[widget] pair-swap animation skipped: {ex.Message}");
+            }
         }
 
         /// <summary>

--- a/tests/TaskbarQuota.Tests/UiWatchdogTests.cs
+++ b/tests/TaskbarQuota.Tests/UiWatchdogTests.cs
@@ -1,0 +1,21 @@
+using TaskbarQuota.Taskbar;
+
+namespace TaskbarQuota.Tests;
+
+public class UiWatchdogTests
+{
+    [Fact]
+    public void RequestsRestartAfterThreeMisses()
+        => Assert.True(TaskBarManager.ShouldRestartUiWatchdog(3, isQuitting: false, restartRequested: false));
+
+    [Fact]
+    public void DoesNotRestartBeforeThreshold()
+        => Assert.False(TaskBarManager.ShouldRestartUiWatchdog(2, isQuitting: false, restartRequested: false));
+
+    [Fact]
+    public void DoesNotRestartWhileQuittingOrAfterARequest()
+    {
+        Assert.False(TaskBarManager.ShouldRestartUiWatchdog(3, isQuitting: true, restartRequested: false));
+        Assert.False(TaskBarManager.ShouldRestartUiWatchdog(3, isQuitting: false, restartRequested: true));
+    }
+}


### PR DESCRIPTION
## Problem

Closes #70.

The taskbar widget can disappear after running for a while. The process may either terminate with a WinUI stowed exception or remain alive while its UI dispatcher is no longer servicing work. In the latter case, background services continue running but the widget stays gone until the app is restarted.

The failure occurs during provider-switch and layout churn, where storyboard targets can be invalidated while the widget is being recreated or its visual tree is torn down.

## Fix

- **Harden every widget animation path.** `Storyboard.Stop()`, retargeting, and `Begin()` calls in `WidgetSummary` and `TaskBarWidget` are now guarded. If a visual target is invalid, the failed storyboard is discarded and the affected opacity/transform is reset to its resting value, so a cosmetic animation cannot kill the UI thread or strand a tile off-screen.
- **Recover a wedged UI thread.** The existing external thread-pool watchdog submits a dispatcher heartbeat every 5 seconds. After three missed heartbeats (~15 seconds), it requests a one-shot app restart through `AppInstance.Restart("--startup-widget")`; the watchdog is stopped cleanly during shutdown.
- **Cover hard process failures.** Windows application restart recovery is registered at launch so crash/hang recovery can bring the tray widget back with the correct startup argument.
- **Improve diagnostics.** Log lines include the process ID, which makes interleaved installed/dev instances distinguishable in `%TEMP%\\taskbarquota.log`.
- **Keep the scope focused.** Unrelated `MainWindow` sizing/backdrop changes from the original PR were removed.

## Test plan

- [x] Focused UI watchdog tests
- [x] Full test suite: 831 passed / 0 failed
- [x] `git diff --check`
- [ ] Windows soak test through provider switches, widget recreation, and display topology changes
- [ ] Optional WER LocalDumps capture for any remaining hard crash variant

## Notes

The restart path is intentionally one-shot per process, preventing repeated restart requests from concurrent watchdog ticks. A Windows soak test is still recommended because the original failure depends on long-running WinUI lifecycle and visual-tree timing.
