### PR TITLE
fix(dashboard): honor explicit provider disable, hide idle/uninstalled providers

### DIFF
--- a/src/TaskbarQuota.App/DashboardNavigationBinder.cs
+++ b/src/TaskbarQuota.App/DashboardNavigationBinder.cs
@@ -102,7 +102,9 @@ namespace TaskbarQuota
             bool providerIsKnown = _viewModel.Cards.Any(card => card.ProviderId == id)
                 || _viewModel.AvailableCards.Any(card => card.ProviderId == id);
             _viewModel.SelectProvider(id);
-            if (!providerIsKnown)
+            // Never auto-enable an explicitly-disabled provider from navigation —
+            // only the Settings toggle opts back in.
+            if (!providerIsKnown && !ProviderDiscoveryService.IsExplicitlyDisabled(id))
                 _viewModel.EnableAvailableProvider(id);
             return true;
         }
@@ -139,8 +141,15 @@ namespace TaskbarQuota
         {
             IsSyncing = true;
             _providerGroup.MenuItems.Clear();
+            // Only list providers that can actually be displayed. Disabled, not-installed,
+            // and installed-but-idle providers stay hidden so selecting them can never
+            // resurrect them (issue #83).
             foreach (var provider in UsageCoordinator.Instance.Service.All)
             {
+                if (!_viewModel.Cards.Any(card => card.ProviderId == provider.Id)
+                    && !_viewModel.AvailableCards.Any(card => card.ProviderId == provider.Id))
+                    continue;
+
                 var card = _viewModel.Cards.Concat(_viewModel.AvailableCards)
                     .FirstOrDefault(candidate => candidate.ProviderId == provider.Id);
                 var displayName = card?.DisplayName ?? provider.DisplayName;

--- a/src/TaskbarQuota.App/Services/ProviderDiscoveryService.cs
+++ b/src/TaskbarQuota.App/Services/ProviderDiscoveryService.cs
@@ -9,7 +9,18 @@ namespace TaskbarQuota;
 
 /// <summary>
 /// Tracks which providers are probed, configured, and visible in the dashboard vs taskbar widget.
-/// Auto-hides <see cref="ProviderErrorKind.NotInstalled"/> providers unless the user explicitly enables them.
+///
+/// Display rules (strict — a provider must never leak onto the UI on its own):
+/// <list type="bullet">
+///   <item>Explicitly disabled → never shown or fetched anywhere. Only the Settings
+///   toggle opts back in.</item>
+///   <item>Not installed → never shown or fetched. Install state comes from
+///   <see cref="ProviderInstallDetector"/> (CLI, credentials, or desktop app).</item>
+///   <item>Installed → shown only with open/use evidence: the detected active provider
+///   (CLI terminal, desktop app, or a browser tab linking the app), recently-active
+///   this session, or explicit user intent (enabled in Settings, pinned).</item>
+/// </list>
+/// Installed-but-idle providers stay hidden and unfetched.
 /// </summary>
 public static class ProviderDiscoveryService
 {
@@ -22,10 +33,16 @@ public static class ProviderDiscoveryService
     private static readonly HashSet<ProviderId> ExplicitlyEnabled = new();
     private static readonly HashSet<ProviderId> ExplicitlyDisabled = new();
 
+    /// <summary>Test hook for open/use evidence without running foreground detection.</summary>
+    internal static Func<ProviderId, bool>? IsRecentlyActiveOverrideForTesting;
+
     static ProviderDiscoveryService() => Load();
 
     /// <summary>
-    /// Ensures every detected installed provider is visible in the dashboard and widget unless the user hid it.
+    /// Enforces "never shown when not installed" against stale settings: hides providers
+    /// with nothing installed unless the user explicitly opted in. Never makes anything
+    /// visible — surfacing is driven by open/use evidence (see
+    /// <see cref="ShouldShowInDashboard"/>) or explicit opt-in.
     /// </summary>
     public static void SyncInstalledProviderVisibility()
     {
@@ -37,11 +54,11 @@ public static class ProviderDiscoveryService
             bool dashboardChanged = false;
             foreach (ProviderId id in Enum.GetValues<ProviderId>())
             {
-                if (!ProviderInstallDetector.IsInstalled(id) || ExplicitlyDisabled.Contains(id))
+                if (ProviderInstallDetector.IsInstalled(id) || ExplicitlyEnabled.Contains(id))
                     continue;
 
-                widgetChanged |= TryEnableProviderSilent(id, out bool dashChanged);
-                dashboardChanged |= dashChanged;
+                widgetChanged |= WidgetSettingsService.SetProviderVisibleSilent(id, false);
+                dashboardChanged |= WidgetSettingsService.SetProviderDashboardVisibleSilent(id, false);
             }
 
             if (widgetChanged)
@@ -58,35 +75,12 @@ public static class ProviderDiscoveryService
         {
             Probed.Add(result.Id);
 
-            if (ProviderInstallDetector.IsInstalled(result.Id) && !ExplicitlyDisabled.Contains(result.Id))
-                EnsureProviderEnabled(result.Id);
-
-            bool newlyConfigured = result.Ok && !Configured.Contains(result.Id);
-
             if (result.Ok || result.ErrorKind == ProviderErrorKind.AuthRequired)
                 Configured.Add(result.Id);
 
-            if (!ExplicitlyDisabled.Contains(result.Id) && result.Ok)
-            {
-                if (!WidgetSettingsService.IsProviderDashboardVisible(result.Id))
-                    WidgetSettingsService.SetProviderDashboardVisible(result.Id, true);
-
-            // First successful fetch after install/login — restore widget visibility
-            // (auto-hide turns it off for NotInstalled, but usage should return once set up).
-                if (newlyConfigured && !WidgetSettingsService.IsProviderVisible(result.Id))
-                    WidgetSettingsService.SetProviderVisible(result.Id, true);
-            }
-
-            if (result.ErrorKind == ProviderErrorKind.NotRunning
-                && ProviderInstallDetector.IsInstalled(result.Id)
-                && !ExplicitlyDisabled.Contains(result.Id))
-            {
-                if (!WidgetSettingsService.IsProviderDashboardVisible(result.Id))
-                    WidgetSettingsService.SetProviderDashboardVisible(result.Id, true);
-                if (!WidgetSettingsService.IsProviderVisible(result.Id))
-                    WidgetSettingsService.SetProviderVisible(result.Id, true);
-            }
-
+            // Never auto-show: visibility flips only via explicit user action
+            // (Settings toggle, pin, OAuth login). A successful fetch of an idle
+            // provider must not resurrect it on the dashboard or widget.
             if (result.ErrorKind == ProviderErrorKind.NotInstalled
                 && !ProviderInstallDetector.IsInstalled(result.Id)
                 && WidgetSettingsService.AutoHideUnavailable
@@ -130,7 +124,12 @@ public static class ProviderDiscoveryService
         {
             ExplicitlyEnabled.Add(id);
             ExplicitlyDisabled.Remove(id);
-            EnsureProviderEnabled(id);
+            bool widgetChanged = WidgetSettingsService.SetProviderVisibleSilent(id, true);
+            bool dashboardChanged = WidgetSettingsService.SetProviderDashboardVisibleSilent(id, true);
+            if (widgetChanged)
+                WidgetSettingsService.SaveProviderVisibilityAndNotify();
+            if (dashboardChanged)
+                WidgetSettingsService.SaveDashboardProviderVisibilityAndNotify();
             Save();
         }
     }
@@ -149,55 +148,58 @@ public static class ProviderDiscoveryService
 
     public static bool ShouldFetch(ProviderId id, ProviderId? active)
     {
-        if (id == active)
-            return true;
         if (IsExplicitlyDisabled(id))
             return false;
-        if (ProviderInstallDetector.IsInstalled(id))
+        if (id == active)
             return true;
-        if (!IsProbed(id))
-            return true;
-        if (WidgetSettingsService.IsProviderDashboardVisible(id))
-            return true;
-        if (WidgetSettingsService.IsProviderVisible(id))
-            return true;
-        if (IsExplicitlyEnabled(id))
-            return true;
-        if (IsConfigured(id))
-            return true;
-        return false;
+        return IsEligible(id);
     }
 
     public static bool ShouldShowInDashboard(UsageResult result, ProviderId? active)
     {
         if (IsExplicitlyDisabled(result.Id))
             return false;
-        if (ProviderInstallDetector.IsInstalled(result.Id))
-            return true;
         if (result.Id == active)
             return true;
-        if (WidgetSettingsService.IsProviderDashboardVisible(result.Id))
+        return IsEligible(result.Id);
+    }
+
+    /// <summary>
+    /// Eligibility beyond the active provider: installed, and either explicitly kept
+    /// (enabled in Settings, pinned) or recently used this session. Installed-but-idle
+    /// providers stay hidden and unfetched so they can't leak back on their own.
+    /// </summary>
+    private static bool IsEligible(ProviderId id)
+    {
+        if (!ProviderInstallDetector.IsInstalled(id))
+            return false;
+        if (IsExplicitlyEnabled(id))
             return true;
-        if (IsExplicitlyEnabled(result.Id))
+        if (WidgetSettingsService.IsProviderPinned(id))
             return true;
-        if (result.Ok)
-            return true;
-        if (result.ErrorKind == ProviderErrorKind.AuthRequired)
-            return true;
-        if (result.ErrorKind == ProviderErrorKind.NotRunning)
-            return true;
-        if (IsConfigured(result.Id) && result.ErrorKind is not ProviderErrorKind.NotInstalled)
-            return true;
-        return false;
+        return IsRecentlyActive(id);
+    }
+
+    /// <summary>
+    /// Open/use evidence: the provider was detected in the foreground this session via
+    /// a CLI terminal, desktop app, host app, or a browser tab linking the app.
+    /// </summary>
+    private static bool IsRecentlyActive(ProviderId id)
+    {
+        if (IsRecentlyActiveOverrideForTesting is { } fn)
+            return fn(id);
+        return UsageCoordinator.Instance.RecentProviders.Contains(id);
     }
 
     public static bool ShouldShowInAvailable(UsageResult result, ProviderId? active)
     {
-        if (ShouldShowInDashboard(result, active))
-            return false;
-
-        return result.ErrorKind == ProviderErrorKind.NotInstalled
-            || (!result.Ok && !IsConfigured(result.Id));
+        // Discovery surfacing is disabled on purpose: providers appear only with
+        // open/use evidence or explicit opt-in (see ShouldShowInDashboard). Anything
+        // else — including not-installed providers — stays hidden; Settings is the
+        // opt-in surface. Kept (always false) so the Available pipeline stays inert.
+        _ = result;
+        _ = active;
+        return false;
     }
 
     internal static void ResetForTesting()
@@ -208,6 +210,7 @@ public static class ProviderDiscoveryService
             Configured.Clear();
             ExplicitlyEnabled.Clear();
             ExplicitlyDisabled.Clear();
+            IsRecentlyActiveOverrideForTesting = null;
         }
     }
 
@@ -227,35 +230,6 @@ public static class ProviderDiscoveryService
     {
         lock (SyncRoot)
             ExplicitlyDisabled.Add(id);
-    }
-
-    private static void EnsureProviderEnabled(ProviderId id)
-    {
-        if (TryEnableProviderSilent(id, out bool dashboardChanged))
-            WidgetSettingsService.SaveProviderVisibilityAndNotify();
-
-        if (dashboardChanged)
-            WidgetSettingsService.SaveDashboardProviderVisibilityAndNotify();
-    }
-
-    private static bool TryEnableProviderSilent(ProviderId id, out bool dashboardChanged)
-    {
-        dashboardChanged = false;
-        bool widgetChanged = false;
-
-        if (!WidgetSettingsService.IsProviderDashboardVisible(id))
-        {
-            WidgetSettingsService.SetProviderDashboardVisibleSilent(id, true);
-            dashboardChanged = true;
-        }
-
-        if (!WidgetSettingsService.IsProviderVisible(id))
-        {
-            WidgetSettingsService.SetProviderVisibleSilent(id, true);
-            widgetChanged = true;
-        }
-
-        return widgetChanged;
     }
 
     private static void Load()

--- a/src/TaskbarQuota.App/Services/ProviderDiscoveryService.cs
+++ b/src/TaskbarQuota.App/Services/ProviderDiscoveryService.cs
@@ -40,8 +40,10 @@ public static class ProviderDiscoveryService
 
     /// <summary>
     /// Enforces "never shown when not installed" against stale settings: hides providers
-    /// with nothing installed unless the user explicitly opted in. Never makes anything
-    /// visible — surfacing is driven by open/use evidence (see
+    /// with nothing installed unless the user explicitly opted in (enabled in Settings, or
+    /// pinned — a pin is explicit intent, so its visibility flags are preserved and the tile
+    /// returns on its own once the provider is installed or configured again). Never makes
+    /// anything visible — surfacing is driven by open/use evidence (see
     /// <see cref="ShouldShowInDashboard"/>) or explicit opt-in.
     /// </summary>
     public static void SyncInstalledProviderVisibility()
@@ -54,7 +56,9 @@ public static class ProviderDiscoveryService
             bool dashboardChanged = false;
             foreach (ProviderId id in Enum.GetValues<ProviderId>())
             {
-                if (ProviderInstallDetector.IsInstalled(id) || ExplicitlyEnabled.Contains(id))
+                if (ProviderInstallDetector.IsInstalled(id)
+                    || ExplicitlyEnabled.Contains(id)
+                    || WidgetSettingsService.IsProviderPinned(id))
                     continue;
 
                 widgetChanged |= WidgetSettingsService.SetProviderVisibleSilent(id, false);

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -780,7 +780,9 @@ namespace TaskbarQuota.Taskbar
 
             foreach (var provider in providers)
             {
-                if (provider != coordinator.ActiveProvider)
+                // Disabled providers must not leak fetches through adaptive history either.
+                if (provider != coordinator.ActiveProvider
+                    && !ProviderDiscoveryService.IsExplicitlyDisabled(provider))
                     _ = coordinator.RefreshWidgetProviderAsync(provider);
             }
         }

--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -605,6 +605,11 @@ namespace TaskbarQuota
 
         private async Task RefreshSynaraUsageAsync(ProviderId targetProvider)
         {
+            // A disabled provider must not leak fetches through Synara switch refreshes either
+            // (issue #83): detection still tracks it, but nothing may fetch it.
+            if (ProviderDiscoveryService.IsExplicitlyDisabled(targetProvider))
+                return;
+
             try
             {
                 var fresh = (await _service.FetchAsync(targetProvider, force: true).ConfigureAwait(false))
@@ -659,7 +664,11 @@ namespace TaskbarQuota
                 if (modelProvider is ProviderId backgroundProvider
                     && ShouldRefreshOpenCodeProvider(backgroundProvider))
                 {
-                    if (!await RefreshProviderCacheSilentlyAsync(backgroundProvider).ConfigureAwait(false))
+                    // Disabled providers must not leak fetches through OpenCode's background cache
+                    // refresh either (issue #83). Skipping keeps the debounce observation recorded,
+                    // so the same state-file event does not re-trigger.
+                    if (!ProviderDiscoveryService.IsExplicitlyDisabled(backgroundProvider)
+                        && !await RefreshProviderCacheSilentlyAsync(backgroundProvider).ConfigureAwait(false))
                         ForgetOpenCodeProviderObservation(backgroundProvider);
                 }
                 return;
@@ -717,6 +726,12 @@ namespace TaskbarQuota
 
             try
             {
+                // Disabled providers must not leak fetches through OpenCode model-switch
+                // refreshes either (issue #83). Detection bookkeeping above still runs; only
+                // the network refresh and state publish are skipped.
+                if (ProviderDiscoveryService.IsExplicitlyDisabled(target))
+                    return;
+
                 var fresh = (await _service.FetchAsync(target, force: true).ConfigureAwait(false))
                     .WithSource(SourceFor(target));
                 if (!fresh.Ok)
@@ -851,6 +866,11 @@ namespace TaskbarQuota
 
             try
             {
+                // Disabled providers must not leak fetches through Cline switch refreshes
+                // either (issue #83).
+                if (ProviderDiscoveryService.IsExplicitlyDisabled(target))
+                    return;
+
                 var fresh = (await _service.FetchAsync(target, force: true).ConfigureAwait(false))
                     .WithSource(SourceFor(target));
                 await _gate.WaitAsync().ConfigureAwait(false);
@@ -908,10 +928,14 @@ namespace TaskbarQuota
         /// widget routes it to that tile. The tick only ever fetches the ACTIVE provider, so without this a
         /// pinned tile would freeze on its boot snapshot. Cheap: <see cref="UsageService.FetchAsync"/> is
         /// cache-TTL gated, so most calls return the cached snapshot without touching the network. Leaves
-        /// <see cref="LastState"/> and the active provider alone.
+        /// <see cref="LastState"/> and the active provider alone. Disabled providers never hold tiles, so
+        /// refreshing one would be a fetch leak and is refused (issue #83).
         /// </summary>
         public async Task RefreshWidgetProviderAsync(ProviderId id)
         {
+            if (ProviderDiscoveryService.IsExplicitlyDisabled(id))
+                return;
+
             lock (_widgetRefreshInFlight)
             {
                 if (!_widgetRefreshInFlight.Add(id))
@@ -953,7 +977,7 @@ namespace TaskbarQuota
         {
             var active = ActiveProvider;
             var tasks = _service.All
-                .Where(p => force || ProviderDiscoveryService.ShouldFetch(p.Id, active))
+                .Where(p => ShouldFetchForDashboard(p.Id, force, active))
                 .Select(p => Task.Run(() => _service.FetchAsync(p.Id, force, ct), ct))
                 .ToList();
 
@@ -965,6 +989,15 @@ namespace TaskbarQuota
                 onResult(result.WithSource(SourceFor(result.Id)));
             }
         }
+
+        /// <summary>
+        /// Provider filter for dashboard fetch passes. A manual refresh widens the cache policy
+        /// (force), never the provider set: explicitly-disabled providers are never fetched —
+        /// not when forced, and not when they are the active provider (issue #83).
+        /// </summary>
+        internal static bool ShouldFetchForDashboard(ProviderId id, bool force, ProviderId? active)
+            => !ProviderDiscoveryService.IsExplicitlyDisabled(id)
+                && (force || ProviderDiscoveryService.ShouldFetch(id, active));
 
         /// <summary>Fetch every registered provider once so the cache is warm and each is verified.</summary>
         public async Task WarmUpAsync()

--- a/src/TaskbarQuota.App/UsageCoordinator.cs
+++ b/src/TaskbarQuota.App/UsageCoordinator.cs
@@ -1123,24 +1123,29 @@ namespace TaskbarQuota
             if (!await _gate.WaitAsync(0).ConfigureAwait(false)) return;
             try
             {
-                var result = await _service.FetchAsync(target, force).ConfigureAwait(false);
-                result = result.WithSource(SourceFor(target));
-
-                // The active provider may have changed while we awaited the network; if so, drop this
-                // stale result and let the next tick fetch the current target.
-                if (target != (_lastActive ?? WidgetDisplayProvider ?? ProviderId.Codex))
-                    return;
-
-                if (target != _lastLogged)
+                // A disabled provider must not leak network fetches either: nothing is allowed
+                // to display it, so only the widget fallback below stays fresh.
+                if (!ProviderDiscoveryService.IsExplicitlyDisabled(target))
                 {
-                    _lastLogged = target;
-                    if (result.Ok && result.Fetch is { } f)
-                        Diagnostics.Log.Information($"Switched to {target} (detected={detected}) session={f.Usage.Primary.UsedPercent:0}% weekly={f.Usage.Secondary?.UsedPercent ?? -1:0}% plan={f.Usage.LoginMethod}");
-                    else
-                        Diagnostics.Log.Warning($"Switched to {target} (detected={detected}) FAILED: {result.Error}");
+                    var result = await _service.FetchAsync(target, force).ConfigureAwait(false);
+                    result = result.WithSource(SourceFor(target));
+
+                    // The active provider may have changed while we awaited the network; if so, drop this
+                    // stale result and let the next tick fetch the current target.
+                    if (target != (_lastActive ?? WidgetDisplayProvider ?? ProviderId.Codex))
+                        return;
+
+                    if (target != _lastLogged)
+                    {
+                        _lastLogged = target;
+                        if (result.Ok && result.Fetch is { } f)
+                            Diagnostics.Log.Information($"Switched to {target} (detected={detected}) session={f.Usage.Primary.UsedPercent:0}% weekly={f.Usage.Secondary?.UsedPercent ?? -1:0}% plan={f.Usage.LoginMethod}");
+                        else
+                            Diagnostics.Log.Warning($"Switched to {target} (detected={detected}) FAILED: {result.Error}");
+                    }
+                    LastState = result;
+                    StateChanged?.Invoke(result);
                 }
-                LastState = result;
-                StateChanged?.Invoke(result);
 
                 await PublishWidgetProviderStateAsync(target, force).ConfigureAwait(false);
             }

--- a/src/TaskbarQuota.App/ViewModels/DashboardViewModel.cs
+++ b/src/TaskbarQuota.App/ViewModels/DashboardViewModel.cs
@@ -90,7 +90,10 @@ namespace TaskbarQuota.ViewModels
                 if (card.ProviderId != id)
                     continue;
 
-                EnableAvailableProvider(id);
+                // An explicitly-disabled provider must never be re-enabled by selection —
+                // only the Settings toggle opts back in.
+                if (!ProviderDiscoveryService.IsExplicitlyDisabled(id))
+                    EnableAvailableProvider(id);
                 return;
             }
         }

--- a/tests/TaskbarQuota.Tests/ProviderDiscoveryServiceTests.cs
+++ b/tests/TaskbarQuota.Tests/ProviderDiscoveryServiceTests.cs
@@ -264,4 +264,42 @@ public class ProviderDiscoveryServiceTests
         Assert.False(ProviderDiscoveryService.ShouldFetch(ProviderId.Grok, active: null));
         Assert.True(ProviderDiscoveryService.ShouldFetch(ProviderId.Grok, active: ProviderId.Grok));
     }
+
+    [Fact]
+    public void SyncInstalledProviderVisibility_KeepsPinnedProviderVisible()
+    {
+        // A pin is explicit user intent: sync must not clobber its visibility flags even
+        // when nothing is currently detected as installed (issue #83).
+        WidgetSettingsService.SetProviderPinnedForTesting(ProviderId.Grok, true);
+        WidgetSettingsService.SetProviderVisibleForTesting(ProviderId.Grok, true);
+        WidgetSettingsService.SetProviderDashboardVisibleForTesting(ProviderId.Grok, true);
+
+        ProviderDiscoveryService.SyncInstalledProviderVisibility();
+
+        Assert.True(WidgetSettingsService.IsProviderVisible(ProviderId.Grok));
+        Assert.True(WidgetSettingsService.IsProviderDashboardVisible(ProviderId.Grok));
+    }
+
+    [Fact]
+    public void ShouldFetchForDashboard_NeverFetchesDisabledProviderEvenWhenForced()
+    {
+        // The manual-refresh (force) path must not bypass the disabled filter — not even
+        // when the disabled provider is the active one (issue #83).
+        ProviderDiscoveryService.MarkExplicitlyDisabledForTesting(ProviderId.Claude);
+
+        Assert.False(UsageCoordinator.ShouldFetchForDashboard(ProviderId.Claude, force: true, active: ProviderId.Claude));
+        Assert.False(UsageCoordinator.ShouldFetchForDashboard(ProviderId.Claude, force: true, active: null));
+        Assert.False(UsageCoordinator.ShouldFetchForDashboard(ProviderId.Claude, force: false, active: null));
+    }
+
+    [Fact]
+    public void ShouldFetchForDashboard_ForceWidensCachePolicyButNotTheProviderSet()
+    {
+        // Without force the eligibility rules apply: an idle installed provider is not fetched.
+        ProviderInstallDetector.IsInstalledOverrideForTesting = _ => true;
+        Assert.False(UsageCoordinator.ShouldFetchForDashboard(ProviderId.Grok, force: false, active: null));
+
+        // With force any non-disabled provider is refreshed.
+        Assert.True(UsageCoordinator.ShouldFetchForDashboard(ProviderId.Grok, force: true, active: null));
+    }
 }

--- a/tests/TaskbarQuota.Tests/ProviderDiscoveryServiceTests.cs
+++ b/tests/TaskbarQuota.Tests/ProviderDiscoveryServiceTests.cs
@@ -10,6 +10,7 @@ public class ProviderDiscoveryServiceTests
         ProviderDiscoveryService.ResetForTesting();
         WidgetSettingsService.ResetProviderVisibilityForTesting();
         WidgetSettingsService.ResetDashboardProviderVisibilityForTesting();
+        WidgetSettingsService.ResetProviderPinsForTesting();
         WidgetSettingsService.ApplyAutoHideUnavailable(true);
         ProviderInstallDetector.IsInstalledOverrideForTesting = _ => false;
         ProviderInstallDetector.ResetCliCacheForTesting();
@@ -28,8 +29,12 @@ public class ProviderDiscoveryServiceTests
     }
 
     [Fact]
-    public void RecordFetchResult_MarksConfiguredOnSuccess()
+    public void RecordFetchResult_MarksConfiguredWithoutRestoringVisibility()
     {
+        ProviderInstallDetector.IsInstalledOverrideForTesting = id => id == ProviderId.Codex;
+        WidgetSettingsService.SetProviderVisibleForTesting(ProviderId.Codex, false);
+        WidgetSettingsService.SetProviderDashboardVisibleForTesting(ProviderId.Codex, false);
+
         var provider = new UsageService().Get(ProviderId.Codex)!;
         var result = UsageResult.Success(
             ProviderId.Codex,
@@ -39,13 +44,15 @@ public class ProviderDiscoveryServiceTests
         ProviderDiscoveryService.RecordFetchResult(result);
 
         Assert.True(ProviderDiscoveryService.IsConfigured(ProviderId.Codex));
-        Assert.True(WidgetSettingsService.IsProviderDashboardVisible(ProviderId.Codex));
-        Assert.True(WidgetSettingsService.IsProviderVisible(ProviderId.Codex));
+        // A successful fetch of an idle provider must not resurrect it (issue #83).
+        Assert.False(WidgetSettingsService.IsProviderDashboardVisible(ProviderId.Codex));
+        Assert.False(WidgetSettingsService.IsProviderVisible(ProviderId.Codex));
     }
 
     [Fact]
-    public void RecordFetchResult_RestoresWidgetAfterNewlyConfigured()
+    public void RecordFetchResult_DoesNotRestoreIdleInstalledProvider()
     {
+        ProviderInstallDetector.IsInstalledOverrideForTesting = id => id == ProviderId.Grok;
         WidgetSettingsService.SetProviderVisibleForTesting(ProviderId.Grok, false);
         WidgetSettingsService.SetProviderDashboardVisibleForTesting(ProviderId.Grok, false);
         ProviderDiscoveryService.MarkProbedForTesting(ProviderId.Grok);
@@ -58,8 +65,8 @@ public class ProviderDiscoveryServiceTests
 
         ProviderDiscoveryService.RecordFetchResult(result);
 
-        Assert.True(WidgetSettingsService.IsProviderVisible(ProviderId.Grok));
-        Assert.True(WidgetSettingsService.IsProviderDashboardVisible(ProviderId.Grok));
+        Assert.False(WidgetSettingsService.IsProviderVisible(ProviderId.Grok));
+        Assert.False(WidgetSettingsService.IsProviderDashboardVisible(ProviderId.Grok));
     }
 
     [Theory]
@@ -86,14 +93,15 @@ public class ProviderDiscoveryServiceTests
     }
 
     [Fact]
-    public void ShouldShowInAvailable_ReturnsHiddenNotInstalled()
+    public void ShouldShowInAvailable_NeverSurfacesProviders()
     {
         ProviderDiscoveryService.MarkProbedForTesting(ProviderId.Devin);
         WidgetSettingsService.SetProviderDashboardVisibleForTesting(ProviderId.Devin, false);
 
         var result = UsageResult.Failure(ProviderId.Devin, "Not installed", kind: ProviderErrorKind.NotInstalled);
 
-        Assert.True(ProviderDiscoveryService.ShouldShowInAvailable(result, active: null));
+        // Discovery surfacing is disabled: Settings is the opt-in surface (issue #83).
+        Assert.False(ProviderDiscoveryService.ShouldShowInAvailable(result, active: null));
         Assert.False(ProviderDiscoveryService.ShouldShowInDashboard(result, active: null));
     }
 
@@ -112,7 +120,7 @@ public class ProviderDiscoveryServiceTests
     }
 
     [Fact]
-    public void ShouldShowInDashboard_ReturnsNotRunningProvider()
+    public void ShouldShowInDashboard_HidesNotInstalledProvider()
     {
         ProviderDiscoveryService.MarkProbedForTesting(ProviderId.Antigravity);
         var result = UsageResult.Failure(
@@ -120,22 +128,122 @@ public class ProviderDiscoveryServiceTests
             "Waiting for Antigravity to be open.",
             kind: ProviderErrorKind.NotRunning);
 
-        Assert.True(ProviderDiscoveryService.ShouldShowInDashboard(result, active: null));
+        Assert.False(ProviderDiscoveryService.ShouldShowInDashboard(result, active: null));
         Assert.False(ProviderDiscoveryService.ShouldShowInAvailable(result, active: null));
     }
 
     [Fact]
-    public void SyncInstalledProviderVisibility_EnablesDashboardAndWidget()
+    public void SyncInstalledProviderVisibility_DoesNotAutoShowInstalledProvider()
     {
         ProviderInstallDetector.IsInstalledOverrideForTesting = id => id == ProviderId.Grok;
         WidgetSettingsService.SetProviderVisibleForTesting(ProviderId.Grok, false);
         WidgetSettingsService.SetProviderDashboardVisibleForTesting(ProviderId.Grok, false);
 
-        ProviderDiscoveryService.RecordFetchResult(
-            UsageResult.Failure(ProviderId.Grok, "auth", kind: ProviderErrorKind.AuthRequired));
+        ProviderDiscoveryService.SyncInstalledProviderVisibility();
 
-        Assert.True(WidgetSettingsService.IsProviderDashboardVisible(ProviderId.Grok));
-        Assert.True(WidgetSettingsService.IsProviderVisible(ProviderId.Grok));
+        Assert.False(WidgetSettingsService.IsProviderDashboardVisible(ProviderId.Grok));
+        Assert.False(WidgetSettingsService.IsProviderVisible(ProviderId.Grok));
+    }
+
+    [Fact]
+    public void SyncInstalledProviderVisibility_HidesStaleNotInstalledProvider()
+    {
+        WidgetSettingsService.SetProviderVisibleForTesting(ProviderId.Grok, true);
+        WidgetSettingsService.SetProviderDashboardVisibleForTesting(ProviderId.Grok, true);
+
+        ProviderDiscoveryService.SyncInstalledProviderVisibility();
+
+        Assert.False(WidgetSettingsService.IsProviderDashboardVisible(ProviderId.Grok));
+        Assert.False(WidgetSettingsService.IsProviderVisible(ProviderId.Grok));
+    }
+
+    [Fact]
+    public void ShouldShowInDashboard_ShowsActiveProviderEvenWhenNotInstalled()
+    {
+        // Browser-tab detection can make a provider active with nothing installed
+        // (web use counts as open) — the open app always shows.
+        var result = UsageResult.Failure(ProviderId.Claude, "Not installed", kind: ProviderErrorKind.NotInstalled);
+
+        Assert.True(ProviderDiscoveryService.ShouldShowInDashboard(result, active: ProviderId.Claude));
+    }
+
+    [Fact]
+    public void ShouldShowInDashboard_HidesDisabledActiveProvider()
+    {
+        ProviderDiscoveryService.MarkExplicitlyDisabledForTesting(ProviderId.Claude);
+        var provider = new UsageService().Get(ProviderId.Claude)!;
+        var result = UsageResult.Success(
+            ProviderId.Claude,
+            provider,
+            new ProviderFetchResult(new UsageSnapshot(new RateWindow(10)), "test"));
+
+        Assert.False(ProviderDiscoveryService.ShouldShowInDashboard(result, active: ProviderId.Claude));
+    }
+
+    [Fact]
+    public void ShouldShowInDashboard_HidesIdleInstalledProvider()
+    {
+        ProviderInstallDetector.IsInstalledOverrideForTesting = _ => true;
+        var provider = new UsageService().Get(ProviderId.Grok)!;
+        var result = UsageResult.Success(
+            ProviderId.Grok,
+            provider,
+            new ProviderFetchResult(new UsageSnapshot(new RateWindow(10)), "test"));
+
+        Assert.False(ProviderDiscoveryService.ShouldShowInDashboard(result, active: null));
+        Assert.False(ProviderDiscoveryService.ShouldShowInAvailable(result, active: null));
+        Assert.False(ProviderDiscoveryService.ShouldFetch(ProviderId.Grok, active: null));
+    }
+
+    [Fact]
+    public void ShouldShowInDashboard_ShowsExplicitlyEnabledInstalledProvider()
+    {
+        ProviderInstallDetector.IsInstalledOverrideForTesting = id => id == ProviderId.Codex;
+        ProviderDiscoveryService.EnableProvider(ProviderId.Codex);
+        var provider = new UsageService().Get(ProviderId.Codex)!;
+        var result = UsageResult.Success(
+            ProviderId.Codex,
+            provider,
+            new ProviderFetchResult(new UsageSnapshot(new RateWindow(10)), "test"));
+
+        Assert.True(ProviderDiscoveryService.ShouldShowInDashboard(result, active: null));
+        Assert.True(ProviderDiscoveryService.ShouldFetch(ProviderId.Codex, active: null));
+    }
+
+    [Fact]
+    public void ShouldShowInDashboard_ShowsRecentlyActiveInstalledProvider()
+    {
+        ProviderInstallDetector.IsInstalledOverrideForTesting = _ => true;
+        ProviderDiscoveryService.IsRecentlyActiveOverrideForTesting = id => id == ProviderId.Grok;
+        var provider = new UsageService().Get(ProviderId.Grok)!;
+        var result = UsageResult.Success(
+            ProviderId.Grok,
+            provider,
+            new ProviderFetchResult(new UsageSnapshot(new RateWindow(10)), "test"));
+
+        Assert.True(ProviderDiscoveryService.ShouldShowInDashboard(result, active: null));
+        Assert.True(ProviderDiscoveryService.ShouldFetch(ProviderId.Grok, active: null));
+    }
+
+    [Fact]
+    public void ShouldShowInDashboard_ShowsPinnedInstalledProvider()
+    {
+        ProviderInstallDetector.IsInstalledOverrideForTesting = id => id == ProviderId.Grok;
+        WidgetSettingsService.SetProviderPinnedForTesting(ProviderId.Grok, true);
+        var provider = new UsageService().Get(ProviderId.Grok)!;
+        var result = UsageResult.Success(
+            ProviderId.Grok,
+            provider,
+            new ProviderFetchResult(new UsageSnapshot(new RateWindow(10)), "test"));
+
+        Assert.True(ProviderDiscoveryService.ShouldShowInDashboard(result, active: null));
+        Assert.True(ProviderDiscoveryService.ShouldFetch(ProviderId.Grok, active: null));
+    }
+
+    [Fact]
+    public void ShouldFetch_FetchesActiveProviderEvenWhenNotInstalled()
+    {
+        Assert.True(ProviderDiscoveryService.ShouldFetch(ProviderId.Grok, active: ProviderId.Grok));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #83.

Claude Code could not stay disabled: turning it off in Settings was undone by nav selection auto-enabling it, flyout SelectProvider(active) on widget click, fetch-driven auto-restore, and installed-always-shows (lingering ~/.claude credentials keep IsInstalled true).

New display rules (ProviderDiscoveryService):
- Explicitly disabled -> never shown, never fetched. Only the Settings toggle opts back in.
- Not installed -> never shown, never fetched. Available/discovery surfacing stays inert.
- Installed -> shown only with open/use evidence: detected active (CLI, desktop, browser tab), recently active, Settings-enabled, or pinned.

Changes:
- RecordFetchResult / SyncInstalledProviderVisibility no longer auto-show; sync only hides stale not-installed entries.
- DashboardNavigationBinder: nav lists only displayable providers; selection never re-enables a disabled one.
- DashboardViewModel.SelectProvider: same guard.
- UsageCoordinator tick + TaskBarManager pinned refresh skip disabled providers (no fetch leak).

Tests: updated ProviderDiscoveryServiceTests to the new contract + 8 new cases (active override incl. browser-only use, disabled-active hidden, idle-installed hidden/unfetched, enabled/recent/pinned shown). Full suite: 827/827 green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled providers no longer reappear in navigation or become re-enabled through selection.
  * Disabled providers no longer trigger background usage fetches, widget updates, or refresh requests.
  * Installed but idle providers remain hidden unless explicitly enabled, pinned, recently active, or currently active.
  * Navigation now excludes unavailable or inactive providers.
  * Provider visibility is preserved consistently after successful or unsuccessful fetches.
  * Explicitly hidden widgets remain hidden when providers are enabled or visibility is synchronized.
  * Pinned providers remain visible during provider visibility updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->