### PR TITLE
fix(codex): Free plan Monthly label and unused reset

### DIFF
--- a/src/TaskbarQuota.App/Usage/Providers/CodexProvider.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CodexProvider.cs
@@ -92,8 +92,10 @@ namespace TaskbarQuota.Usage.Providers
                     primary = WithLabel(primary, "Weekly");
             }
 
-            // Unused windows still carry a far-future reset_at (often ~full period remaining, e.g. "29d 23h"
-            // on Free). That countdown is meaningless until quota is actually consumed — clear it for UI.
+            // Codex leaves used_percent at 0 until the agent is actually used, while still advertising a
+            // far-future reset_at (often ~full period remaining, e.g. "29d 23h" on Free). That countdown is
+            // a phantom until quota is consumed — including after a real reset, which also returns 0% until
+            // the next use. Clear the subtitle for UI; keep ResetAt for replenishment math.
             primary = ClearUnusedReset(primary);
             if (secondary != null) secondary = ClearUnusedReset(secondary);
             if (codeReview != null) codeReview = ClearUnusedReset(codeReview);
@@ -240,6 +242,8 @@ namespace TaskbarQuota.Usage.Providers
         private static RateWindow WithLabel(RateWindow window, string label)
             => new(window.UsedPercent, window.WindowMinutes, window.ResetAt, window.ResetDescription, label);
 
+        // Hide the reset subtitle at 0%. Codex does not populate used_percent until the agent is used, so
+        // 0% means "not started" (or "reset and idle"), not "N days remaining".
         private static RateWindow ClearUnusedReset(RateWindow window)
             => window.UsedPercent > 0
                 ? window

--- a/src/TaskbarQuota.App/Usage/Providers/CodexProvider.cs
+++ b/src/TaskbarQuota.App/Usage/Providers/CodexProvider.cs
@@ -81,11 +81,22 @@ namespace TaskbarQuota.Usage.Providers
                     : WithUsedPercent(secondary, hs);
             }
 
-            // OpenAI temporarily disabled the 5h session limit (issue #18), so the API now returns a single
-            // weekly window that would otherwise render under the "Session" label. When the only window we
-            // have is the weekly one, relabel it "Weekly" — the value and reset time are already correct.
-            if (secondary == null && hasPrimary && IsWeeklyWindow(primary))
-                primary = WithLabel(primary, "Weekly");
+            // OpenAI temporarily disabled the 5h session limit (issue #18), so the API may return a single
+            // long window that would otherwise render under the "Session" label. Free plans use a ~30-day
+            // window; Plus/Pro weekly-only plans use ~7 days. Relabel from duration so Free is not "Weekly".
+            if (secondary == null && hasPrimary)
+            {
+                if (IsMonthlyWindow(primary))
+                    primary = WithLabel(primary, "Monthly");
+                else if (IsWeeklyWindow(primary))
+                    primary = WithLabel(primary, "Weekly");
+            }
+
+            // Unused windows still carry a far-future reset_at (often ~full period remaining, e.g. "29d 23h"
+            // on Free). That countdown is meaningless until quota is actually consumed — clear it for UI.
+            primary = ClearUnusedReset(primary);
+            if (secondary != null) secondary = ClearUnusedReset(secondary);
+            if (codeReview != null) codeReview = ClearUnusedReset(codeReview);
 
             var usage = new UsageSnapshot(primary) { HasPrimaryWindow = hasPrimary };
             if (secondary != null) usage.Secondary = secondary;
@@ -194,9 +205,9 @@ namespace TaskbarQuota.Usage.Providers
                     continue;
 
                 if (rl.TryGetProperty("primary_window", out var primary) && primary.ValueKind == JsonValueKind.Object)
-                    usage.ExtraRateWindows.Add(new NamedRateWindow($"{shortName}-session", $"{shortName} Session", ParseWindow(primary)));
+                    usage.ExtraRateWindows.Add(new NamedRateWindow($"{shortName}-session", $"{shortName} Session", ClearUnusedReset(ParseWindow(primary))));
                 if (rl.TryGetProperty("secondary_window", out var secondary) && secondary.ValueKind == JsonValueKind.Object)
-                    usage.ExtraRateWindows.Add(new NamedRateWindow($"{shortName}-weekly", $"{shortName} Weekly", ParseWindow(secondary)));
+                    usage.ExtraRateWindows.Add(new NamedRateWindow($"{shortName}-weekly", $"{shortName} Weekly", ClearUnusedReset(ParseWindow(secondary))));
             }
         }
 
@@ -229,11 +240,24 @@ namespace TaskbarQuota.Usage.Providers
         private static RateWindow WithLabel(RateWindow window, string label)
             => new(window.UsedPercent, window.WindowMinutes, window.ResetAt, window.ResetDescription, label);
 
-        // A weekly window spans ~7 days. Treat an unknown duration as weekly too: when only one window is
-        // present the 5h session has been dropped, so the lone window is the weekly one. A window shorter
-        // than a day is still a real session window and keeps its "Session" label.
+        private static RateWindow ClearUnusedReset(RateWindow window)
+            => window.UsedPercent > 0
+                ? window
+                : new RateWindow(window.UsedPercent, window.WindowMinutes, window.ResetAt, resetDescription: null, window.Label);
+
+        // Free ChatGPT/Codex plans expose a ~30-day primary window (limit_window_seconds ≈ 2592000).
+        // Threshold below true calendar-month length so a 20+ day lone window is still labeled Monthly.
+        private const int MonthlyWindowMinutes = 20 * 1440;
+
+        private static bool IsMonthlyWindow(RateWindow window)
+            => window.WindowMinutes is int minutes && minutes >= MonthlyWindowMinutes;
+
+        // A weekly window spans ~7 days (below the monthly threshold). Treat an unknown duration as weekly
+        // too: when only one window is present the 5h session has been dropped, so the lone window is the
+        // weekly one. A window shorter than a day is still a real session window and keeps its "Session" label.
         private static bool IsWeeklyWindow(RateWindow window)
-            => window.WindowMinutes is not int minutes || minutes >= 1440;
+            => !IsMonthlyWindow(window)
+                && (window.WindowMinutes is not int minutes || minutes >= 1440);
 
         private static CostSnapshot? ExtractCredits(JsonElement json, double? headerCredits)
         {

--- a/tests/TaskbarQuota.Tests/CodexProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/CodexProviderTests.cs
@@ -53,7 +53,7 @@ public class CodexProviderTests
               "plan_type": "plus",
               "rate_limit": {
                 "primary_window": {
-                  "used_percent": 0,
+                  "used_percent": 12,
                   "limit_window_seconds": 604800,
                   "reset_at": 1893542400
                 }
@@ -65,9 +65,66 @@ public class CodexProviderTests
         var result = CodexProvider.BuildResult(doc.RootElement);
 
         Assert.Equal("Weekly", result.Usage.Primary.Label);
-        Assert.Equal(0, result.Usage.Primary.UsedPercent);
+        Assert.Equal(12, result.Usage.Primary.UsedPercent);
         Assert.True(result.Usage.HasPrimaryWindow);
         Assert.Null(result.Usage.Secondary);
+        Assert.NotNull(result.Usage.Primary.ResetDescription);
+    }
+
+    [Fact]
+    public void BuildResult_FreeMonthlyOnlyWindow_RelabelsPrimaryAsMonthly()
+    {
+        // Free ChatGPT/Codex plans use a ~30-day window instead of weekly.
+        var resetAt = DateTimeOffset.UtcNow.AddDays(29).AddHours(23).ToUnixTimeSeconds();
+        var json = $$"""
+            {
+              "plan_type": "free",
+              "rate_limit": {
+                "primary_window": {
+                  "used_percent": 5,
+                  "limit_window_seconds": 2592000,
+                  "reset_at": {{resetAt}}
+                }
+              }
+            }
+            """;
+        using var doc = JsonDocument.Parse(json);
+
+        var result = CodexProvider.BuildResult(doc.RootElement);
+
+        Assert.Equal("Free", result.Usage.LoginMethod);
+        Assert.Equal("Monthly", result.Usage.Primary.Label);
+        Assert.Equal(5, result.Usage.Primary.UsedPercent);
+        Assert.True(result.Usage.HasPrimaryWindow);
+        Assert.Null(result.Usage.Secondary);
+        Assert.StartsWith("29d", result.Usage.Primary.ResetDescription);
+    }
+
+    [Fact]
+    public void BuildResult_UnusedWindow_ClearsResetCountdown()
+    {
+        // Unused Free windows still report a full-period reset_at (~29d 23h). Hide it until used.
+        var resetAt = DateTimeOffset.UtcNow.AddDays(29).AddHours(23).ToUnixTimeSeconds();
+        var json = $$"""
+            {
+              "plan_type": "free",
+              "rate_limit": {
+                "primary_window": {
+                  "used_percent": 0,
+                  "limit_window_seconds": 2592000,
+                  "reset_at": {{resetAt}}
+                }
+              }
+            }
+            """;
+        using var doc = JsonDocument.Parse(json);
+
+        var result = CodexProvider.BuildResult(doc.RootElement);
+
+        Assert.Equal("Monthly", result.Usage.Primary.Label);
+        Assert.Equal(0, result.Usage.Primary.UsedPercent);
+        Assert.Null(result.Usage.Primary.ResetDescription);
+        Assert.NotNull(result.Usage.Primary.ResetAt);
     }
 
     [Fact]

--- a/tests/TaskbarQuota.Tests/CodexProviderTests.cs
+++ b/tests/TaskbarQuota.Tests/CodexProviderTests.cs
@@ -128,6 +128,82 @@ public class CodexProviderTests
     }
 
     [Fact]
+    public void BuildResult_FractionalUse_KeepsResetCountdown()
+    {
+        // used_percent can be 0.1 while the widget still paints "0%". The countdown must stay once use started.
+        var resetAt = DateTimeOffset.UtcNow.AddDays(29).AddHours(23).ToUnixTimeSeconds();
+        var json = $$"""
+            {
+              "plan_type": "free",
+              "rate_limit": {
+                "primary_window": {
+                  "used_percent": 0.1,
+                  "limit_window_seconds": 2592000,
+                  "reset_at": {{resetAt}}
+                }
+              }
+            }
+            """;
+        using var doc = JsonDocument.Parse(json);
+
+        var result = CodexProvider.BuildResult(doc.RootElement);
+
+        Assert.Equal("Monthly", result.Usage.Primary.Label);
+        Assert.Equal(0.1, result.Usage.Primary.UsedPercent);
+        Assert.NotNull(result.Usage.Primary.ResetDescription);
+    }
+
+    [Fact]
+    public void BuildResult_UnusedExtraWindow_ClearsResetCountdown()
+    {
+        var resetAt = DateTimeOffset.UtcNow.AddDays(6).ToUnixTimeSeconds();
+        var json = $$"""
+            {
+              "plan_type": "pro",
+              "rate_limit": {
+                "primary_window": {
+                  "used_percent": 10,
+                  "limit_window_seconds": 18000,
+                  "reset_at": {{resetAt}}
+                },
+                "secondary_window": {
+                  "used_percent": 5,
+                  "limit_window_seconds": 604800,
+                  "reset_at": {{resetAt}}
+                }
+              },
+              "additional_rate_limits": [
+                {
+                  "limit_name": "GPT-5.3-Codex-Spark",
+                  "rate_limit": {
+                    "primary_window": {
+                      "used_percent": 0,
+                      "limit_window_seconds": 18000,
+                      "reset_at": {{resetAt}}
+                    },
+                    "secondary_window": {
+                      "used_percent": 0,
+                      "limit_window_seconds": 604800,
+                      "reset_at": {{resetAt}}
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+        using var doc = JsonDocument.Parse(json);
+
+        var result = CodexProvider.BuildResult(doc.RootElement);
+
+        var session = Assert.Single(result.Usage.ExtraRateWindows, w => w.Title == "Spark Session");
+        var weekly = Assert.Single(result.Usage.ExtraRateWindows, w => w.Title == "Spark Weekly");
+        Assert.Null(session.Window.ResetDescription);
+        Assert.Null(weekly.Window.ResetDescription);
+        Assert.NotNull(session.Window.ResetAt);
+        Assert.NotNull(weekly.Window.ResetAt);
+    }
+
+    [Fact]
     public void BuildResult_SessionOnlyShortWindow_KeepsSessionLabel()
     {
         // A lone sub-day window is still a real 5h session — must not be relabeled Weekly.


### PR DESCRIPTION
## Summary
- Label lone Codex Free rate windows (~30 days) as **Monthly** instead of incorrectly calling them Weekly.
- Hide the phantom reset countdown (e.g. `29d 23h`) when usage is still 0%; show it only after quota is used.

## Test plan
- [ ] On a Free ChatGPT/Codex account at 0% usage, confirm the bar is labeled Monthly and no reset subtitle appears
- [ ] After some Free usage, confirm reset countdown appears and Monthly label remains
- [ ] On Plus/Pro weekly-only (no 5h session), confirm Weekly label still works
- [ ] `dotnet test --filter FullyQualifiedName~CodexProviderTests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage-window labels to distinguish weekly and monthly limits.
  * Reset countdowns are now cleared when a limit window is unused.
  * Additional rate-limit windows now display accurate reset information.

* **Tests**
  * Added coverage for monthly free-plan windows, fractional usage, and unused-window reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->