### PR TITLE
fix(taskbar): identify screens by monitor identity, not GDI numbers

### DIFF
--- a/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
+++ b/src/TaskbarQuota.App/FlyoutWindow.xaml.cs
@@ -837,9 +837,10 @@ namespace TaskbarQuota
                 item.Pin.Visibility = pinned ? Visibility.Visible : Visibility.Collapsed;
 
             string? fixedDisplay = WidgetSettingsService.GetPinnedProviderDisplay(id);
+            TaskbarWindowTarget.TryFindAll(out var pinDisplays);
             string pinDescription = fixedDisplay is null
                 ? "pinned — follows app screen"
-                : $"pinned to {TaskbarWindowTarget.GetDisplayLabel(fixedDisplay)}";
+                : $"pinned to {TaskbarWindowTarget.GetDisplayLabel(fixedDisplay, pinDisplays)}";
             ToolTipService.SetToolTip(button, pinned ? $"{displayName} — {pinDescription}" : displayName);
         }
 

--- a/src/TaskbarQuota.App/Interop/Native.cs
+++ b/src/TaskbarQuota.App/Interop/Native.cs
@@ -221,6 +221,16 @@ namespace TaskbarQuota.Interop
 
         [DllImport("user32.dll", CharSet = CharSet.Auto, EntryPoint = "GetMonitorInfo")]
         public static extern bool GetMonitorInfo([In] IntPtr hMonitor, ref MONITORINFOEX lpmi);
+
+        public const uint MONITORINFOF_PRIMARY = 1;
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool EnumDisplayDevices(
+            string? lpDevice,
+            uint iDevNum,
+            ref DISPLAY_DEVICE lpDisplayDevice,
+            uint dwFlags);
     }
 
     public static class WtsApi32
@@ -240,6 +250,7 @@ namespace TaskbarQuota.Interop
     {
         public const int DWMWA_WINDOW_CORNER_PREFERENCE = 33;
         public const int DWMWA_CLOAK = 13;
+        public const int DWMWA_CLOAKED = 14;
 
         [DllImport("dwmapi.dll")]
         public static extern int DwmSetWindowAttribute(
@@ -254,6 +265,13 @@ namespace TaskbarQuota.Interop
             int attribute,
             ref int value,
             int valueSize);
+
+        [DllImport("dwmapi.dll")]
+        public static extern int DwmGetWindowAttribute(
+            IntPtr hwnd,
+            int attribute,
+            out int pfAttribute,
+            int cbAttribute);
     }
 
     public enum DwmWindowCornerPreference
@@ -296,6 +314,30 @@ namespace TaskbarQuota.Interop
         {
             cbSize = Marshal.SizeOf<MONITORINFOEX>(),
             szDevice = string.Empty,
+        };
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+    public struct DISPLAY_DEVICE
+    {
+        public int cb;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        public string DeviceName;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        public string DeviceString;
+        public uint StateFlags;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        public string DeviceID;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        public string DeviceKey;
+
+        public static DISPLAY_DEVICE Create() => new()
+        {
+            cb = Marshal.SizeOf<DISPLAY_DEVICE>(),
+            DeviceName = string.Empty,
+            DeviceString = string.Empty,
+            DeviceID = string.Empty,
+            DeviceKey = string.Empty,
         };
     }
 

--- a/src/TaskbarQuota.App/Interop/Native.cs
+++ b/src/TaskbarQuota.App/Interop/Native.cs
@@ -223,6 +223,8 @@ namespace TaskbarQuota.Interop
         public static extern bool GetMonitorInfo([In] IntPtr hMonitor, ref MONITORINFOEX lpmi);
 
         public const uint MONITORINFOF_PRIMARY = 1;
+        public const uint EDD_GET_DEVICE_INTERFACE_NAME = 1;
+        public const uint DISPLAY_DEVICE_ACTIVE = 1;
 
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -50,6 +50,7 @@ namespace TaskbarQuota.Taskbar
         private static readonly TopologyStabilityTracker TopologyStability = new();
         private static readonly Dictionary<IntPtr, int> MissingTaskbarObservations = new();
         private static readonly AdaptiveDisplayProviderState AdaptiveDisplayProviders = new();
+        private static IReadOnlyList<DisplayIdentity> DisplayIdentities = [];
         private static ProviderId? _lastLoggedWidgetApplyProvider;
         private static WidgetSurfaceMode _activeSurface = WidgetSurfaceMode.Taskbar;
         // Foreground hook: fires the instant Windows switches windows so the focus-follows-provider
@@ -595,6 +596,8 @@ namespace TaskbarQuota.Taskbar
                     Log.Warning("Could not enumerate Windows taskbars; keeping existing widgets until the next health check");
                     return;
                 }
+                RememberDisplayIdentities(targets);
+                MigratePersistedDisplayKeys();
                 var targetsByHandle = targets.ToDictionary(target => target.Handle);
 
                 foreach (var pair in Widgets.ToArray())
@@ -719,15 +722,15 @@ namespace TaskbarQuota.Taskbar
             return TaskbarContentRouter.ProvidersForDisplay(
                 providers,
                 mode,
-                WidgetSettingsService.SelectedTaskbarDisplayKey,
+                ResolveDisplayKey(WidgetSettingsService.SelectedTaskbarDisplayKey) ?? string.Empty,
                 widget.DisplayKey,
                 primary,
                 available,
                 provider => displayActive == provider
                     ? widget.DisplayKey
-                    : WidgetSettingsService.GetAdaptiveProviderDisplay(provider),
+                    : ResolveDisplayKey(WidgetSettingsService.GetAdaptiveProviderDisplay(provider)),
                 WidgetSettingsService.IsProviderPinned,
-                WidgetSettingsService.GetPinnedProviderDisplay);
+                provider => ResolveDisplayKey(WidgetSettingsService.GetPinnedProviderDisplay(provider)));
         }
 
         private static ProviderId? ActiveProviderForWidget(
@@ -753,6 +756,55 @@ namespace TaskbarQuota.Taskbar
 
         internal static bool ShouldRemoveMissingTaskbar(int consecutiveMisses, bool hostAlive)
             => !hostAlive || consecutiveMisses >= 2;
+
+        private static void RememberDisplayIdentities(IReadOnlyList<TaskbarWindowTarget> targets)
+        {
+            var identities = new DisplayIdentity[targets.Count];
+            for (int i = 0; i < targets.Count; i++)
+                identities[i] = targets[i].ToIdentity();
+            DisplayIdentities = identities;
+        }
+
+        private static string? ResolveDisplayKey(string? key)
+        {
+            if (string.IsNullOrWhiteSpace(key)
+                || key == WidgetSettingsService.AllDisplaysPinDestination
+                || DisplayIdentities.Count == 0)
+            {
+                return key;
+            }
+
+            return TaskbarWindowTarget.ResolvePersistedDisplayKey(key, DisplayIdentities);
+        }
+
+        private static void MigratePersistedDisplayKeys()
+        {
+            if (DisplayIdentities.Count == 0)
+                return;
+
+            if (WidgetSettingsService.CurrentTaskbarPlacement == TaskbarPlacementMode.SelectedDisplay
+                && TaskbarWindowTarget.TryMigratePersistedKey(
+                    WidgetSettingsService.SelectedTaskbarDisplayKey,
+                    DisplayIdentities,
+                    out string selected))
+            {
+                Log.Information(
+                    $"Migrated selected taskbar display {WidgetSettingsService.SelectedTaskbarDisplayKey} -> {selected}");
+                WidgetSettingsService.ApplyTaskbarPlacement(TaskbarPlacementMode.SelectedDisplay, selected);
+            }
+
+            foreach (ProviderId provider in Enum.GetValues<ProviderId>())
+            {
+                string? pinned = WidgetSettingsService.GetPinnedProviderDisplay(provider);
+                if (pinned is null || pinned == WidgetSettingsService.AllDisplaysPinDestination)
+                    continue;
+                if (!TaskbarWindowTarget.TryMigratePersistedKey(pinned, DisplayIdentities, out string resolved))
+                    continue;
+
+                Log.Information($"Migrated pinned display for {provider}: {pinned} -> {resolved}");
+                WidgetSettingsService.SetPinnedProviderDisplay(provider, resolved);
+            }
+        }
 
         private static void OnTopologyChanged(TopologyChange change)
             => _dispatcher?.TryEnqueue(() => ScheduleTopologyRecovery(change));
@@ -815,6 +867,9 @@ namespace TaskbarQuota.Taskbar
                 return false;
             }
 
+            RememberDisplayIdentities(targets);
+            MigratePersistedDisplayKeys();
+
             string signature = string.Join(
                 "|",
                 targets.Select(target => $"{target.Handle.ToInt64():X}:{target.DisplayKey}:{target.IsPrimary}"));
@@ -862,13 +917,13 @@ namespace TaskbarQuota.Taskbar
             return TaskbarContentRouter.ActivityForDisplay(
                 snapshot,
                 WidgetSettingsService.CurrentTaskbarPlacement,
-                WidgetSettingsService.SelectedTaskbarDisplayKey,
+                ResolveDisplayKey(WidgetSettingsService.SelectedTaskbarDisplayKey) ?? string.Empty,
                 widget.DisplayKey,
                 primary,
                 available,
-                WidgetSettingsService.GetAdaptiveProviderDisplay,
+                provider => ResolveDisplayKey(WidgetSettingsService.GetAdaptiveProviderDisplay(provider)),
                 WidgetSettingsService.IsProviderPinned,
-                WidgetSettingsService.GetPinnedProviderDisplay);
+                provider => ResolveDisplayKey(WidgetSettingsService.GetPinnedProviderDisplay(provider)));
         }
 
         private static void SyncWidgetState()

--- a/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskBarManager.cs
@@ -51,6 +51,7 @@ namespace TaskbarQuota.Taskbar
         private static readonly Dictionary<IntPtr, int> MissingTaskbarObservations = new();
         private static readonly AdaptiveDisplayProviderState AdaptiveDisplayProviders = new();
         private static IReadOnlyList<DisplayIdentity> DisplayIdentities = [];
+        private static IReadOnlyList<TaskbarWindowTarget> DisplayTargets = [];
         private static ProviderId? _lastLoggedWidgetApplyProvider;
         private static WidgetSurfaceMode _activeSurface = WidgetSurfaceMode.Taskbar;
         // Foreground hook: fires the instant Windows switches windows so the focus-follows-provider
@@ -580,7 +581,7 @@ namespace TaskbarQuota.Taskbar
             _widgetHealthTimer.Start();
         }
 
-        private static void EnsureWidgets()
+        private static void EnsureWidgets(IReadOnlyList<TaskbarWindowTarget>? confirmedTargets = null)
         {
             if (IsFloatingSurface)
                 return;
@@ -591,13 +592,15 @@ namespace TaskbarQuota.Taskbar
             _isReconcilingWidgets = true;
             try
             {
-                if (!TaskbarWindowTarget.TryFindAll(out var targets))
+                var targets = confirmedTargets;
+                if (targets is null && !TaskbarWindowTarget.TryFindAll(out targets))
                 {
                     Log.Warning("Could not enumerate Windows taskbars; keeping existing widgets until the next health check");
                     return;
                 }
                 RememberDisplayIdentities(targets);
-                MigratePersistedDisplayKeys();
+                if (confirmedTargets is not null || TopologyStability.Observe(GetTopologySignature(targets)))
+                    MigratePersistedDisplayKeys();
                 var targetsByHandle = targets.ToDictionary(target => target.Handle);
 
                 foreach (var pair in Widgets.ToArray())
@@ -750,7 +753,7 @@ namespace TaskbarQuota.Taskbar
                 displayKey,
                 hwnd => User32.IsWindow(hwnd)
                     && string.Equals(
-                        TaskbarWindowTarget.GetDisplayKeyForWindow(hwnd),
+                        TaskbarWindowTarget.GetDisplayKeyForWindow(hwnd, DisplayTargets),
                         displayKey,
                         StringComparison.OrdinalIgnoreCase));
 
@@ -759,6 +762,7 @@ namespace TaskbarQuota.Taskbar
 
         private static void RememberDisplayIdentities(IReadOnlyList<TaskbarWindowTarget> targets)
         {
+            DisplayTargets = targets;
             var identities = new DisplayIdentity[targets.Count];
             for (int i = 0; i < targets.Count; i++)
                 identities[i] = targets[i].ToIdentity();
@@ -867,13 +871,7 @@ namespace TaskbarQuota.Taskbar
                 return false;
             }
 
-            RememberDisplayIdentities(targets);
-            MigratePersistedDisplayKeys();
-
-            string signature = string.Join(
-                "|",
-                targets.Select(target => $"{target.Handle.ToInt64():X}:{target.DisplayKey}:{target.IsPrimary}"));
-            if (!TopologyStability.Observe(signature))
+            if (!TopologyStability.Observe(GetTopologySignature(targets)))
                 return false;
 
             if (_topologyForceReset)
@@ -884,7 +882,8 @@ namespace TaskbarQuota.Taskbar
                 _topologyForceReset = false;
             }
 
-            EnsureWidgets();
+            // Reconcile and migrate against the exact snapshot that passed the stability check.
+            EnsureWidgets(targets);
             SyncWidgetState();
 
             return targets.All(target =>
@@ -904,6 +903,10 @@ namespace TaskbarQuota.Taskbar
             Log.Information($"Taskbar topology recovery completed ({_topologyRecoveryReason})");
             _topologyRecoveryReason = string.Empty;
         }
+
+        private static string GetTopologySignature(IReadOnlyList<TaskbarWindowTarget> targets)
+            => string.Join("|", targets.Select(target =>
+                $"{target.Handle.ToInt64():X}:{target.DisplayKey}:{target.GdiDeviceName}:{target.IsPrimary}"));
 
         private static AgentActivitySnapshot ActivityForWidget(
             TaskBarWidget widget,
@@ -1227,7 +1230,7 @@ namespace TaskbarQuota.Taskbar
 
         private static void OnProviderWindowObserved(ProviderId provider, IntPtr hwnd)
         {
-            string displayKey = TaskbarWindowTarget.GetDisplayKeyForWindow(hwnd);
+            string displayKey = TaskbarWindowTarget.GetDisplayKeyForWindow(hwnd, DisplayTargets);
             if (displayKey.Length == 0)
                 return;
 
@@ -1241,7 +1244,7 @@ namespace TaskbarQuota.Taskbar
             if (AdaptiveDisplayProviders.GetProviderForWindow(hwnd) is not { } provider)
                 return;
 
-            string displayKey = TaskbarWindowTarget.GetDisplayKeyForWindow(hwnd);
+            string displayKey = TaskbarWindowTarget.GetDisplayKeyForWindow(hwnd, DisplayTargets);
             if (displayKey.Length != 0)
                 RecordAdaptiveProviderDisplay(provider, displayKey, hwnd);
         }

--- a/src/TaskbarQuota.App/Taskbar/TaskbarWindowTarget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskbarWindowTarget.cs
@@ -4,13 +4,16 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text;
 using TaskbarQuota.Diagnostics;
 using TaskbarQuota.Interop;
 
 namespace TaskbarQuota.Taskbar
 {
-    internal readonly record struct DisplayIdentity(string DisplayKey, string GdiDeviceName, bool IsPrimary);
+    internal readonly record struct DisplayIdentity(
+        string DisplayKey, string GdiDeviceName, bool IsPrimary,
+        string LegacyDisplayKey = "", string LegacySuffixedDisplayKey = "");
 
     internal readonly record struct TaskbarWindowTarget(
         IntPtr Handle,
@@ -18,7 +21,9 @@ namespace TaskbarQuota.Taskbar
         string DisplayKey,
         string GdiDeviceName = "",
         IntPtr Monitor = default,
-        RECT Bounds = default)
+        RECT Bounds = default,
+        string LegacyDisplayKey = "",
+        string LegacySuffixedDisplayKey = "")
     {
         internal const string PrimaryClassName = "Shell_TrayWnd";
         internal const string SecondaryClassName = "Shell_SecondaryTrayWnd";
@@ -32,7 +37,8 @@ namespace TaskbarQuota.Taskbar
             }
         }
 
-        public DisplayIdentity ToIdentity() => new(DisplayKey, GdiDeviceName, IsPrimary);
+        public DisplayIdentity ToIdentity()
+            => new(DisplayKey, GdiDeviceName, IsPrimary, LegacyDisplayKey, LegacySuffixedDisplayKey);
 
         public static bool TryFindAll(out IReadOnlyList<TaskbarWindowTarget> result)
         {
@@ -61,6 +67,13 @@ namespace TaskbarQuota.Taskbar
         internal string GetPositionPath(string directory)
         {
             string path = Path.Combine(directory, BuildPositionFileName(DisplayKey));
+
+            // Prefer layouts saved by earlier PR builds over the original GDI-keyed layout.
+            foreach (string legacyKey in new[] { LegacySuffixedDisplayKey, LegacyDisplayKey })
+            {
+                if (legacyKey.Length > 0 && !string.Equals(legacyKey, DisplayKey, StringComparison.OrdinalIgnoreCase))
+                    MigratePositionFiles(Path.Combine(directory, BuildPositionFileName(legacyKey)), path);
+            }
 
             string gdiKey = SanitizeDisplayToken(GdiDeviceName);
             if (gdiKey.Length > 0 && !string.Equals(gdiKey, DisplayKey, StringComparison.OrdinalIgnoreCase))
@@ -94,13 +107,15 @@ namespace TaskbarQuota.Taskbar
         }
 
         internal static string BuildDisplayKey(string? displayId, RECT bounds)
-            => BuildDisplayKey(displayId, stableMonitorId: null, bounds);
+            => BuildDisplayKey(displayId, monitorInterfaceName: null, bounds);
 
-        internal static string BuildDisplayKey(string? displayId, string? stableMonitorId, RECT bounds)
+        internal static string BuildDisplayKey(string? displayId, string? monitorInterfaceName, RECT bounds)
         {
-            string stable = SanitizeDisplayToken(stableMonitorId);
-            if (stable.Length > 0)
-                return stable;
+            // Windows registers this interface per monitor instance. Hash the complete path
+            // (including separators) to retain its identity in a bounded, file-safe key.
+            if (!string.IsNullOrWhiteSpace(monitorInterfaceName))
+                return "MONITOR_" + Convert.ToHexString(SHA256.HashData(
+                    Encoding.UTF8.GetBytes(monitorInterfaceName.Trim().ToUpperInvariant())));
 
             string sanitized = SanitizeDisplayToken(displayId);
             return sanitized.Length > 0
@@ -186,7 +201,15 @@ namespace TaskbarQuota.Taskbar
                     .First());
             }
 
-            return DisambiguateDisplayKeys(chosen);
+            // Older builds used model/driver IDs, sometimes shared by multiple monitors.
+            // Only offer an unqualified legacy alias when it has one possible live owner.
+            var legacyCounts = chosen.Where(target => target.LegacyDisplayKey.Length > 0)
+                .GroupBy(target => target.LegacyDisplayKey, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+            return chosen.Select(target => target.LegacyDisplayKey.Length > 0
+                    && legacyCounts[target.LegacyDisplayKey] > 1
+                ? target with { LegacyDisplayKey = string.Empty }
+                : target).ToList();
         }
 
         /// <summary>
@@ -248,6 +271,8 @@ namespace TaskbarQuota.Taskbar
             // The primary/sole-secondary heuristics are temporary routing fallbacks, not proof
             // of identity. Persisting one during an incomplete scan loses the original choice.
             resolved = persisted;
+            if (string.IsNullOrWhiteSpace(persisted))
+                return false;
             foreach (var item in live)
             {
                 if (MatchesIdentity(item, persisted.Trim()))
@@ -309,13 +334,23 @@ namespace TaskbarQuota.Taskbar
                 return string.Empty;
 
             var device = DISPLAY_DEVICE.Create();
-            return User32.EnumDisplayDevices(gdiDeviceName, 0, ref device, 0)
-                ? SanitizeDisplayToken(device.DeviceID)
-                : string.Empty;
+            for (uint index = 0; User32.EnumDisplayDevices(
+                gdiDeviceName, index, ref device, User32.EDD_GET_DEVICE_INTERFACE_NAME); index++)
+            {
+                if ((device.StateFlags & User32.DISPLAY_DEVICE_ACTIVE) != 0)
+                    return device.DeviceID;
+                device = DISPLAY_DEVICE.Create();
+            }
+
+            return string.Empty;
         }
 
         private static bool MatchesIdentity(DisplayIdentity identity, string key)
             => string.Equals(identity.DisplayKey, key, StringComparison.OrdinalIgnoreCase)
+                || (identity.LegacyDisplayKey.Length > 0
+                    && string.Equals(identity.LegacyDisplayKey, key, StringComparison.OrdinalIgnoreCase))
+                || (identity.LegacySuffixedDisplayKey.Length > 0
+                    && string.Equals(identity.LegacySuffixedDisplayKey, key, StringComparison.OrdinalIgnoreCase))
                 || string.Equals(identity.GdiDeviceName, key, StringComparison.OrdinalIgnoreCase)
                 || string.Equals(
                     SanitizeDisplayToken(identity.GdiDeviceName),
@@ -329,52 +364,6 @@ namespace TaskbarQuota.Taskbar
 
         private static int DisplayArea(RECT bounds)
             => Math.Max(0, bounds.right - bounds.left) * Math.Max(0, bounds.bottom - bounds.top);
-
-        internal static IReadOnlyList<TaskbarWindowTarget> DisambiguateDisplayKeys(
-            IReadOnlyList<TaskbarWindowTarget> targets)
-        {
-            if (targets.Count < 2)
-                return targets;
-
-            var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-            foreach (var target in targets)
-                counts[target.DisplayKey] = counts.GetValueOrDefault(target.DisplayKey) + 1;
-
-            bool anyDuplicate = false;
-            foreach (int count in counts.Values)
-            {
-                if (count > 1)
-                {
-                    anyDuplicate = true;
-                    break;
-                }
-            }
-
-            if (!anyDuplicate)
-                return targets;
-
-            var unique = new List<TaskbarWindowTarget>(targets.Count);
-            foreach (var target in targets)
-            {
-                if (counts[target.DisplayKey] == 1)
-                {
-                    unique.Add(target);
-                    continue;
-                }
-
-                string suffix = SanitizeDisplayToken(target.GdiDeviceName);
-                if (suffix.Length == 0)
-                {
-                    suffix = string.Create(
-                        CultureInfo.InvariantCulture,
-                        $"{target.Bounds.left}_{target.Bounds.top}");
-                }
-
-                unique.Add(target with { DisplayKey = $"{target.DisplayKey}_{suffix}" });
-            }
-
-            return unique;
-        }
 
         private static bool EnumTaskbarWindow(IntPtr hwnd, IntPtr lParam)
         {
@@ -401,13 +390,21 @@ namespace TaskbarQuota.Taskbar
                 ? info.szDevice
                 : string.Empty;
             var keyBounds = info.rcMonitor.right > info.rcMonitor.left ? info.rcMonitor : bounds;
+            string gdiKey = SanitizeDisplayToken(gdiDevice);
+            var legacyDevice = DISPLAY_DEVICE.Create();
+            string legacyKey = gdiDevice.Length > 0
+                && User32.EnumDisplayDevices(gdiDevice, 0, ref legacyDevice, 0)
+                    ? SanitizeDisplayToken(legacyDevice.DeviceID)
+                    : string.Empty;
             targets.Add(new TaskbarWindowTarget(
                 hwnd,
                 isPrimary,
                 BuildDisplayKey(gdiDevice, TryGetMonitorDeviceId(gdiDevice), keyBounds),
-                SanitizeDisplayToken(gdiDevice),
+                gdiKey,
                 monitor,
-                bounds));
+                bounds,
+                legacyKey,
+                legacyKey.Length > 0 && gdiKey.Length > 0 ? $"{legacyKey}_{gdiKey}" : string.Empty));
             return true;
         }
 
@@ -426,7 +423,9 @@ namespace TaskbarQuota.Taskbar
 
             try
             {
-                bool foundSource = false;
+                // An earlier identity may already have migrated and then had its layout reset.
+                // Carry that completion forward even when no layout files remain to copy.
+                bool foundSource = File.Exists(sourcePath + ".migrated");
                 foreach (string suffix in new[] { "", ".order", ".activity", ".activity.manual" })
                 {
                     string source = sourcePath + suffix;

--- a/src/TaskbarQuota.App/Taskbar/TaskbarWindowTarget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskbarWindowTarget.cs
@@ -54,14 +54,20 @@ namespace TaskbarQuota.Taskbar
         }
 
         public string GetPositionPath()
-        {
-            string directory = Path.Combine(
+            => GetPositionPath(Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "TaskbarQuota");
+                "TaskbarQuota"));
+
+        internal string GetPositionPath(string directory)
+        {
             string path = Path.Combine(directory, BuildPositionFileName(DisplayKey));
 
+            string gdiKey = SanitizeDisplayToken(GdiDeviceName);
+            if (gdiKey.Length > 0 && !string.Equals(gdiKey, DisplayKey, StringComparison.OrdinalIgnoreCase))
+                MigratePositionFiles(Path.Combine(directory, BuildPositionFileName(gdiKey)), path);
+
             if (IsPrimary)
-                return MigrateLegacyPrimaryPosition(directory, path);
+                MigratePositionFiles(Path.Combine(directory, "taskbar-widget-position.txt"), path);
 
             return path;
         }
@@ -239,23 +245,24 @@ namespace TaskbarQuota.Taskbar
             IReadOnlyList<DisplayIdentity> live,
             out string resolved)
         {
-            resolved = ResolvePersistedDisplayKey(persisted, live);
-            if (resolved.Length == 0
-                || string.Equals(resolved, persisted, StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
+            // The primary/sole-secondary heuristics are temporary routing fallbacks, not proof
+            // of identity. Persisting one during an incomplete scan loses the original choice.
+            resolved = persisted;
             foreach (var item in live)
             {
-                if (string.Equals(item.DisplayKey, resolved, StringComparison.OrdinalIgnoreCase))
-                    return true;
+                if (MatchesIdentity(item, persisted.Trim()))
+                {
+                    resolved = item.DisplayKey;
+                    return !string.Equals(resolved, persisted, StringComparison.OrdinalIgnoreCase);
+                }
             }
 
             return false;
         }
 
-        internal static string GetDisplayKeyForWindow(IntPtr hwnd)
+        internal static string GetDisplayKeyForWindow(
+            IntPtr hwnd,
+            IReadOnlyList<TaskbarWindowTarget>? liveTargets = null)
         {
             if (hwnd == IntPtr.Zero || !User32.IsWindow(hwnd))
                 return string.Empty;
@@ -263,6 +270,12 @@ namespace TaskbarQuota.Taskbar
             var monitor = User32.MonitorFromWindow(hwnd, MonitorFromFlags.MONITOR_DEFAULTTONULL);
             if (monitor == IntPtr.Zero)
                 return string.Empty;
+
+            if (liveTargets is null)
+                TryFindAll(out liveTargets);
+            string canonicalKey = GetDisplayKeyForMonitor(monitor, liveTargets);
+            if (canonicalKey.Length > 0)
+                return canonicalKey;
 
             var info = MONITORINFOEX.Create();
             if (!User32.GetMonitorInfo(monitor, ref info))
@@ -272,6 +285,22 @@ namespace TaskbarQuota.Taskbar
                 info.szDevice,
                 TryGetMonitorDeviceId(info.szDevice),
                 info.rcMonitor);
+        }
+
+        internal static string GetDisplayKeyForMonitor(
+            IntPtr monitor,
+            IReadOnlyList<TaskbarWindowTarget> liveTargets)
+        {
+            if (monitor != IntPtr.Zero)
+            {
+                foreach (var target in liveTargets)
+                {
+                    if (target.Monitor == monitor)
+                        return target.DisplayKey;
+                }
+            }
+
+            return string.Empty;
         }
 
         internal static string TryGetMonitorDeviceId(string? gdiDeviceName)
@@ -389,23 +418,37 @@ namespace TaskbarQuota.Taskbar
         private static RECT GetBounds(IntPtr hwnd)
             => User32.GetWindowRect(hwnd, out var bounds) ? bounds : default;
 
-        private static string MigrateLegacyPrimaryPosition(string directory, string displayPositionPath)
+        private static void MigratePositionFiles(string sourcePath, string destinationPath)
         {
-            string legacyPath = Path.Combine(directory, "taskbar-widget-position.txt");
-            if (File.Exists(displayPositionPath) || !File.Exists(legacyPath))
-                return displayPositionPath;
+            string migrationMarker = destinationPath + ".migrated";
+            if (File.Exists(migrationMarker))
+                return;
 
             try
             {
-                Directory.CreateDirectory(directory);
-                File.Move(legacyPath, displayPositionPath);
-                Log.Information($"Migrated the primary taskbar widget position to {Path.GetFileName(displayPositionPath)}");
-                return displayPositionPath;
+                bool foundSource = false;
+                foreach (string suffix in new[] { "", ".order", ".activity", ".activity.manual" })
+                {
+                    string source = sourcePath + suffix;
+                    string destination = destinationPath + suffix;
+                    if (!File.Exists(source))
+                        continue;
+
+                    foundSource = true;
+                    // Preserve the original for retries and older app versions. Never overwrite
+                    // a position the user has already saved under the new monitor identity.
+                    if (!File.Exists(destination))
+                        File.Copy(source, destination);
+                }
+
+                // A later user reset may delete a position or manual-position marker. Do not
+                // restore those deliberately removed files the next time the host is created.
+                if (foundSource)
+                    File.WriteAllText(migrationMarker, "1");
             }
             catch (Exception ex)
             {
-                Log.Warning(ex, "Could not migrate the primary taskbar widget position");
-                return legacyPath;
+                Log.Warning(ex, $"Could not migrate taskbar layout {Path.GetFileName(sourcePath)}");
             }
         }
     }

--- a/src/TaskbarQuota.App/Taskbar/TaskbarWindowTarget.cs
+++ b/src/TaskbarQuota.App/Taskbar/TaskbarWindowTarget.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using TaskbarQuota.Diagnostics;
@@ -9,12 +10,29 @@ using TaskbarQuota.Interop;
 
 namespace TaskbarQuota.Taskbar
 {
-    internal readonly record struct TaskbarWindowTarget(IntPtr Handle, bool IsPrimary, string DisplayKey)
+    internal readonly record struct DisplayIdentity(string DisplayKey, string GdiDeviceName, bool IsPrimary);
+
+    internal readonly record struct TaskbarWindowTarget(
+        IntPtr Handle,
+        bool IsPrimary,
+        string DisplayKey,
+        string GdiDeviceName = "",
+        IntPtr Monitor = default,
+        RECT Bounds = default)
     {
         internal const string PrimaryClassName = "Shell_TrayWnd";
         internal const string SecondaryClassName = "Shell_SecondaryTrayWnd";
 
-        public int DisplayNumber => TryGetDisplayNumber(DisplayKey);
+        public int DisplayNumber
+        {
+            get
+            {
+                int fromGdi = TryGetDisplayNumber(GdiDeviceName);
+                return fromGdi > 0 ? fromGdi : TryGetDisplayNumber(DisplayKey);
+            }
+        }
+
+        public DisplayIdentity ToIdentity() => new(DisplayKey, GdiDeviceName, IsPrimary);
 
         public static bool TryFindAll(out IReadOnlyList<TaskbarWindowTarget> result)
         {
@@ -30,8 +48,8 @@ namespace TaskbarQuota.Taskbar
                 gc.Free();
             }
 
-            targets.Sort(CompareTargets);
-            result = targets;
+            var canonical = SelectCanonicalTaskbars(targets);
+            result = OrderForDisplay(canonical);
             return success;
         }
 
@@ -54,20 +72,33 @@ namespace TaskbarQuota.Taskbar
             return isPrimary || string.Equals(className, SecondaryClassName, StringComparison.Ordinal);
         }
 
-        internal static string BuildDisplayKey(string? displayId, RECT bounds)
+        internal static string SanitizeDisplayToken(string? value)
         {
             var builder = new StringBuilder();
-            if (!string.IsNullOrWhiteSpace(displayId))
+            if (!string.IsNullOrWhiteSpace(value))
             {
-                foreach (char c in displayId)
+                foreach (char c in value)
                 {
                     if (char.IsLetterOrDigit(c) || c is '-' or '_')
                         builder.Append(c);
                 }
             }
 
-            return builder.Length > 0
-                ? builder.ToString()
+            return builder.ToString();
+        }
+
+        internal static string BuildDisplayKey(string? displayId, RECT bounds)
+            => BuildDisplayKey(displayId, stableMonitorId: null, bounds);
+
+        internal static string BuildDisplayKey(string? displayId, string? stableMonitorId, RECT bounds)
+        {
+            string stable = SanitizeDisplayToken(stableMonitorId);
+            if (stable.Length > 0)
+                return stable;
+
+            string sanitized = SanitizeDisplayToken(displayId);
+            return sanitized.Length > 0
+                ? sanitized
                 : string.Create(
                     CultureInfo.InvariantCulture,
                     $"{bounds.left}_{bounds.top}_{bounds.right}_{bounds.bottom}");
@@ -94,13 +125,134 @@ namespace TaskbarQuota.Taskbar
                     : 0;
         }
 
+        internal static string FormatScreenLabel(int ordinal, bool isPrimary, bool includePrimarySuffix = true)
+        {
+            string label = $"Screen {Math.Max(1, ordinal)}";
+            return includePrimarySuffix && isPrimary ? $"{label} (primary)" : label;
+        }
+
         internal static string GetDisplayLabel(string displayKey)
+            => GetDisplayLabel(displayKey, liveTargets: null);
+
+        internal static string GetDisplayLabel(string displayKey, IReadOnlyList<TaskbarWindowTarget>? liveTargets)
         {
             if (displayKey == WidgetSettingsService.AllDisplaysPinDestination)
                 return "all screens";
 
+            if (liveTargets is { Count: > 0 })
+            {
+                var ordered = OrderForDisplay(liveTargets);
+                for (int i = 0; i < ordered.Count; i++)
+                {
+                    if (MatchesIdentity(ordered[i].ToIdentity(), displayKey))
+                        return FormatScreenLabel(i + 1, ordered[i].IsPrimary, includePrimarySuffix: false);
+                }
+            }
+
             int number = TryGetDisplayNumber(displayKey);
             return number > 0 ? $"Screen {number}" : "this screen";
+        }
+
+        internal static IReadOnlyList<TaskbarWindowTarget> OrderForDisplay(
+            IEnumerable<TaskbarWindowTarget> targets)
+            => targets
+                .OrderByDescending(target => target.IsPrimary)
+                .ThenBy(target => target.Bounds.left)
+                .ThenBy(target => target.Bounds.top)
+                .ThenBy(target => target.DisplayKey, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+        /// <summary>
+        /// Keeps one taskbar per monitor so leftover Explorer <c>Shell_SecondaryTrayWnd</c> windows
+        /// do not appear as extra screens.
+        /// </summary>
+        internal static IReadOnlyList<TaskbarWindowTarget> SelectCanonicalTaskbars(
+            IEnumerable<TaskbarWindowTarget> candidates)
+        {
+            var chosen = new List<TaskbarWindowTarget>();
+            foreach (var group in candidates
+                .Where(IsUsableCandidate)
+                .GroupBy(target => target.Monitor))
+            {
+                chosen.Add(group
+                    .OrderByDescending(target => target.IsPrimary)
+                    .ThenByDescending(target => DisplayArea(target.Bounds))
+                    .First());
+            }
+
+            return DisambiguateDisplayKeys(chosen);
+        }
+
+        /// <summary>
+        /// Maps a persisted GDI name such as <c>DISPLAY2</c> onto the current monitor identity.
+        /// Windows increments <c>\\.\DISPLAYn</c> across driver resets, so last session's
+        /// DISPLAY2 is often today's DISPLAY7 on the same physical screen.
+        /// </summary>
+        internal static string ResolvePersistedDisplayKey(
+            string? persisted,
+            IReadOnlyList<DisplayIdentity> live)
+        {
+            if (string.IsNullOrWhiteSpace(persisted) || live.Count == 0)
+                return persisted?.Trim() ?? string.Empty;
+
+            string key = persisted.Trim();
+            if (key == WidgetSettingsService.AllDisplaysPinDestination)
+                return key;
+
+            foreach (var item in live)
+            {
+                if (MatchesIdentity(item, key))
+                    return item.DisplayKey;
+            }
+
+            int persistedNumber = TryGetDisplayNumber(key);
+            if (persistedNumber == 1)
+            {
+                foreach (var item in live)
+                {
+                    if (item.IsPrimary)
+                        return item.DisplayKey;
+                }
+            }
+
+            if (persistedNumber > 1)
+            {
+                DisplayIdentity? secondary = null;
+                foreach (var item in live)
+                {
+                    if (item.IsPrimary)
+                        continue;
+                    if (secondary is not null)
+                        return key;
+                    secondary = item;
+                }
+
+                if (secondary is { } onlySecondary)
+                    return onlySecondary.DisplayKey;
+            }
+
+            return key;
+        }
+
+        internal static bool TryMigratePersistedKey(
+            string persisted,
+            IReadOnlyList<DisplayIdentity> live,
+            out string resolved)
+        {
+            resolved = ResolvePersistedDisplayKey(persisted, live);
+            if (resolved.Length == 0
+                || string.Equals(resolved, persisted, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            foreach (var item in live)
+            {
+                if (string.Equals(item.DisplayKey, resolved, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+
+            return false;
         }
 
         internal static string GetDisplayKeyForWindow(IntPtr hwnd)
@@ -113,51 +265,126 @@ namespace TaskbarQuota.Taskbar
                 return string.Empty;
 
             var info = MONITORINFOEX.Create();
-            return User32.GetMonitorInfo(monitor, ref info)
-                ? BuildDisplayKey(info.szDevice, info.rcMonitor)
+            if (!User32.GetMonitorInfo(monitor, ref info))
+                return string.Empty;
+
+            return BuildDisplayKey(
+                info.szDevice,
+                TryGetMonitorDeviceId(info.szDevice),
+                info.rcMonitor);
+        }
+
+        internal static string TryGetMonitorDeviceId(string? gdiDeviceName)
+        {
+            if (string.IsNullOrWhiteSpace(gdiDeviceName))
+                return string.Empty;
+
+            var device = DISPLAY_DEVICE.Create();
+            return User32.EnumDisplayDevices(gdiDeviceName, 0, ref device, 0)
+                ? SanitizeDisplayToken(device.DeviceID)
                 : string.Empty;
+        }
+
+        private static bool MatchesIdentity(DisplayIdentity identity, string key)
+            => string.Equals(identity.DisplayKey, key, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(identity.GdiDeviceName, key, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(
+                    SanitizeDisplayToken(identity.GdiDeviceName),
+                    SanitizeDisplayToken(key),
+                    StringComparison.OrdinalIgnoreCase);
+
+        private static bool IsUsableCandidate(TaskbarWindowTarget target)
+            => target.Monitor != IntPtr.Zero
+                && target.Bounds.right > target.Bounds.left
+                && target.Bounds.bottom > target.Bounds.top;
+
+        private static int DisplayArea(RECT bounds)
+            => Math.Max(0, bounds.right - bounds.left) * Math.Max(0, bounds.bottom - bounds.top);
+
+        internal static IReadOnlyList<TaskbarWindowTarget> DisambiguateDisplayKeys(
+            IReadOnlyList<TaskbarWindowTarget> targets)
+        {
+            if (targets.Count < 2)
+                return targets;
+
+            var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            foreach (var target in targets)
+                counts[target.DisplayKey] = counts.GetValueOrDefault(target.DisplayKey) + 1;
+
+            bool anyDuplicate = false;
+            foreach (int count in counts.Values)
+            {
+                if (count > 1)
+                {
+                    anyDuplicate = true;
+                    break;
+                }
+            }
+
+            if (!anyDuplicate)
+                return targets;
+
+            var unique = new List<TaskbarWindowTarget>(targets.Count);
+            foreach (var target in targets)
+            {
+                if (counts[target.DisplayKey] == 1)
+                {
+                    unique.Add(target);
+                    continue;
+                }
+
+                string suffix = SanitizeDisplayToken(target.GdiDeviceName);
+                if (suffix.Length == 0)
+                {
+                    suffix = string.Create(
+                        CultureInfo.InvariantCulture,
+                        $"{target.Bounds.left}_{target.Bounds.top}");
+                }
+
+                unique.Add(target with { DisplayKey = $"{target.DisplayKey}_{suffix}" });
+            }
+
+            return unique;
         }
 
         private static bool EnumTaskbarWindow(IntPtr hwnd, IntPtr lParam)
         {
             var builder = new StringBuilder(64);
             User32.GetClassName(hwnd, builder, builder.Capacity);
-            if (IsTaskbarClassName(builder.ToString(), out bool isPrimary)
-                && User32.IsWindow(hwnd)
-                && GCHandle.FromIntPtr(lParam).Target is List<TaskbarWindowTarget> targets)
+            if (!IsTaskbarClassName(builder.ToString(), out bool isPrimary)
+                || !User32.IsWindow(hwnd)
+                || IsCloaked(hwnd)
+                || GCHandle.FromIntPtr(lParam).Target is not List<TaskbarWindowTarget> targets)
             {
-                var bounds = GetBounds(hwnd);
-                if (bounds.right <= bounds.left || bounds.bottom <= bounds.top)
-                    return true;
-                targets.Add(new TaskbarWindowTarget(
-                    hwnd,
-                    isPrimary,
-                    BuildDisplayKey(TryGetDisplayId(hwnd), bounds)));
+                return true;
             }
 
+            var monitor = User32.MonitorFromWindow(hwnd, MonitorFromFlags.MONITOR_DEFAULTTONULL);
+            if (monitor == IntPtr.Zero)
+                return true;
+
+            var bounds = GetBounds(hwnd);
+            if (bounds.right <= bounds.left || bounds.bottom <= bounds.top)
+                return true;
+
+            var info = MONITORINFOEX.Create();
+            string gdiDevice = User32.GetMonitorInfo(monitor, ref info)
+                ? info.szDevice
+                : string.Empty;
+            var keyBounds = info.rcMonitor.right > info.rcMonitor.left ? info.rcMonitor : bounds;
+            targets.Add(new TaskbarWindowTarget(
+                hwnd,
+                isPrimary,
+                BuildDisplayKey(gdiDevice, TryGetMonitorDeviceId(gdiDevice), keyBounds),
+                SanitizeDisplayToken(gdiDevice),
+                monitor,
+                bounds));
             return true;
         }
 
-        private static int CompareTargets(TaskbarWindowTarget left, TaskbarWindowTarget right)
-        {
-            if (left.IsPrimary != right.IsPrimary)
-                return left.IsPrimary ? -1 : 1;
-
-            var leftBounds = GetBounds(left.Handle);
-            var rightBounds = GetBounds(right.Handle);
-            int byTop = leftBounds.top.CompareTo(rightBounds.top);
-            return byTop != 0 ? byTop : leftBounds.left.CompareTo(rightBounds.left);
-        }
-
-        private static string TryGetDisplayId(IntPtr taskbarHandle)
-        {
-            var monitor = User32.MonitorFromWindow(taskbarHandle, MonitorFromFlags.MONITOR_DEFAULTTONEAREST);
-            if (monitor == IntPtr.Zero)
-                return string.Empty;
-
-            var info = MONITORINFOEX.Create();
-            return User32.GetMonitorInfo(monitor, ref info) ? info.szDevice : string.Empty;
-        }
+        private static bool IsCloaked(IntPtr hwnd)
+            => DwmApi.DwmGetWindowAttribute(hwnd, DwmApi.DWMWA_CLOAKED, out int cloaked, sizeof(int)) == 0
+                && cloaked != 0;
 
         private static RECT GetBounds(IntPtr hwnd)
             => User32.GetWindowRect(hwnd, out var bounds) ? bounds : default;

--- a/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/DashboardPage.xaml.cs
@@ -525,11 +525,12 @@ namespace TaskbarQuota.Views
                 && WidgetSettingsService.CurrentTaskbarPlacement == TaskbarPlacementMode.Adaptive;
             ProviderPinText.Text = canPinHere ? "Pin here" : card.ProviderPinToggleText;
 
+            TaskbarWindowTarget.TryFindAll(out var pinDisplays);
             string? fixedDisplay = WidgetSettingsService.GetPinnedProviderDisplay(card.ProviderId);
             string tooltip = card.IsProviderPinned && fixedDisplay is not null
-                ? $"Pinned to {TaskbarWindowTarget.GetDisplayLabel(fixedDisplay)}"
+                ? $"Pinned to {TaskbarWindowTarget.GetDisplayLabel(fixedDisplay, pinDisplays)}"
                 : canPinHere
-                    ? $"Pin {card.DisplayName} to {TaskbarWindowTarget.GetDisplayLabel(_pinHereDisplayKey)}"
+                    ? $"Pin {card.DisplayName} to {TaskbarWindowTarget.GetDisplayLabel(_pinHereDisplayKey, pinDisplays)}"
                     : DefaultPinTooltip;
             ToolTipService.SetToolTip(ProviderPinToggle, tooltip);
             Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(ProviderPinToggle, tooltip);

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml
@@ -90,7 +90,7 @@
 
             <tk:SettingsCard x:Name="TaskbarPlacementCard"
                              Header="Taskbar screens"
-                             Description="Show the same usage on every taskbar, choose one screen, or keep one active provider per screen. With two or more screens, Adaptive mode also lets each pinned provider target a fixed screen.">
+                             Description="Show the same usage on every taskbar, choose one screen, or keep one active provider per screen. Screens are numbered from the current layout, primary first. With two or more screens, Adaptive mode also lets each pinned provider target a fixed screen.">
                 <tk:SettingsCard.HeaderIcon>
                     <FontIcon Glyph="&#xE7F4;"/>
                 </tk:SettingsCard.HeaderIcon>

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
@@ -25,6 +25,7 @@ namespace TaskbarQuota.Views
         // Per-provider controls, so changing one updates only its own row instead of rebuilding the list.
         private readonly Dictionary<ProviderId, ProviderToggleRow> _providerRows = new();
         private readonly List<PinOption> _pinOptions = new();
+        private IReadOnlyList<DisplayIdentity> _pinDisplayIdentities = [];
 
         private sealed record TaskbarPlacementOption(
             string Label,
@@ -382,14 +383,8 @@ namespace TaskbarQuota.Views
                     identities.Add(target.ToIdentity());
 
                 string selectedKey = WidgetSettingsService.SelectedTaskbarDisplayKey;
-                if (WidgetSettingsService.CurrentTaskbarPlacement == TaskbarPlacementMode.SelectedDisplay
-                    && TaskbarWindowTarget.TryMigratePersistedKey(selectedKey, identities, out string migrated)
-                    && !_isInitializing)
-                {
-                    WidgetSettingsService.ApplyTaskbarPlacement(TaskbarPlacementMode.SelectedDisplay, migrated);
-                    selectedKey = migrated;
-                }
-                else if (WidgetSettingsService.CurrentTaskbarPlacement == TaskbarPlacementMode.SelectedDisplay)
+                // The manager owns persistence after topology settles; this scan is only for labels.
+                if (WidgetSettingsService.CurrentTaskbarPlacement == TaskbarPlacementMode.SelectedDisplay)
                 {
                     selectedKey = TaskbarWindowTarget.ResolvePersistedDisplayKey(selectedKey, identities);
                 }
@@ -436,6 +431,7 @@ namespace TaskbarQuota.Views
         private void BuildPinOptions()
         {
             _pinOptions.Clear();
+            _pinDisplayIdentities = [];
             _pinOptions.Add(new("Not pinned", false));
 
             if (WidgetSettingsService.CurrentTaskbarPlacement != TaskbarPlacementMode.Adaptive)
@@ -461,6 +457,7 @@ namespace TaskbarQuota.Views
             }
 
             var identities = displays.Select(target => target.ToIdentity()).ToList();
+            _pinDisplayIdentities = identities;
             _pinOptions.Add(new("Pinned — follow app", true));
             _pinOptions.Add(new(
                 "Pinned — all screens",
@@ -490,7 +487,7 @@ namespace TaskbarQuota.Views
             }
         }
 
-        private static bool PinOptionMatches(ProviderId provider, PinOption option)
+        private bool PinOptionMatches(ProviderId provider, PinOption option)
         {
             bool pinned = WidgetSettingsService.IsProviderPinned(provider);
             if (pinned != option.IsPinned)
@@ -501,6 +498,7 @@ namespace TaskbarQuota.Views
                 return true;
 
             string selected = WidgetSettingsService.GetPinnedProviderDisplay(provider) ?? string.Empty;
+            selected = TaskbarWindowTarget.ResolvePersistedDisplayKey(selected, _pinDisplayIdentities);
             return string.Equals(selected, option.DisplayKey, System.StringComparison.OrdinalIgnoreCase);
         }
 

--- a/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
+++ b/src/TaskbarQuota.App/Views/SettingsPage.xaml.cs
@@ -373,36 +373,37 @@ namespace TaskbarQuota.Views
                 AddTaskbarPlacementOption(new("All screens", TaskbarPlacementMode.AllDisplays));
 
                 var seen = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
-                if (TaskbarWindowTarget.TryFindAll(out var targets))
-                {
-                    foreach (var target in targets
-                        .OrderBy(target => target.DisplayNumber == 0 ? int.MaxValue : target.DisplayNumber)
-                        .ThenByDescending(target => target.IsPrimary))
-                    {
-                        if (!seen.Add(target.DisplayKey))
-                            continue;
+                IReadOnlyList<TaskbarWindowTarget> targets = System.Array.Empty<TaskbarWindowTarget>();
+                if (TaskbarWindowTarget.TryFindAll(out var found))
+                    targets = found;
 
-                        string screenName = target.DisplayNumber > 0
-                            ? $"Screen {target.DisplayNumber}"
-                            : "Detected screen";
-                        if (target.IsPrimary)
-                            screenName += " (primary)";
-                        AddTaskbarPlacementOption(new(
-                            screenName,
-                            TaskbarPlacementMode.SelectedDisplay,
-                            target.DisplayKey));
-                    }
-                }
+                var identities = new List<DisplayIdentity>(targets.Count);
+                foreach (var target in targets)
+                    identities.Add(target.ToIdentity());
 
                 string selectedKey = WidgetSettingsService.SelectedTaskbarDisplayKey;
                 if (WidgetSettingsService.CurrentTaskbarPlacement == TaskbarPlacementMode.SelectedDisplay
-                    && selectedKey.Length > 0
-                    && seen.Add(selectedKey))
+                    && TaskbarWindowTarget.TryMigratePersistedKey(selectedKey, identities, out string migrated)
+                    && !_isInitializing)
                 {
+                    WidgetSettingsService.ApplyTaskbarPlacement(TaskbarPlacementMode.SelectedDisplay, migrated);
+                    selectedKey = migrated;
+                }
+                else if (WidgetSettingsService.CurrentTaskbarPlacement == TaskbarPlacementMode.SelectedDisplay)
+                {
+                    selectedKey = TaskbarWindowTarget.ResolvePersistedDisplayKey(selectedKey, identities);
+                }
+
+                for (int i = 0; i < targets.Count; i++)
+                {
+                    var target = targets[i];
+                    if (!seen.Add(target.DisplayKey))
+                        continue;
+
                     AddTaskbarPlacementOption(new(
-                        $"{selectedKey} (disconnected)",
+                        TaskbarWindowTarget.FormatScreenLabel(i + 1, target.IsPrimary),
                         TaskbarPlacementMode.SelectedDisplay,
-                        selectedKey));
+                        target.DisplayKey));
                 }
 
                 AddTaskbarPlacementOption(new("Adaptive (follow each agent)", TaskbarPlacementMode.Adaptive));
@@ -449,32 +450,27 @@ namespace TaskbarQuota.Views
                 return;
             }
 
-            var displays = targets
-                .GroupBy(target => target.DisplayKey, System.StringComparer.OrdinalIgnoreCase)
-                .Select(group => group.First())
-                .OrderBy(target => target.DisplayNumber == 0 ? int.MaxValue : target.DisplayNumber)
-                .ThenByDescending(target => target.IsPrimary)
-                .ToList();
+            var displays = TaskbarWindowTarget.OrderForDisplay(
+                targets
+                    .GroupBy(target => target.DisplayKey, System.StringComparer.OrdinalIgnoreCase)
+                    .Select(group => group.First()));
             if (displays.Count < 2)
             {
                 _pinOptions.Add(new("Pinned", true, MatchesAnyDestination: true));
                 return;
-
             }
 
+            var identities = displays.Select(target => target.ToIdentity()).ToList();
             _pinOptions.Add(new("Pinned — follow app", true));
             _pinOptions.Add(new(
                 "Pinned — all screens",
                 true,
                 WidgetSettingsService.AllDisplaysPinDestination));
 
-            foreach (var target in displays)
+            for (int i = 0; i < displays.Count; i++)
             {
-                string screenName = target.DisplayNumber > 0
-                    ? $"Screen {target.DisplayNumber}"
-                    : "Detected screen";
-                if (target.IsPrimary)
-                    screenName += " (primary)";
+                var target = displays[i];
+                string screenName = TaskbarWindowTarget.FormatScreenLabel(i + 1, target.IsPrimary);
                 _pinOptions.Add(new($"Pinned — {screenName}", true, target.DisplayKey));
             }
 
@@ -483,10 +479,14 @@ namespace TaskbarQuota.Views
             foreach (ProviderId provider in System.Enum.GetValues<ProviderId>())
             {
                 string? saved = WidgetSettingsService.GetPinnedProviderDisplay(provider);
-                if (saved is not null
-                    && saved != WidgetSettingsService.AllDisplaysPinDestination
-                    && known.Add(saved))
-                    _pinOptions.Add(new($"Pinned — {saved} (disconnected)", true, saved));
+                if (saved is null || saved == WidgetSettingsService.AllDisplaysPinDestination)
+                    continue;
+
+                string resolved = TaskbarWindowTarget.ResolvePersistedDisplayKey(saved, identities);
+                if (!known.Add(resolved))
+                    continue;
+
+                _pinOptions.Add(new("Pinned — previously chosen screen (unavailable)", true, saved));
             }
         }
 

--- a/tests/TaskbarQuota.Tests/TaskbarWindowTargetTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskbarWindowTargetTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using TaskbarQuota.Interop;
 using TaskbarQuota.Taskbar;
 
@@ -33,6 +34,17 @@ public class TaskbarWindowTargetTests
     }
 
     [Fact]
+    public void BuildDisplayKey_PrefersStableMonitorIdOverGdiName()
+    {
+        var displayKey = TaskbarWindowTarget.BuildDisplayKey(
+            @"\\.\DISPLAY7",
+            @"MONITOR\DELA0D5\{4d36e96e-e325-11ce-bfc1-08002be10318}\0004",
+            new RECT { left = 2560, top = 0, right = 4480, bottom = 1080 });
+
+        Assert.Equal("MONITORDELA0D54d36e96e-e325-11ce-bfc1-08002be103180004", displayKey);
+    }
+
+    [Fact]
     public void BuildDisplayKey_FallsBackToBoundsWhenDisplayIdIsUnavailable()
     {
         var displayKey = TaskbarWindowTarget.BuildDisplayKey(
@@ -57,4 +69,149 @@ public class TaskbarWindowTargetTests
     [InlineData(WidgetSettingsService.AllDisplaysPinDestination, "all screens")]
     public void GetDisplayLabel_never_exposes_internal_display_keys(string displayKey, string expected)
         => Assert.Equal(expected, TaskbarWindowTarget.GetDisplayLabel(displayKey));
+
+    [Fact]
+    public void FormatScreenLabel_uses_current_layout_ordinals()
+    {
+        Assert.Equal("Screen 1 (primary)", TaskbarWindowTarget.FormatScreenLabel(1, isPrimary: true));
+        Assert.Equal("Screen 2", TaskbarWindowTarget.FormatScreenLabel(2, isPrimary: false));
+        Assert.Equal("Screen 1", TaskbarWindowTarget.FormatScreenLabel(1, isPrimary: true, includePrimarySuffix: false));
+    }
+
+    [Fact]
+    public void OrderForDisplay_puts_primary_first_then_left_to_right()
+    {
+        var rightSecondary = Target(
+            handle: 3,
+            primary: false,
+            key: "RIGHT",
+            gdi: "DISPLAY7",
+            monitor: 30,
+            left: 2560);
+        var leftSecondary = Target(
+            handle: 2,
+            primary: false,
+            key: "LEFT",
+            gdi: "DISPLAY6",
+            monitor: 20,
+            left: -1920);
+        var primary = Target(
+            handle: 1,
+            primary: true,
+            key: "PRIMARY",
+            gdi: "DISPLAY1",
+            monitor: 10,
+            left: 0);
+
+        var ordered = TaskbarWindowTarget.OrderForDisplay([rightSecondary, leftSecondary, primary]);
+
+        Assert.Equal(["PRIMARY", "LEFT", "RIGHT"], ordered.Select(target => target.DisplayKey));
+        Assert.Equal(
+            "Screen 2",
+            TaskbarWindowTarget.GetDisplayLabel("LEFT", ordered));
+    }
+
+    [Fact]
+    public void SelectCanonicalTaskbars_keeps_one_window_per_monitor()
+    {
+        var live = Target(1, true, "LIVE", "DISPLAY7", monitor: 10, left: 2560, width: 1920);
+        var stale = Target(2, false, "STALE", "DISPLAY2", monitor: 10, left: 2560, width: 800);
+
+        var chosen = TaskbarWindowTarget.SelectCanonicalTaskbars([stale, live]);
+
+        Assert.Single(chosen);
+        Assert.Equal("LIVE", chosen[0].DisplayKey);
+        Assert.Equal(new IntPtr(1), chosen[0].Handle);
+    }
+
+    [Fact]
+    public void SelectCanonicalTaskbars_drops_windows_without_a_monitor()
+    {
+        var orphan = Target(4, false, "ORPHAN", "DISPLAY9", monitor: 0, left: 0);
+        var live = Target(5, true, "PRIMARY", "DISPLAY1", monitor: 11, left: 0);
+
+        var chosen = TaskbarWindowTarget.SelectCanonicalTaskbars([orphan, live]);
+
+        Assert.Equal(["PRIMARY"], chosen.Select(target => target.DisplayKey));
+    }
+
+    [Fact]
+    public void DisambiguateDisplayKeys_suffixes_identical_monitor_ids()
+    {
+        var left = Target(1, true, "GENERIC", "DISPLAY1", monitor: 1, left: 0);
+        var right = Target(2, false, "GENERIC", "DISPLAY2", monitor: 2, left: 1920);
+
+        var unique = TaskbarWindowTarget.DisambiguateDisplayKeys([left, right]);
+
+        Assert.Equal(["GENERIC_DISPLAY1", "GENERIC_DISPLAY2"], unique.Select(target => target.DisplayKey));
+    }
+
+    [Fact]
+    public void ResolvePersistedDisplayKey_matches_current_gdi_name()
+    {
+        DisplayIdentity[] live =
+        [
+            new("MONITORA", "DISPLAY6", true),
+            new("MONITORB", "DISPLAY7", false),
+        ];
+
+        Assert.Equal("MONITORB", TaskbarWindowTarget.ResolvePersistedDisplayKey("DISPLAY7", live));
+        Assert.Equal("MONITORA", TaskbarWindowTarget.ResolvePersistedDisplayKey("MONITORA", live));
+    }
+
+    [Fact]
+    public void ResolvePersistedDisplayKey_maps_orphaned_secondary_gdi_name_to_the_only_other_screen()
+    {
+        DisplayIdentity[] live =
+        [
+            new("MONITORA", "DISPLAY6", true),
+            new("MONITORB", "DISPLAY7", false),
+        ];
+
+        Assert.Equal("MONITORB", TaskbarWindowTarget.ResolvePersistedDisplayKey("DISPLAY2", live));
+        Assert.True(TaskbarWindowTarget.TryMigratePersistedKey("DISPLAY2", live, out string migrated));
+        Assert.Equal("MONITORB", migrated);
+    }
+
+    [Fact]
+    public void ResolvePersistedDisplayKey_maps_display1_to_the_current_primary()
+    {
+        DisplayIdentity[] live =
+        [
+            new("MONITORA", "DISPLAY6", true),
+            new("MONITORB", "DISPLAY7", false),
+        ];
+
+        Assert.Equal("MONITORA", TaskbarWindowTarget.ResolvePersistedDisplayKey("DISPLAY1", live));
+    }
+
+    [Fact]
+    public void ResolvePersistedDisplayKey_keeps_orphaned_key_when_several_secondaries_exist()
+    {
+        DisplayIdentity[] live =
+        [
+            new("MONITORA", "DISPLAY6", true),
+            new("MONITORB", "DISPLAY7", false),
+            new("MONITORC", "DISPLAY8", false),
+        ];
+
+        Assert.Equal("DISPLAY2", TaskbarWindowTarget.ResolvePersistedDisplayKey("DISPLAY2", live));
+        Assert.False(TaskbarWindowTarget.TryMigratePersistedKey("DISPLAY2", live, out _));
+    }
+
+    private static TaskbarWindowTarget Target(
+        int handle,
+        bool primary,
+        string key,
+        string gdi,
+        int monitor,
+        int left,
+        int width = 1920)
+        => new(
+            new IntPtr(handle),
+            primary,
+            key,
+            gdi,
+            new IntPtr(monitor),
+            new RECT { left = left, top = 0, right = left + width, bottom = 1080 });
 }

--- a/tests/TaskbarQuota.Tests/TaskbarWindowTargetTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskbarWindowTargetTests.cs
@@ -7,6 +7,9 @@ namespace TaskbarQuota.Tests;
 
 public class TaskbarWindowTargetTests
 {
+    private const string MonitorA = @"\\?\DISPLAY#GENERIC#5&abc&0&UID100#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}";
+    private const string MonitorB = @"\\?\DISPLAY#GENERIC#5&abc&0&UID101#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}";
+
     [Theory]
     [InlineData(TaskbarWindowTarget.PrimaryClassName, true)]
     [InlineData(TaskbarWindowTarget.SecondaryClassName, false)]
@@ -35,14 +38,20 @@ public class TaskbarWindowTargetTests
     }
 
     [Fact]
-    public void BuildDisplayKey_PrefersStableMonitorIdOverGdiName()
+    public void BuildDisplayKey_uses_case_insensitive_monitor_interface_independent_of_gdi_name()
     {
         var displayKey = TaskbarWindowTarget.BuildDisplayKey(
             @"\\.\DISPLAY7",
-            @"MONITOR\DELA0D5\{4d36e96e-e325-11ce-bfc1-08002be10318}\0004",
+            MonitorA,
             new RECT { left = 2560, top = 0, right = 4480, bottom = 1080 });
 
-        Assert.Equal("MONITORDELA0D54d36e96e-e325-11ce-bfc1-08002be103180004", displayKey);
+        Assert.StartsWith("MONITOR_", displayKey);
+        Assert.Equal(72, displayKey.Length);
+        Assert.Equal(displayKey, TaskbarWindowTarget.BuildDisplayKey("DISPLAY2", MonitorA.ToLowerInvariant(), default));
+        Assert.NotEqual(displayKey, TaskbarWindowTarget.BuildDisplayKey("DISPLAY7", MonitorB, default));
+        Assert.NotEqual(
+            TaskbarWindowTarget.BuildDisplayKey("DISPLAY7", "a#bc", default),
+            TaskbarWindowTarget.BuildDisplayKey("DISPLAY7", "ab#c", default));
     }
 
     [Fact]
@@ -137,14 +146,65 @@ public class TaskbarWindowTargetTests
     }
 
     [Fact]
-    public void DisambiguateDisplayKeys_suffixes_identical_monitor_ids()
+    public void Canonical_targets_use_distinct_monitor_instances_and_drop_ambiguous_legacy_aliases()
     {
-        var left = Target(1, true, "GENERIC", "DISPLAY1", monitor: 1, left: 0);
-        var right = Target(2, false, "GENERIC", "DISPLAY2", monitor: 2, left: 1920);
+        var left = InstanceTarget(1, true, MonitorA, "DISPLAY1", 1, 0);
+        var right = InstanceTarget(2, false, MonitorB, "DISPLAY2", 2, 1920);
 
-        var unique = TaskbarWindowTarget.DisambiguateDisplayKeys([left, right]);
+        var unique = TaskbarWindowTarget.SelectCanonicalTaskbars([left, right]);
 
-        Assert.Equal(["GENERIC_DISPLAY1", "GENERIC_DISPLAY2"], unique.Select(target => target.DisplayKey));
+        Assert.NotEqual(unique[0].DisplayKey, unique[1].DisplayKey);
+        Assert.All(unique, target => Assert.Empty(target.LegacyDisplayKey));
+        var identities = unique.Select(target => target.ToIdentity()).ToArray();
+        Assert.False(TaskbarWindowTarget.TryMigratePersistedKey("GENERIC", identities, out _));
+        Assert.True(TaskbarWindowTarget.TryMigratePersistedKey("GENERIC_DISPLAY2", identities, out string migrated));
+        Assert.Equal(right.DisplayKey, migrated);
+    }
+
+    [Fact]
+    public void Selected_and_pinned_duplicate_monitor_survives_disconnect_reconnect_and_gdi_renumbering()
+    {
+        var primary = Target(3, true, "PRIMARY", "DISPLAY3", 30, -1920);
+        var left = InstanceTarget(1, false, MonitorA, "DISPLAY1", 10, 0);
+        var right = InstanceTarget(2, false, MonitorB, "DISPLAY2", 20, 1920);
+        var initial = TaskbarWindowTarget.SelectCanonicalTaskbars([primary, left, right]);
+        string saved = initial.Single(target => target.Monitor == left.Monitor).DisplayKey;
+
+        IReadOnlyList<TaskbarWindowTarget>[] snapshots = [
+            TaskbarWindowTarget.SelectCanonicalTaskbars([primary, left]),
+            TaskbarWindowTarget.SelectCanonicalTaskbars([primary, right]),
+            TaskbarWindowTarget.SelectCanonicalTaskbars([right, primary, left]),
+            TaskbarWindowTarget.SelectCanonicalTaskbars([
+                primary,
+                InstanceTarget(11, false, MonitorA, "DISPLAY6", 100, 2560),
+                InstanceTarget(12, false, MonitorB, "DISPLAY7", 200, -1920),
+            ]),
+        ];
+        foreach (var targets in snapshots)
+        {
+            var identities = targets.Select(target => target.ToIdentity()).ToArray();
+            Assert.Equal(saved, TaskbarWindowTarget.ResolvePersistedDisplayKey(saved, identities));
+            Assert.False(TaskbarWindowTarget.TryMigratePersistedKey(saved, identities, out _));
+            var available = targets.Select(target => target.DisplayKey).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (var mode in new[] { TaskbarPlacementMode.SelectedDisplay, TaskbarPlacementMode.Adaptive })
+            {
+                foreach (var target in targets)
+                {
+                    bool routed = TaskbarContentRouter.IsRoutedToDisplay(
+                        ProviderId.Codex, mode, saved, target.DisplayKey, primary.DisplayKey, available,
+                        _ => null, _ => true, _ => saved);
+                    Assert.Equal(target.DisplayKey == (available.Contains(saved) ? saved : primary.DisplayKey), routed);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void Unambiguous_monitor_id_from_earlier_pr_build_migrates_to_interface_key()
+    {
+        var target = InstanceTarget(1, true, MonitorA, "DISPLAY6", 10, 0);
+        Assert.True(TaskbarWindowTarget.TryMigratePersistedKey("GENERIC", [target.ToIdentity()], out string migrated));
+        Assert.Equal(target.DisplayKey, migrated);
     }
 
     [Fact]
@@ -204,14 +264,14 @@ public class TaskbarWindowTargetTests
     public void Window_monitor_uses_canonical_key_for_adaptive_history_with_duplicate_ids()
     {
         var targets = TaskbarWindowTarget.SelectCanonicalTaskbars([
-            Target(1, true, "GENERIC", "DISPLAY1", 10, 0),
-            Target(2, false, "GENERIC", "DISPLAY2", 20, 1920),
+            InstanceTarget(1, true, MonitorA, "DISPLAY1", 10, 0),
+            InstanceTarget(2, false, MonitorB, "DISPLAY2", 20, 1920),
         ]);
         string windowKey = TaskbarWindowTarget.GetDisplayKeyForMonitor(new IntPtr(20), targets);
         var history = new AdaptiveDisplayProviderState();
         history.Observe(ProviderId.Codex, windowKey, new IntPtr(100));
 
-        Assert.Equal("GENERIC_DISPLAY2", windowKey);
+        Assert.Equal(TaskbarWindowTarget.BuildDisplayKey("DISPLAY2", MonitorB, default), windowKey);
         Assert.Equal(ProviderId.Codex, history.GetProvider(targets[1].DisplayKey));
         Assert.Null(history.GetProvider(targets[0].DisplayKey));
         Assert.Equal(string.Empty, TaskbarWindowTarget.GetDisplayKeyForMonitor(IntPtr.Zero, targets));
@@ -318,6 +378,45 @@ public class TaskbarWindowTargetTests
             Directory.Delete(directory, recursive: true);
         }
     }
+
+    [Theory]
+    [InlineData("GENERIC")]
+    [InlineData("GENERIC_DISPLAY2")]
+    public void Interface_key_migration_preserves_earlier_pr_layout_and_subsequent_reset(string oldKey)
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "taskbarquota-interface-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var target = InstanceTarget(2, false, MonitorB, "DISPLAY2", 20, 1920);
+            string oldPath = Path.Combine(directory, TaskbarWindowTarget.BuildPositionFileName(oldKey));
+            string gdiPath = Path.Combine(directory, TaskbarWindowTarget.BuildPositionFileName("DISPLAY2"));
+            File.WriteAllText(oldPath, "456");
+            File.WriteAllText(oldPath + ".migrated", "1");
+            File.WriteAllText(gdiPath, "123");
+
+            string currentPath = target.GetPositionPath(directory);
+            Assert.Equal("456", File.ReadAllText(currentPath));
+            Assert.Equal(currentPath, (target with { GdiDeviceName = "DISPLAY7" }).GetPositionPath(directory));
+
+            // Simulate a layout reset before installing this revision: only the old migration receipt remains.
+            File.Delete(oldPath);
+            File.Delete(currentPath);
+            File.Delete(currentPath + ".migrated");
+            target.GetPositionPath(directory);
+            Assert.False(File.Exists(currentPath));
+            Assert.True(File.Exists(currentPath + ".migrated"));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static TaskbarWindowTarget InstanceTarget(
+        int handle, bool primary, string instance, string gdi, int monitor, int left)
+        => Target(handle, primary, TaskbarWindowTarget.BuildDisplayKey(gdi, instance, default), gdi, monitor, left)
+            with { LegacyDisplayKey = "GENERIC", LegacySuffixedDisplayKey = $"GENERIC_{gdi}" };
 
     private static TaskbarWindowTarget Target(
         int handle,

--- a/tests/TaskbarQuota.Tests/TaskbarWindowTargetTests.cs
+++ b/tests/TaskbarQuota.Tests/TaskbarWindowTargetTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using TaskbarQuota.Interop;
 using TaskbarQuota.Taskbar;
+using TaskbarQuota.Usage;
 
 namespace TaskbarQuota.Tests;
 
@@ -169,8 +170,8 @@ public class TaskbarWindowTargetTests
         ];
 
         Assert.Equal("MONITORB", TaskbarWindowTarget.ResolvePersistedDisplayKey("DISPLAY2", live));
-        Assert.True(TaskbarWindowTarget.TryMigratePersistedKey("DISPLAY2", live, out string migrated));
-        Assert.Equal("MONITORB", migrated);
+        Assert.False(TaskbarWindowTarget.TryMigratePersistedKey("DISPLAY2", live, out string persisted));
+        Assert.Equal("DISPLAY2", persisted);
     }
 
     [Fact]
@@ -197,6 +198,125 @@ public class TaskbarWindowTargetTests
 
         Assert.Equal("DISPLAY2", TaskbarWindowTarget.ResolvePersistedDisplayKey("DISPLAY2", live));
         Assert.False(TaskbarWindowTarget.TryMigratePersistedKey("DISPLAY2", live, out _));
+    }
+
+    [Fact]
+    public void Window_monitor_uses_canonical_key_for_adaptive_history_with_duplicate_ids()
+    {
+        var targets = TaskbarWindowTarget.SelectCanonicalTaskbars([
+            Target(1, true, "GENERIC", "DISPLAY1", 10, 0),
+            Target(2, false, "GENERIC", "DISPLAY2", 20, 1920),
+        ]);
+        string windowKey = TaskbarWindowTarget.GetDisplayKeyForMonitor(new IntPtr(20), targets);
+        var history = new AdaptiveDisplayProviderState();
+        history.Observe(ProviderId.Codex, windowKey, new IntPtr(100));
+
+        Assert.Equal("GENERIC_DISPLAY2", windowKey);
+        Assert.Equal(ProviderId.Codex, history.GetProvider(targets[1].DisplayKey));
+        Assert.Null(history.GetProvider(targets[0].DisplayKey));
+        Assert.Equal(string.Empty, TaskbarWindowTarget.GetDisplayKeyForMonitor(IntPtr.Zero, targets));
+        Assert.Equal(string.Empty, TaskbarWindowTarget.GetDisplayKeyForMonitor(new IntPtr(99), targets));
+    }
+
+    [Fact]
+    public void Migration_preserves_selection_until_missing_monitor_returns()
+    {
+        DisplayIdentity[] partial = [
+            new("MONITORA", "DISPLAY6", true),
+            new("MONITORB", "DISPLAY7", false),
+        ];
+        // Even repeated incomplete scans must not permanently assign DISPLAY8 to B.
+        for (int i = 0; i < 3; i++)
+        {
+            Assert.Equal("MONITORB", TaskbarWindowTarget.ResolvePersistedDisplayKey("DISPLAY8", partial));
+            Assert.False(TaskbarWindowTarget.TryMigratePersistedKey("DISPLAY8", partial, out string saved));
+            Assert.Equal("DISPLAY8", saved);
+        }
+
+        DisplayIdentity[] complete = [.. partial, new("MONITORC", "DISPLAY8", false)];
+        Assert.True(TaskbarWindowTarget.TryMigratePersistedKey("DISPLAY8", complete, out string migrated));
+        Assert.Equal("MONITORC", migrated);
+        Assert.False(TaskbarWindowTarget.TryMigratePersistedKey(migrated, complete, out _));
+    }
+
+    [Fact]
+    public void Migration_does_not_persist_a_guessed_primary()
+    {
+        DisplayIdentity[] live = [new("MONITORA", "DISPLAY6", true)];
+        Assert.Equal("MONITORA", TaskbarWindowTarget.ResolvePersistedDisplayKey("DISPLAY1", live));
+        Assert.False(TaskbarWindowTarget.TryMigratePersistedKey("DISPLAY1", live, out string saved));
+        Assert.Equal("DISPLAY1", saved);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void Position_migration_preserves_layout_files_and_existing_destination(bool primary, bool legacy)
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "taskbarquota-layout-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var target = Target(1, primary, "MONITORB", "DISPLAY2", 20, 1920);
+            string source = Path.Combine(directory, legacy
+                ? "taskbar-widget-position.txt"
+                : "taskbar-widget-position-DISPLAY2.txt");
+            string destination = Path.Combine(directory, "taskbar-widget-position-MONITORB.txt");
+            string[] suffixes = ["", ".order", ".activity", ".activity.manual"];
+            string[] contents = ["123", "ActivityFirst", "456", "1"];
+            for (int i = 0; i < suffixes.Length; i++)
+                File.WriteAllText(source + suffixes[i], contents[i]);
+
+            Assert.Equal(destination, target.GetPositionPath(directory));
+            for (int i = 0; i < suffixes.Length; i++)
+            {
+                Assert.Equal(contents[i], File.ReadAllText(destination + suffixes[i]));
+                Assert.Equal(contents[i], File.ReadAllText(source + suffixes[i]));
+                File.WriteAllText(destination + suffixes[i], "updated");
+            }
+
+            target.GetPositionPath(directory);
+            foreach (string suffix in suffixes)
+                Assert.Equal("updated", File.ReadAllText(destination + suffix));
+
+            // Clearing manual layout must survive another host creation, even with old files present.
+            foreach (string suffix in suffixes)
+                File.Delete(destination + suffix);
+            target.GetPositionPath(directory);
+            foreach (string suffix in suffixes)
+                Assert.False(File.Exists(destination + suffix));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Position_migration_copies_sidecars_even_when_main_position_already_exists()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "taskbarquota-layout-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var target = Target(1, false, "MONITORB", "DISPLAY2", 20, 1920);
+            string source = Path.Combine(directory, "taskbar-widget-position-DISPLAY2.txt");
+            string destination = Path.Combine(directory, "taskbar-widget-position-MONITORB.txt");
+            File.WriteAllText(destination, "789");
+            File.WriteAllText(source + ".activity", "456");
+            File.WriteAllText(source + ".activity.manual", "1");
+
+            target.GetPositionPath(directory);
+
+            Assert.Equal("789", File.ReadAllText(destination));
+            Assert.Equal("456", File.ReadAllText(destination + ".activity"));
+            Assert.Equal("1", File.ReadAllText(destination + ".activity.manual"));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
     }
 
     private static TaskbarWindowTarget Target(


### PR DESCRIPTION
## Summary
- Fixes #85: a two-monitor PC could show Screen 6, Screen 7, and a leftover `DISPLAY2` because labels used unstable Windows GDI names (`\\.\DISPLAYn`), which increment across driver resets.
- Screens are now labeled from the current layout (Screen 1 primary, then left to right), leftover Explorer taskbar windows are ignored, and saved selections remap onto the same physical monitor so the widget does not vanish after a topology change.
- All screens / selected screen / Adaptive routing is unchanged: All screens still shows on every live taskbar, and a chosen screen still shows only there.

## Test plan
- [ ] Open Settings → Taskbar screens on a 2-monitor PC and confirm the list is All screens, Screen 1 (primary), Screen 2, Adaptive — no `DISPLAY2 (disconnected)` and no Screen 6/7
- [ ] Choose All screens and confirm the widget appears on both taskbars
- [ ] Choose Screen 1, then Screen 2, and confirm the widget only appears on that taskbar
- [ ] Restart the app (or sleep/wake) and confirm the previous screen choice still targets the same physical monitor
- [ ] Confirm Adaptive still follows the focused agent app per screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved multi-monitor taskbar placement and pinning across display changes.
  - Display labels now more accurately reflect the current screen layout, with the primary display identified consistently.
  - Saved display selections can be restored or migrated when monitor identities change.
  - Pin and taskbar tooltips now show more accurate target display names.
  - Duplicate or unavailable display targets are handled more reliably.

- **Documentation**
  - Clarified that screen numbering follows the current layout, with the primary screen listed first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->