### PR TITLE
Fix hidden providers appearing in sidebar

### DIFF
--- a/src/TaskbarQuota.App/DashboardNavigationBinder.cs
+++ b/src/TaskbarQuota.App/DashboardNavigationBinder.cs
@@ -139,19 +139,16 @@ namespace TaskbarQuota
         {
             IsSyncing = true;
             _providerGroup.MenuItems.Clear();
-            foreach (var provider in UsageCoordinator.Instance.Service.All)
+            foreach (var card in _viewModel.Cards)
             {
-                var card = _viewModel.Cards.Concat(_viewModel.AvailableCards)
-                    .FirstOrDefault(candidate => candidate.ProviderId == provider.Id);
-                var displayName = card?.DisplayName ?? provider.DisplayName;
                 var item = new NavigationViewItem
                 {
-                    Content = displayName,
-                    Tag = provider.Id,
-                    Icon = CreateProviderIcon(provider.Id),
+                    Content = card.DisplayName,
+                    Tag = card.ProviderId,
+                    Icon = CreateProviderIcon(card.ProviderId),
                     HorizontalAlignment = HorizontalAlignment.Stretch,
                 };
-                ApplyPinBadge(item, provider.Id, displayName);
+                ApplyPinBadge(item, card.ProviderId, card.DisplayName);
                 _providerGroup.MenuItems.Add(item);
             }
 

--- a/src/TaskbarQuota.App/DashboardNavigationBinder.cs
+++ b/src/TaskbarQuota.App/DashboardNavigationBinder.cs
@@ -152,6 +152,12 @@ namespace TaskbarQuota
                 _providerGroup.MenuItems.Add(item);
             }
 
+            if (_requestedProviderId is ProviderId requested
+                && !_viewModel.Cards.Any(card => card.ProviderId == requested))
+            {
+                _requestedProviderId = null;
+            }
+
             SyncSelection();
             IsSyncing = false;
         }


### PR DESCRIPTION
## Summary
- build the Providers sidebar from dashboard-visible cards
- stop unavailable or explicitly disabled providers from being listed
- preserve provider configuration access through Settings

## Testing
- `dotnet test tests/TaskbarQuota.Tests/TaskbarQuota.Tests.csproj --artifacts-path <isolated-temp-directory>` (837 passed)

Closes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The dashboard navigation now displays only providers with available usage cards.
  * Removed navigation entries for unavailable or unrepresented providers.
  * Provider names now use the appropriate service display names when shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->